### PR TITLE
ci: prefix Dependabot PR titles with chore(deps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       time: "09:00"
       timezone: America/Denver
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
     groups:
       types:
         patterns: ["@types/*"]
@@ -33,6 +37,10 @@ updates:
       time: "09:00"
       timezone: America/Denver
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
     groups:
       rails:
         patterns: ["rails", "actionpack", "actionview", "activejob",
@@ -52,3 +60,6 @@ updates:
       time: "09:00"
       timezone: America/Denver
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
The PR-title workflow runs amannn/action-semantic-pull-request, which
rejects Dependabot's default "Bump X from Y to Z" titles for lacking a
conventional-commit type. Configure commit-message.prefix per ecosystem
so future updates land as "chore(deps): bump ...".