### PR TITLE
ci: auto-merge Dependabot PRs once required checks pass

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,7 +9,7 @@ Repository automation. Each file's purpose:
 | `workflows/codeql.yml`    | Weekly CodeQL scans for JS/TS and Ruby. |
 | `workflows/pr-title.yml`  | Conventional-commit format check on every PR title. |
 | `workflows/labeler.yml`   | Auto-applies `area:*` labels by changed paths. Config in `labeler.yml`. |
-| `workflows/auto-merge.yml`| Enables squash auto-merge for PRs with `claude-cd` + `auto-merge-ok`. |
+| `workflows/auto-merge.yml`| Enables squash auto-merge for PRs with `claude-cd` + `auto-merge-ok`, or any PR authored by `dependabot[bot]`. |
 | `labeler.yml`             | Path → label mapping. |
 | `dependabot.yml`          | Weekly grouped dep PRs (npm + bundler) + monthly actions bumps. |
 | `CODEOWNERS`              | Review routing. |
@@ -29,7 +29,8 @@ Repository automation. Each file's purpose:
    `CI · API / rspec`, `CodeQL / javascript-typescript`,
    `CodeQL / ruby`. Configure in repo Settings → Branches.
 6. **Auto-merge** is opt-in per PR via labels (`auto-merge-ok` +
-   `claude-cd`). Branch protection still gates everything.
+   `claude-cd`) and is automatic for `dependabot[bot]` PRs. Branch
+   protection still gates everything — failing CI blocks the merge.
 7. **`continue-on-error: true`** on Brakeman + Rubocop until the
    codebase grows to where they're meaningful. Re-tighten in Phase 1.
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,8 +2,8 @@ name: Auto-merge
 
 # Realizes the auto-merge policy from docs/delivery-playbook.md.
 # Enables PR auto-merge (squash) when:
-#   - PR has the `auto-merge-ok` label
-#   - PR is part of the `claude-cd` series
+#   - PR has the `auto-merge-ok` label AND `claude-cd` label, OR
+#   - PR is authored by `dependabot[bot]`
 # Once enabled, GitHub completes the merge as soon as required checks
 # pass and required reviews are satisfied. Branch protection on master
 # is what actually gates the merge — this workflow just opts in.
@@ -19,8 +19,9 @@ permissions:
 jobs:
   enable:
     if: >-
-      contains(github.event.pull_request.labels.*.name, 'auto-merge-ok') &&
-      contains(github.event.pull_request.labels.*.name, 'claude-cd')
+      (contains(github.event.pull_request.labels.*.name, 'auto-merge-ok') &&
+       contains(github.event.pull_request.labels.*.name, 'claude-cd')) ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: peter-evans/enable-pull-request-automerge@v3


### PR DESCRIPTION
## Summary

Extends `.github/workflows/auto-merge.yml` so any PR authored by `dependabot[bot]` is automatically opted into GitHub's native squash auto-merge, in addition to the existing `auto-merge-ok` + `claude-cd` label combo. Branch protection on `master` still gates the actual merge — required CI checks (JS, API/RSpec, CodeQL) must pass, otherwise nothing merges. README updated to match.

## Why

Dependabot opens grouped weekly bumps that almost always pass CI cleanly. Clicking "merge" on each one is just toil. If the checks we already trust are green, the PR should merge itself and the loop should keep moving.

## Test plan

- [ ] Confirm "Allow auto-merge" is enabled in repo Settings → General (required for the action to take effect).
- [ ] Wait for next Dependabot PR (or trigger one) and verify the `Auto-merge` workflow run flips on auto-merge.
- [ ] Verify a Dependabot PR with failing CI does *not* merge.
- [ ] Verify the existing `auto-merge-ok` + `claude-cd` path still works on a Claude-authored PR.