### PR TITLE
docs: delivery framework — playbook, status log, phase subplans

### DIFF
--- a/docs/delivery-playbook.md
+++ b/docs/delivery-playbook.md
@@ -1,0 +1,189 @@
+# Delivery playbook
+
+The recipe followed by the autonomous delivery loop (a `/loop 30m` task
+running every 30 minutes) and any human picking up where it left off.
+
+This document is the source of truth. The loop reads from it; humans read
+from it. If the loop's behavior diverges from this file, the file wins.
+
+## Operating principles
+
+1. **PR per task.** One PR per item in `docs/roadmap.md`'s "Next up"
+   queue. No artificial size cap — a thorough Phase 1.1 (controllers +
+   routes + specs + factories + docs) lives in one PR. Don't split a
+   coherent task across two PRs just to be small. *Don't* bundle
+   unrelated work to be big.
+2. **Tests are part of the task.** A PR without tests for the new
+   behavior is incomplete. RSpec for the API, Vitest for filter-engine,
+   Vitest/RTL for web, Jest/RTL for mobile.
+3. **Review cycles are part of the task.** Every PR opened by the loop
+   automatically requests `@codex review` and (when the loop is
+   confident in the change) at least one self-review pass before
+   marking ready-for-merge.
+4. **CI must pass.** Never request human review on red. Never
+   auto-merge on red.
+5. **Trust review.** Auto-merge runs only after CI is green AND no
+   unresolved review threads AND `@shadoath` (the project owner) has
+   either explicitly approved or labeled the PR `auto-merge-ok`.
+6. **Plan-first updates.** Before starting work, the loop syncs
+   `docs/roadmap.md`'s "Next up" queue. Before merging, it ticks the
+   completed item. Mid-task progress goes in `docs/status.md` (see
+   §Status log).
+7. **Ping when stuck.** Three failed CI runs in a row, an unaddressed
+   human review comment that needs a judgement call, or any
+   `[BLOCKED]` item promoted to next pauses the loop and pings
+   `@shadoath` via a PR comment.
+8. **Honest scope.** Don't pull next-phase work into a current-phase
+   PR. Don't refactor adjacent code while fixing a bug. Don't add
+   features the roadmap didn't ask for.
+9. **Subplans for depth.** Each phase has a `docs/plans/phase-N.md`
+   that decomposes the phase into ordered tasks, gotchas, and
+   acceptance criteria. The roadmap's "Next up" links into the
+   relevant subplan.
+
+## The loop
+
+Each tick runs this sequence top-to-bottom and stops at the first
+applicable branch.
+
+### 1. Read state
+
+- `git fetch origin`
+- Read `docs/status.md` to see what the previous tick left off doing.
+- Identify the latest open PR authored by the loop (label
+  `claude-cd` or branch matching `claude/*`).
+- Pull its check status, review threads, merge state, and any new
+  comments since last tick.
+
+### 2. Branch on PR state
+
+| State | Action |
+|---|---|
+| PR open, CI green, approved (or `auto-merge-ok` labeled), no unresolved threads | **Squash-merge**, then continue to step 3. |
+| PR open, CI green, awaiting `@codex review` | Wait. Log "awaiting codex" in `docs/status.md`. |
+| PR open, CI green, has unresolved review threads | Read each thread. If small + clear, address and push. If ambiguous or architectural, post a question on the thread tagging `@shadoath` and pause. |
+| PR open, CI red | Fetch the failing logs. If the cause is known and the fix is small, push it to the same branch. If unknown after one diagnosis attempt, post a status comment summarizing the failure, ping `@shadoath`, and pause. |
+| PR open, CI pending | Do nothing. Log "waiting for CI." |
+| PR open, conflicts with master | Rebase onto master. If conflicts are mechanical, resolve and force-push. If non-trivial, ping and pause. |
+| No PR open, branch has commits | Open the PR, request codex review, do a self-review pass, then continue to step 3. |
+| No PR open, working tree clean | Continue to step 3. |
+
+### 3. Update the plan
+
+- Tick the merged item in `docs/roadmap.md`.
+- Append a status entry to `docs/status.md` (one line per tick:
+  timestamp, what changed, what's next).
+- If the merged work surfaced followup work, add it to the
+  roadmap's "Discovered" section. **Don't silently expand the
+  Next-up queue** — discovered items get a human review before
+  they're picked up.
+
+### 4. Pick the next item
+
+- Read `docs/roadmap.md` "Next up" queue.
+- Take the topmost unblocked item.
+- Open the relevant `docs/plans/phase-N.md` to confirm scope.
+- Create a branch: `claude/<phase-slug>` from origin/master.
+
+### 5. Do the work
+
+- Implement the item per its subplan.
+- Run local checks before pushing:
+  - `pnpm typecheck`, `pnpm lint`, `pnpm test` (the relevant subset)
+  - `bundle exec rspec` (the relevant subset)
+- Commit with a conventional message (`feat(api): ...`,
+  `fix(web): ...`, `docs: ...`, `chore(ci): ...`).
+- Push the branch.
+
+### 6. Open the PR
+
+- Title: `<scope>: <imperative summary>` (matches the roadmap
+  item).
+- Body sections: **Why** (linked roadmap item), **What** (bullet
+  diff summary), **Test plan** (checklist), **Notes** (anything
+  surprising).
+- Labels: `claude-cd`, plus `auto-merge-ok` if the PR is small +
+  mechanical (lockfile bumps, type regen, no behavior change).
+- Request `@codex review` immediately.
+- Subscribe to PR activity for webhook events.
+- Append to `docs/status.md`.
+
+### 7. End the tick
+
+- The next tick (or webhook event) picks up state.
+
+## Status log
+
+`docs/status.md` is the loop's running log. One line per tick or
+event, prepended (newest first). Format:
+
+```
+2026-04-29 14:32 — opened #123 phase-1.1-devise-jwt-login (+512/-3); requested codex
+2026-04-29 14:31 — merged #122 delivery-framework; queue: phase-1.1
+```
+
+The log lets a human (or the next tick) reconstruct what happened
+without scrolling GitHub. It's also where the loop posts mid-task
+progress so a tick interrupted at the 28-minute mark leaves enough
+breadcrumbs for the next tick to resume.
+
+## Auto-merge policy
+
+Auto-merge is enabled per-PR, never globally. The loop only enables
+it when **all** of the following are true:
+
+- The PR is in the `claude-cd` series.
+- The PR description has a populated **Test plan** checklist.
+- CI is green.
+- `@codex review` has no unaddressed comments.
+- Either `@shadoath` has approved OR the PR has the
+  `auto-merge-ok` label.
+- No file under `apps/api/db/migrate/` was edited destructively (a
+  new migration is fine; editing a previously-shipped migration is
+  not).
+- No file under `_legacy/` was modified.
+
+The loop never bypasses CI, never force-pushes to master, never
+deletes branches it didn't create.
+
+## Stop conditions (ping `@shadoath`)
+
+The loop pauses (no action, posts status, pings) when:
+
+- Same CI failure 3 ticks in a row → human intervention requested.
+- An open review thread contains `?` or starts with "should we" or
+  "why" → treated as a question that needs a human answer.
+- A roadmap item carries a `[BLOCKED]` prefix → skip; do not start.
+- The next item requires secrets the loop doesn't have (Apple
+  signing key, Anthropic API key in CI, etc.) → skip with a
+  status comment.
+- Diff size for a single PR exceeds 2,000 lines without a clear
+  reason → pause and propose splitting.
+
+How to ping: post a top-level PR comment that starts
+`@shadoath` followed by a one-paragraph status. GitHub's default
+notifications email this to the owner.
+
+## Cadence
+
+- **Default**: 30 minutes per tick.
+- **Burst**: subscribed PR webhook events (CI completed, review
+  submitted, comment posted) trigger an immediate handler outside
+  the cadence.
+- **Quiet hours**: none — the loop's state is small enough that a
+  Sunday-morning tick is harmless.
+
+## Cron prompt
+
+The loop is started with:
+
+```
+/loop 30m Run one tick of the BiteWorthy delivery loop. Read
+docs/delivery-playbook.md (procedure), docs/roadmap.md (queue),
+and docs/status.md (last-tick state). State your read of the world
+in one paragraph before acting. Stop when stuck per the playbook.
+```
+
+The procedure lives in this file so it can evolve via PR like any
+other code. If the playbook changes mid-loop, the next tick picks
+up the new version automatically.

--- a/docs/plans/phase-1.md
+++ b/docs/plans/phase-1.md
@@ -1,0 +1,143 @@
+# Phase 1 — Schema + auth + admin (subplan)
+
+Phase 1 stands up authenticated user accounts, the admin tooling that
+lets us hand-build seed data, and the read endpoints + OpenAPI codegen
+that the web and mobile apps need before Phase 2 ingestion or Phase 3
+filtering can do anything visible.
+
+**Demo at the end:** an admin creates a restaurant + a 10-item menu
+in the admin UI; mobile and web both render it; toggling a dietary
+profile changes what's shown.
+
+## Tasks (one PR each)
+
+### 1.1 — Devise JWT login + signup endpoints
+
+**Branch**: `claude/phase-1.1-devise-jwt`
+
+- `POST   /api/v1/auth/signup`     → create User + empty UserProfile
+- `POST   /api/v1/auth/login`      → returns JWT
+- `DELETE /api/v1/auth/logout`     → rotates `users.jti`
+- `POST   /api/v1/auth/refresh`    → mints fresh JWT, rotates jti
+
+Implementation notes:
+- `devise-jwt` already in the Gemfile. Configure the `jwt_secret_key`
+  initializer (use `Rails.application.secret_key_base`).
+- JWT denylist strategy: `JtiMatcher` against `users.jti` column —
+  a logout rotates the column, invalidating the token.
+- ApplicationController enforces JWT presence with a
+  `current_user!` helper for namespaced controllers.
+
+Specs:
+- request specs covering signup happy + duplicate email + invalid
+  email; login happy + wrong password + unconfirmed account; logout
+  rotates jti; refresh works once before logout.
+
+Acceptance:
+- All four endpoints return JSON, status codes match the spec
+  (201/200/204/200).
+- `User.first_or_create!(email: ...)` from Rails console works
+  end-to-end.
+
+### 1.2 — OmniAuth Apple + Google
+
+**Branch**: `claude/phase-1.2-omniauth`
+
+- `GET /api/v1/auth/:provider`           → OmniAuth init
+- `GET /api/v1/auth/:provider/callback`  → finalize, return JWT
+
+Implementation notes:
+- Provider configs use ENV vars; document them in `apps/api/.env.example`.
+- On first sign-in: create User + empty UserProfile, mark `confirmed_at`.
+- On subsequent sign-ins: match by `provider`+`uid`.
+
+Stop conditions:
+- Apple signing key not in CI yet → skip CI assertions for that
+  provider; integration-tested via VCR cassettes.
+
+### 1.3 — `GET/PATCH /api/v1/profile`
+
+**Branch**: `claude/phase-1.3-user-profile`
+
+- GET returns `{ avoid_ingredient_ids, avoid_tag_ids, prefer_tag_ids,
+  strictness, primary_dietary_profile }`.
+- PATCH replaces arrays wholesale.
+- Optional body field `dietary_profile_slug`: applies a preset's
+  ingredient + tag avoid lists to the user (additive, never
+  destructive).
+
+Specs: round-trip on each field, dietary-profile preset application.
+
+### 1.4 — Full ingredient port
+
+**Branch**: `claude/phase-1.4-ingredients-port`
+
+- Parse `_legacy/db/seeds/0_ingredients.rb` into structured
+  `apps/api/db/seeds/ingredients.yml`.
+- Goal: ≥ 1000 ingredients seeded with `path` ltree paths and
+  `aliases[]`.
+- Categorize by 2020 module groupings (fruits, herbs, grains, nuts,
+  legumes, vegetables, animal-products, dairy, meat, poultry, fish,
+  spices) → ltree path roots.
+- Add `allergen: true` to the big-9 sub-trees.
+
+Specs: seed task is idempotent; spot-check 10 ingredients have
+expected ancestry.
+
+### 1.5 — Rails admin dashboard skeleton
+
+**Branch**: `claude/phase-1.5-admin`
+
+- Mount Avo or ActiveAdmin at `/admin`.
+- CRUD on: City, Restaurant, Address, Hours, Menu, MenuSection, Item,
+  ItemVariant, ItemModifier, Ingredient, Tag, DietaryProfile.
+- Read-only on User and Suggestion.
+- Behind a `User#is_admin?` flag.
+
+Stop conditions:
+- Decision needed on Avo vs ActiveAdmin → ping owner if not already
+  decided in the PR description.
+
+### 1.6 — OpenAPI codegen
+
+**Branch**: `claude/phase-1.6-openapi`
+
+- rswag specs for every endpoint shipped in 1.1–1.5.
+- `bin/openapi-export` rake task that writes `docs/openapi.json`.
+- `pnpm --filter @biteworthy/api-types build:codegen` runs
+  `openapi-typescript` → `packages/api-types/src/generated.ts`.
+- Hand-written types in `packages/api-types/src/index.ts` deleted;
+  re-export only from `generated.ts`.
+- CI step that re-runs codegen and fails if the diff is non-empty
+  (catches stale types).
+
+### 1.7 — Restaurant + Item read endpoints with filter
+
+**Branch**: `claude/phase-1.7-read-with-filter`
+
+- `GET /api/v1/restaurants/:id/items?profile=…`
+- Server runs the dietary-filter SQL described in `docs/schema.md`
+  (the `&&` and `cardinality` query).
+- Each hidden item carries `reasons: [{kind, ingredient_id|tag_id}]`
+  for the transparency UI.
+- Strict mode is honored when `profile.strictness == 'strict'`.
+
+Specs: with no profile, all published items show. With "Vegan"
+profile, dairy items are hidden with reason. With strict + suggested
+items, those are hidden with reason `unconfirmed-strict`.
+
+## Cross-cutting
+
+- **CI subtask** (resolve before 1.7 merges): generate `schema.rb`
+  via `bin/rails db:migrate && bin/rails db:schema:dump`, check it
+  in, fix the eslint flat-config import order so `pnpm lint` is green.
+- **Docs**: each PR updates `docs/openapi.json` (after 1.6 lands) and
+  the relevant section of `docs/schema.md` if the model changed.
+
+## Out of scope for Phase 1
+
+- AI ingestion pipeline (Phase 2).
+- The mobile camera UI (Phase 2).
+- The web filter UI (Phase 3) — endpoint exists in 1.7, but the
+  consumer UI doesn't.
+- Reviews + suggestions UX (Phase 4).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,9 +1,32 @@
 # Roadmap
 
-The phase plan that gates every PR. Each phase ends with a real demo,
-not a "feature complete" claim.
+The phase plan. Each phase ends with a real demo. The autonomous
+delivery loop reads the **Next up** queue below to pick its next PR;
+each entry links to a `docs/plans/phase-N.md` subplan with the gory
+details.
 
-## Phase 0 — Foundation ✅ in progress
+## Next up
+
+The loop takes these in order, top-down. `[BLOCKED]` prefix means
+"skip; needs a human to clear." See `docs/delivery-playbook.md` for
+the merge / review / status rules.
+
+1. **subtask: fix master CI** — `db:schema:load` runs against an
+   empty schema; eslint flat config has unmet deps; rspec needs
+   scaffolding. Generate `schema.rb`, simplify the eslint shared
+   config, scaffold rspec. (Blocks everything else from going green.)
+2. **Phase 1.1 — Devise JWT login + signup** (`docs/plans/phase-1.md#11`)
+3. **Phase 1.2 — OmniAuth Apple + Google** (`docs/plans/phase-1.md#12`)
+4. **Phase 1.3 — `GET/PATCH /api/v1/profile`** (`docs/plans/phase-1.md#13`)
+5. **Phase 1.4 — full ingredient port** (`docs/plans/phase-1.md#14`)
+6. **Phase 1.5 — Rails admin dashboard** (`docs/plans/phase-1.md#15`)
+7. **Phase 1.6 — OpenAPI codegen for `packages/api-types`** (`docs/plans/phase-1.md#16`)
+8. **Phase 1.7 — Restaurant + Item read endpoints with filter** (`docs/plans/phase-1.md#17`)
+
+After Phase 1 ships, the loop pulls Phase 2 items into "Next up" via a
+plan-update PR (so a human reviews the next batch before they auto-run).
+
+## Phase 0 — Foundation ✅
 
 - [x] Archive 2020 codebase to `_legacy/`
 - [x] pnpm + Turborepo monorepo
@@ -12,76 +35,86 @@ not a "feature complete" claim.
 - [x] Expo mobile skeleton
 - [x] Shared TS packages: api-types, filter-engine (with tests),
       ui-tokens, eslint-config
-- [x] CI: GitHub Actions for JS + Rails
+- [x] CI workflow committed (failing on master — see Next-up #1)
 - [x] ADR 0001 capturing every stack pick
-- [ ] `pnpm install` + `bin/setup` + `pnpm dev` boot all three apps
+- [x] Delivery playbook + status log + phase subplans
 
-**Demo:** all three apps say "hello" against the same Rails API.
+**Demo:** all three apps say "hello" against the same Rails API. Held
+back by the master-CI subtask.
 
 ## Phase 1 — Schema + auth + admin (weeks 2–3)
 
-- [ ] Devise JWT login / signup / refresh endpoints
-- [ ] Apple + Google OAuth round trips
-- [ ] User profile (avoid/prefer/strictness) read + update endpoint
-- [ ] Admin dashboard (Rails-side, ERB) for cities, restaurants,
-      ingredients, tags, dietary profiles
-- [ ] Full ~1500-row ingredient port from `_legacy/db/seeds/0_ingredients.rb`
-      into structured YAML
-- [ ] OpenAPI spec via rswag → generates `packages/api-types`
-- [ ] Restaurant + item read endpoints with the dietary-filter scope wired
-      into Active Record
+Subplan: `docs/plans/phase-1.md`. Tasks 1.1 through 1.7 are in
+"Next up" above.
 
-**Demo:** admin creates a restaurant + a 10-item menu by hand; mobile and
-web both render it; toggling a dietary profile changes what's shown.
+**Demo:** admin creates a restaurant + a 10-item menu by hand; mobile
+and web both render it; toggling a dietary profile changes what's
+shown.
 
 ## Phase 2 — AI ingestion MVP (weeks 4–6) ⭐
 
-- [ ] AnthropicClient service (Faraday + Bearer + prompt caching)
-- [ ] IngestionRun + IngestionItem state machine
-- [ ] Solid Queue jobs: ExtractMenu, ResolveIngredients, ResolveTags
-- [ ] Mobile: multi-page camera capture → upload → wait → swipe-verify UI
-- [ ] Web: paste URL or upload PDF → verify
-- [ ] Cost + latency dashboard in admin
+Subplan: `docs/plans/phase-2.md` (drafted at end of Phase 1).
 
-**Demo:** photograph a real Durango menu in person; 60 seconds later the
-items appear staged; 5 minutes of swiping promotes them to live.
+- AnthropicClient service (Faraday + Bearer + prompt caching)
+- IngestionRun + IngestionItem state machine
+- Solid Queue jobs: ExtractMenu, ResolveIngredients, ResolveTags
+- Mobile: multi-page camera capture → upload → wait → swipe-verify UI
+- Web: paste URL or upload PDF → verify
+- Cost + latency dashboard in admin
+
+**Demo:** photograph a real Durango menu in person; 60 seconds later
+the items appear staged; 5 minutes of swiping promotes them to live.
 
 ## Phase 3 — Dietary filter (weeks 7–9)
 
-- [ ] Profile onboarding (6 taps to working filter)
-- [ ] Curated dietary-profile presets fully wired
-- [ ] Filtered restaurant page (mobile + web) — applyProfile from
-      filter-engine
-- [ ] Transparency layer: every hidden item shows reason
-- [ ] One-tap override per item ("show anyway")
-- [ ] Strict-mode toggle (hides anything not `confidence: confirmed`)
-- [ ] Shareable filter URLs (encode profile in a token)
+Subplan: `docs/plans/phase-3.md` (drafted at end of Phase 2).
+
+- Profile onboarding (6 taps to working filter)
+- Curated dietary-profile presets fully wired
+- Filtered restaurant page (mobile + web) — `applyProfile` from
+  filter-engine
+- Transparency layer: every hidden item shows reason
+- One-tap override per item ("show anyway")
+- Strict-mode toggle (hides anything not `confidence: confirmed`)
+- Shareable filter URLs (encode profile in a token)
 
 **Demo:** open the app, pick "Celiac + tree-nut allergy", scan a real
 menu, see only the dishes that pass. Hidden items each say *why*.
 
 ## Phase 4 — Reviews + accounts (weeks 10–11)
 
-- [ ] Per-item reviews (1–5 + text + photo)
-- [ ] Review moderation queue
-- [ ] User profile pages
-- [ ] "My filtered menus" history
-- [ ] Restaurant claim flow (domain-email verification)
-- [ ] Suggestion queue UX for community edits
+Subplan: `docs/plans/phase-4.md`.
+
+- Per-item reviews (1–5 + text + photo)
+- Review moderation queue
+- User profile pages
+- "My filtered menus" history
+- Restaurant claim flow (domain-email verification)
+- Suggestion queue UX for community edits
 
 **Demo:** a logged-in user reviews a dish from a restaurant they
 filtered to; an owner claims that restaurant.
 
 ## Phase 5 — Launch (week 12)
 
-- [ ] Seed 30 Durango restaurants via the ingestion pipeline
-- [ ] App Store + Play Store submission
-- [ ] SEO landing pages: `/durango/gluten-free`, `/durango/vegan`, etc.
-- [ ] PostHog funnels: app_open → profile_set → menu_filtered →
-      restaurant_tap
-- [ ] Public launch posts + outreach to Durango press
+Subplan: `docs/plans/phase-5.md`.
+
+- Seed 30 Durango restaurants via the ingestion pipeline
+- App Store + Play Store submission
+- SEO landing pages: `/durango/gluten-free`, `/durango/vegan`, etc.
+- PostHog funnels: app_open → profile_set → menu_filtered →
+  restaurant_tap
+- Public launch posts + outreach to Durango press
 
 **Demo:** real users on a Friday night using it to pick where to eat.
+
+## Discovered (loop-added followups)
+
+The loop appends here when work surfaces a new task that doesn't
+belong in the current phase. Humans triage these into the appropriate
+phase or "Next up" queue.
+
+(empty)
 
 ## What we are explicitly NOT doing in v1
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,19 @@
+# Delivery status log
+
+The autonomous loop's running log. Newest entries on top. One line per
+tick or significant event. Format:
+
+```
+YYYY-MM-DD HH:MM (UTC) — <summary>
+```
+
+The point is breadcrumbs: a tick interrupted at minute 28 should leave
+enough here for the next tick (or a human dropping in) to resume
+without spelunking GitHub.
+
+---
+
+2026-04-28 09:00 — Phase 0 merged (PR #110). Some master CI red — added
+to Next-up as a subtask. Framework PR (`claude/delivery-framework`)
+opening shortly with playbook v2, status log, phase-1 subplan, roadmap
+restructure.


### PR DESCRIPTION
## Why

@shadoath asked for an autonomous delivery loop that runs every 30 minutes, takes one item at a time off a planned queue, opens PRs, lands them with `@codex review` + a couple of self-review cycles, updates the plan, and pings when stuck. This PR operationalizes that workflow before any Phase 1 code starts so the loop has clear rules to follow and a human-readable trail to audit.

Pure docs — no code, no migrations, no behavior change.

## What

### `docs/delivery-playbook.md` (v2)
The recipe each `/loop 30m` tick follows. Key updates from your feedback:
- **One PR per task**, no artificial size cap. Don't split a coherent Phase 1.1 into three PRs to chase a 500-line target. Don't bundle unrelated work to be big.
- **Tests + review cycles are part of the task**. A PR without specs is incomplete. Every PR auto-requests `@codex review` and goes through at least one self-review pass before flagging ready-for-merge.
- **Stop conditions ping `@shadoath`** via a top-level PR comment (which GitHub emails by default): 3x same CI failure, `?` in a review thread, `[BLOCKED]` prefix on a roadmap item, missing secrets, > 2k-line diff without justification.
- **Auto-merge gated** on CI green + codex clear + owner-approved-or-labeled. Never bypasses CI. Never force-pushes master. Never edits previously-shipped migrations or `_legacy/`.

### `docs/status.md`
Running breadcrumb log, newest first, one line per tick. A 28-minute tick that gets interrupted leaves enough trail for the next tick (or a human) to resume.

### `docs/plans/phase-1.md`
Full Phase 1 subplan, decomposed into seven PR-sized tasks:
- **1.1** Devise JWT login + signup
- **1.2** OmniAuth Apple + Google
- **1.3** `GET/PATCH /api/v1/profile`
- **1.4** Full ingredient port from `_legacy/db/seeds/0_ingredients.rb`
- **1.5** Rails admin dashboard (Avo or ActiveAdmin)
- **1.6** OpenAPI codegen — kills the hand-written `packages/api-types`
- **1.7** Restaurant + Item read endpoints with the dietary filter

Each task carries: branch name, acceptance criteria, spec coverage, stop conditions. Subsequent phase subplans (`phase-2.md` etc.) get drafted at the end of each prior phase — keeps the loop from chasing stale plans.

### `docs/roadmap.md` (restructured)
Top of file is now a **Next up** queue the loop reads top-down. Phase 0 boxes are ticked except the master-CI subtask, which is queue item #1. Phase 2–5 sections retain their high-level checklists and link to subplans-to-be-drafted.

## Notes

- Item #1 in Next-up is **fix master CI** before anything else. Failing CI on master:
  - `bin/rails db:schema:load` runs against an empty `schema.rb` — needs schema generation or a switch to `db:migrate`.
  - `eslint-config` flat config imports `@eslint/js` + `typescript-eslint` that aren't in deps — needs simplification or dep adds.
  - `bundle exec rspec` has nothing to find — needs `.rspec` + `rails_helper`.
- The loop won't start Phase 1.1 until that goes green; the playbook says CI must be green to merge, so it'd just spin.

## Test plan

- [ ] `docs/delivery-playbook.md` reads top-to-bottom without ambiguity for someone (or some loop) picking up cold.
- [ ] `docs/roadmap.md` Next-up queue is in your priority order (re-order if not).
- [ ] `docs/plans/phase-1.md` decomposition matches your sense of "one task per PR."
- [ ] No production code touched.

Once this merges I'll start the cron and pick up Next-up #1 (master CI fix) on a fresh `claude/fix-master-ci` branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLUrmzAUNRfjUmSMfkQJjW)_