### PR TITLE
feat(api): omniauth apple + google sign-in (phase 1.2)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,36 @@
+# BiteWorthy API — local environment variables.
+#
+# Copy to .env (which is gitignored) and fill in real values for any
+# variables you need locally. The Rails app boots without these — only
+# the live OAuth handshake or JWT signing actually requires them.
+
+# --- JWT signing -------------------------------------------------------------
+# 64+ random chars. Falls back to Rails.application.secret_key_base
+# when unset, which is fine for local dev. Production must set this
+# (so rotating secret_key_base doesn't invalidate every issued JWT).
+DEVISE_JWT_SECRET_KEY=
+
+# --- Google OAuth ------------------------------------------------------------
+# Console: https://console.cloud.google.com/apis/credentials
+# Authorized redirect URI: http://localhost:3000/api/v1/auth/google_oauth2/callback
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
+# --- Apple OAuth -------------------------------------------------------------
+# Console: https://developer.apple.com/account/resources/identifiers/list/serviceId
+# Required for App Store review. The omniauth-apple strategy generates
+# the client_secret JWT itself from the team_id + key_id + private key.
+#
+# APPLE_OAUTH_CLIENT_ID is the Service ID (e.g. "app.biteworthy.web").
+# APPLE_OAUTH_PRIVATE_KEY is the multi-line PEM body of the .p8 file
+# downloaded from Apple — paste it as a single line with literal \n
+# escapes, or wrap in dotenv's `KEY="-----BEGIN...-----END..."` form.
+APPLE_OAUTH_CLIENT_ID=
+APPLE_OAUTH_TEAM_ID=
+APPLE_OAUTH_KEY_ID=
+APPLE_OAUTH_PRIVATE_KEY=
+
+# --- Mailer ------------------------------------------------------------------
+# Used by Devise for password-reset emails. The mailer itself isn't
+# wired in until Phase 4; this is documented now so .env stays canonical.
+DEVISE_MAILER_FROM=no-reply@biteworthy.app

--- a/apps/api/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/apps/api/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -12,11 +12,12 @@ module Api
       class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         respond_to :json
 
-        # Skip CSRF protection on the callback — the provider's
-        # redirect doesn't carry our CSRF token, and OAuth's `state`
-        # parameter (validated by the strategy) is the actual
-        # cross-site forgery defense for this leg.
-        skip_before_action :verify_authenticity_token, raise: false
+        # No `skip_before_action :verify_authenticity_token` needed:
+        # ApplicationController extends ActionController::API
+        # (config.api_only = true), which never installs CSRF
+        # protection. OAuth's own `state` parameter — validated by the
+        # OmniAuth strategy before we run — is the cross-site forgery
+        # defense for the callback leg.
 
         def google_oauth2
           handle_oauth_callback

--- a/apps/api/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/apps/api/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -1,0 +1,73 @@
+module Api
+  module V1
+    module Auth
+      # GET /api/v1/auth/:provider           → OmniAuth start (handled by Devise/OmniAuth)
+      # GET /api/v1/auth/:provider/callback  → here. Issues a JWT in the Authorization header.
+      #
+      # Mobile + web clients open the start URL in an in-app browser
+      # (or system browser); the provider redirects back to the
+      # callback with an auth hash; this controller mints a JWT and
+      # responds with JSON. There's no session — JWT is the only
+      # piece of state on the client.
+      class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+        respond_to :json
+
+        # Skip CSRF protection on the callback — the provider's
+        # redirect doesn't carry our CSRF token, and OAuth's `state`
+        # parameter (validated by the strategy) is the actual
+        # cross-site forgery defense for this leg.
+        skip_before_action :verify_authenticity_token, raise: false
+
+        def google_oauth2
+          handle_oauth_callback
+        end
+
+        def apple
+          handle_oauth_callback
+        end
+
+        # OmniAuth.config.on_failure routes here. Renders 401 + a JSON
+        # error body so mobile/web don't have to parse a Devise flash.
+        def failure
+          render json: { error: failure_message || "authentication_failed" },
+                 status: :unauthorized
+        end
+
+        private
+
+        def handle_oauth_callback
+          auth = request.env["omniauth.auth"]
+          if auth.blank?
+            render json: { error: "missing_omniauth_payload" }, status: :unauthorized
+            return
+          end
+
+          user = User.from_omniauth(auth)
+
+          unless user.persisted?
+            render json: { errors: user.errors.as_json }, status: :unprocessable_entity
+            return
+          end
+
+          # Mint a JWT. This is the same code path devise-jwt uses for
+          # the dispatch hook on signup/login — UserEncoder reads
+          # `jwt.expiration_time` and `jwt.secret` from the initializer.
+          token, _payload = Warden::JWTAuth::UserEncoder.new.call(user, :user, nil)
+          response.set_header("Authorization", "Bearer #{token}")
+
+          render json: { user: user_payload(user) }, status: :ok
+        end
+
+        def user_payload(user)
+          {
+            id: user.id,
+            email: user.email,
+            handle: user.handle,
+            display_name: user.display_name,
+            provider: user.provider
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -33,9 +33,13 @@ class User < ApplicationRecord
   # otherwise.
   def self.from_omniauth(auth)
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
-    user.email          ||= auth.info.email
-    user.display_name   ||= auth.info.name
-    user.confirmed_at   ||= Time.current
+    # Use `blank?` rather than `||=` because the users.email column has
+    # `default: ""` from Devise's migration generator — fresh records
+    # come back with an empty string, which is truthy and would block
+    # ||= from filling in the OAuth-provided email.
+    user.email          = auth.info.email if user.email.blank?
+    user.display_name   = auth.info.name  if user.display_name.blank?
+    user.confirmed_at ||= Time.current
 
     # Devise needs *some* password for :database_authenticatable's
     # encrypted_password column to be set. Generate a random one on

--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -8,7 +8,9 @@ class User < ApplicationRecord
   # confirmation, so :confirmable is also out for now.
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :jwt_authenticatable, jwt_revocation_strategy: self
+         :jwt_authenticatable, :omniauthable,
+         jwt_revocation_strategy: self,
+         omniauth_providers: [:google_oauth2, :apple]
 
   has_one  :profile, class_name: "UserProfile", dependent: :destroy
   has_many :reviews, dependent: :destroy
@@ -20,6 +22,42 @@ class User < ApplicationRecord
   before_validation :ensure_jti, on: :create
   before_validation :default_handle_from_email, on: :create
   after_create_commit :ensure_profile
+
+  # Find or create a user from an OmniAuth auth hash. Used by both the
+  # google_oauth2 and apple callbacks. New users get an empty
+  # UserProfile (via the after_create_commit callback) and are marked
+  # confirmed — the OAuth provider has already verified the email.
+  #
+  # Apple's callback only returns the user's name on the very first
+  # sign-in, so display_name is best-effort: filled when present, kept
+  # otherwise.
+  def self.from_omniauth(auth)
+    user = find_or_initialize_by(provider: auth.provider, uid: auth.uid)
+    user.email          ||= auth.info.email
+    user.display_name   ||= auth.info.name
+    user.confirmed_at   ||= Time.current
+
+    # Devise needs *some* password for :database_authenticatable's
+    # encrypted_password column to be set. Generate a random one on
+    # first sign-in only — never rotate it on subsequent logins (the
+    # `password` virtual is always nil on re-loaded records, so `||=`
+    # would otherwise re-assign forever).
+    if user.new_record?
+      user.password              = Devise.friendly_token[0, 20]
+      user.password_confirmation = user.password
+    end
+
+    user.save
+    user
+  end
+
+  # OAuth-created users have a `provider` set; only ask Devise to
+  # validate their password when they're plain email/password users
+  # OR when they've explicitly set one.
+  def password_required?
+    return false if provider.present? && !encrypted_password_changed?
+    super
+  end
 
   private
 

--- a/apps/api/config/application.rb
+++ b/apps/api/config/application.rb
@@ -29,5 +29,13 @@ module Biteworthy
     config.autoload_lib(ignore: %w[assets tasks])
 
     # CORS handled in initializers/cors.rb.
+
+    # OmniAuth needs a Rack session to hold the OAuth `state` param
+    # across the provider redirect. api_only mode strips both Cookies
+    # and Session middleware, so we put them back. Nothing else writes
+    # to the session — JWTs carry all post-login state.
+    config.session_store :cookie_store, key: "_biteworthy_session"
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, key: "_biteworthy_session"
   end
 end

--- a/apps/api/config/initializers/devise.rb
+++ b/apps/api/config/initializers/devise.rb
@@ -28,4 +28,23 @@ Devise.setup do |config|
   # headers for navigational requests and 401s for everything else.
   config.responder.error_status = :unprocessable_entity
   config.responder.redirect_status = :see_other
+
+  # OmniAuth providers — credentials come from ENV (see apps/api/.env.example).
+  # Both strategies are registered unconditionally so route helpers
+  # (`user_google_oauth2_omniauth_authorize_path`, etc.) exist in
+  # every environment; missing ENV just means the live OAuth handshake
+  # 401s, which is what we want during local dev without keys.
+  config.omniauth :google_oauth2,
+                  ENV["GOOGLE_OAUTH_CLIENT_ID"],
+                  ENV["GOOGLE_OAUTH_CLIENT_SECRET"],
+                  scope: "email,profile",
+                  prompt: "select_account"
+
+  config.omniauth :apple,
+                  ENV["APPLE_OAUTH_CLIENT_ID"],
+                  "", # client_secret is generated from the private key, not an env var
+                  scope: "email name",
+                  team_id: ENV["APPLE_OAUTH_TEAM_ID"],
+                  key_id: ENV["APPLE_OAUTH_KEY_ID"],
+                  pem: ENV["APPLE_OAUTH_PRIVATE_KEY"]
 end

--- a/apps/api/config/initializers/omniauth.rb
+++ b/apps/api/config/initializers/omniauth.rb
@@ -1,0 +1,19 @@
+# OmniAuth 2.x defaults to POST-only for the request phase as a CSRF
+# mitigation. BiteWorthy's mobile + web clients hit OAuth start URLs
+# via redirect (a GET), which is the standard pattern when there's no
+# DOM to render a form into. Allowing GET here is safe because the
+# `omniauth-rails_csrf_protection` gem (already in the Gemfile)
+# enforces CSRF on the *callback* phase — which is the side that
+# actually receives untrusted input from the provider.
+OmniAuth.config.allowed_request_methods = [:get, :post]
+OmniAuth.config.silence_get_warning = true
+
+# In test mode, fail fast on misconfigured mocks so missing-mock bugs
+# surface in the spec instead of silently 302'ing to /users/sign_in.
+OmniAuth.config.test_mode = true if Rails.env.test?
+
+# Translate OmniAuth's verbose strategy errors into our JSON failure
+# response (handled by Api::V1::Auth::OmniauthCallbacksController#failure).
+OmniAuth.config.on_failure = proc { |env|
+  Api::V1::Auth::OmniauthCallbacksController.action(:failure).call(env)
+}

--- a/apps/api/config/initializers/omniauth.rb
+++ b/apps/api/config/initializers/omniauth.rb
@@ -8,6 +8,12 @@
 OmniAuth.config.allowed_request_methods = [:get, :post]
 OmniAuth.config.silence_get_warning = true
 
+# Mount OmniAuth's internal middleware under the same /api/v1/auth/
+# prefix the rest of the auth routes use. Without this, OmniAuth would
+# only intercept /auth/<provider>/callback URLs, which our routes
+# don't expose.
+OmniAuth.config.path_prefix = "/api/v1/auth"
+
 # In test mode, fail fast on misconfigured mocks so missing-mock bugs
 # surface in the spec instead of silently 302'ing to /users/sign_in.
 OmniAuth.config.test_mode = true if Rails.env.test?

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -9,8 +9,9 @@ Rails.application.routes.draw do
              path: "api/v1/auth",
              path_names: { sign_in: "login", sign_out: "logout", registration: "signup" },
              controllers: {
-               sessions:      "api/v1/auth/sessions",
-               registrations: "api/v1/auth/registrations"
+               sessions:            "api/v1/auth/sessions",
+               registrations:       "api/v1/auth/registrations",
+               omniauth_callbacks:  "api/v1/auth/omniauth_callbacks"
              },
              defaults: { format: :json }
 

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -13,12 +13,34 @@ Rails.application.routes.draw do
                registrations:       "api/v1/auth/registrations",
                omniauth_callbacks:  "api/v1/auth/omniauth_callbacks"
              },
+             # devise_for would mount omniauth at /api/v1/auth/auth/:provider,
+             # which doubles up the /auth segment. We skip it and define our
+             # own clean routes below so the public URL is /api/v1/auth/:provider.
+             skip: [:omniauth_callbacks],
              defaults: { format: :json }
 
   # Custom Devise route — needs the devise_scope wrapper so the
   # SessionsController inherits the right Devise mapping.
   devise_scope :user do
     post "/api/v1/auth/refresh", to: "api/v1/auth/sessions#refresh", as: :api_v1_auth_refresh
+
+    # OmniAuth start + callback. Routes match what OmniAuth.config.path_prefix
+    # tells the OmniAuth middleware to intercept; the start path passes through
+    # the middleware (passthru), the callback path lands on our action that
+    # mints a JWT. Constraints lock the :provider param to known strategies.
+    provider_constraint = { provider: /google_oauth2|apple/ }
+    match "/api/v1/auth/:provider",
+          to: "api/v1/auth/omniauth_callbacks#passthru",
+          via: [:get, :post], constraints: provider_constraint, as: :user_omniauth_authorize
+    get   "/api/v1/auth/google_oauth2/callback",
+          to: "api/v1/auth/omniauth_callbacks#google_oauth2",
+          as: :user_google_oauth2_omniauth_callback
+    get   "/api/v1/auth/apple/callback",
+          to: "api/v1/auth/omniauth_callbacks#apple",
+          as: :user_apple_omniauth_callback
+    match "/api/v1/auth/failure",
+          to: "api/v1/auth/omniauth_callbacks#failure",
+          via: [:get, :post]
   end
 
   namespace :api do

--- a/apps/api/spec/requests/api/v1/auth/omniauth_apple_spec.rb
+++ b/apps/api/spec/requests/api/v1/auth/omniauth_apple_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Apple Sign-In integration smoke. Live VCR cassettes are deferred
+# until the Apple signing key is provisioned in CI (see Phase 1.2 stop
+# condition in docs/plans/phase-1.md). For now, the strategy is
+# exercised through OmniAuth.test_mode with a mocked auth hash, which
+# is enough to verify wiring + the from_omniauth path.
+RSpec.describe "GET /api/v1/auth/apple/callback", type: :request do
+  let(:auth_hash) do
+    omniauth_hash(
+      provider: :apple,
+      uid: "001234.abcdef.5678",
+      email: "appluser@privaterelay.appleid.com",
+      name: "Apple User"
+    )
+  end
+
+  context "first sign-in" do
+    before { mock_omniauth(:apple, auth_hash) }
+
+    it "creates a User + UserProfile and returns 200 with a JWT" do
+      expect {
+        get "/api/v1/auth/apple/callback"
+      }.to change(User, :count).by(1).and change(UserProfile, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Authorization"]).to match(/\ABearer .+/)
+
+      user = User.find_by(provider: "apple", uid: "001234.abcdef.5678")
+      expect(user.email).to eq("appluser@privaterelay.appleid.com")
+      expect(user.confirmed_at).to be_present
+    end
+  end
+
+  context "returning user" do
+    let!(:existing_user) do
+      create(:user, provider: "apple", uid: "001234.abcdef.5678",
+                    email: "appluser@privaterelay.appleid.com",
+                    confirmed_at: Time.current)
+    end
+
+    before { mock_omniauth(:apple, auth_hash) }
+
+    it "matches by [provider, uid] and does not create a duplicate" do
+      expect {
+        get "/api/v1/auth/apple/callback"
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig("user", "id")).to eq(existing_user.id)
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/auth/omniauth_google_spec.rb
+++ b/apps/api/spec/requests/api/v1/auth/omniauth_google_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/auth/google_oauth2/callback", type: :request do
+  let(:auth_hash) do
+    omniauth_hash(
+      provider: :google_oauth2,
+      uid: "google-12345",
+      email: "newcomer@gmail.com",
+      name: "Newcomer Person"
+    )
+  end
+
+  context "first sign-in" do
+    before { mock_omniauth(:google_oauth2, auth_hash) }
+
+    it "creates a User + UserProfile and returns 200 with a JWT" do
+      expect {
+        get "/api/v1/auth/google_oauth2/callback"
+      }.to change(User, :count).by(1).and change(UserProfile, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Authorization"]).to match(/\ABearer .+/)
+
+      body = response.parsed_body
+      expect(body["user"]).to include(
+        "email" => "newcomer@gmail.com",
+        "provider" => "google_oauth2"
+      )
+
+      user = User.find_by(provider: "google_oauth2", uid: "google-12345")
+      expect(user.email).to eq("newcomer@gmail.com")
+      expect(user.confirmed_at).to be_present
+      expect(user.profile).to be_present
+    end
+  end
+
+  context "returning user" do
+    let!(:existing_user) do
+      create(:user, provider: "google_oauth2", uid: "google-12345",
+                    email: "newcomer@gmail.com", confirmed_at: Time.current)
+    end
+
+    before { mock_omniauth(:google_oauth2, auth_hash) }
+
+    it "matches by [provider, uid] and does not create a duplicate" do
+      expect {
+        get "/api/v1/auth/google_oauth2/callback"
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Authorization"]).to match(/\ABearer .+/)
+      expect(response.parsed_body.dig("user", "id")).to eq(existing_user.id)
+    end
+  end
+
+  context "OAuth failure (provider rejected the request)" do
+    before { mock_omniauth_failure(:google_oauth2, :invalid_credentials) }
+
+    it "returns 401 with a JSON error" do
+      get "/api/v1/auth/google_oauth2/callback"
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to have_key("error")
+    end
+  end
+end

--- a/apps/api/spec/support/omniauth_helpers.rb
+++ b/apps/api/spec/support/omniauth_helpers.rb
@@ -1,0 +1,41 @@
+module OmniauthHelpers
+  # Build an OmniAuth::AuthHash mimicking what Google or Apple would
+  # POST back to our callback. Keeps the spec readable — call with
+  # only the fields the test cares about.
+  def omniauth_hash(provider:, uid: "uid-#{SecureRandom.hex(4)}",
+                    email: "oauth-#{SecureRandom.hex(4)}@example.com",
+                    name: "OAuth User")
+    OmniAuth::AuthHash.new(
+      provider: provider.to_s,
+      uid: uid,
+      info: { email: email, name: name },
+      credentials: { token: "fake-token-#{SecureRandom.hex(4)}" }
+    )
+  end
+
+  # Wire a mocked auth payload into OmniAuth so the next request to
+  # /api/v1/auth/<provider>/callback resolves to it instead of hitting
+  # the live provider.
+  def mock_omniauth(provider, auth)
+    OmniAuth.config.mock_auth[provider.to_sym] = auth
+    Rails.application.env_config["devise.mapping"]      = Devise.mappings[:user]
+    Rails.application.env_config["omniauth.auth"]       = auth
+  end
+
+  # Convenience for the failure-path spec.
+  def mock_omniauth_failure(provider, reason = :invalid_credentials)
+    OmniAuth.config.mock_auth[provider.to_sym] = reason
+    Rails.application.env_config["devise.mapping"] = Devise.mappings[:user]
+  end
+end
+
+RSpec.configure do |config|
+  config.include OmniauthHelpers, type: :request
+
+  # Reset OmniAuth state between examples so a mock or failure set in
+  # one spec doesn't leak into the next.
+  config.before(:each, type: :request) do
+    OmniAuth.config.mock_auth.clear
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+end

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 12:30 — tick #30. Hold continues (26th in a row). No-op.
+
 2026-04-29 12:00 — tick #29. Hold continues (25th in a row). No-op.
 
 2026-04-29 11:30 — tick #28. Hold continues (24th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 11:00 — tick #27. Hold continues (23rd in a row). No-op.
+
 2026-04-29 10:30 — tick #26. Hold continues (22nd in a row). No-op.
 
 2026-04-29 10:00 — tick #25. Hold continues (21st in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 01:00 — tick #7. Hold continues (3rd in a row). No-op.
+
 2026-04-29 00:30 — tick #6. Hold continues. PR #128 unchanged from
 #5 (CLEAN/MERGEABLE, no review, no label). No-op tick.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,21 @@ without spelunking GitHub.
 
 ---
 
+2026-04-28 23:00 — tick #3. PR #128 CI · API green (rspec 17/17) and
+CodeQL js+ruby green after the 22:35 push, but the umbrella
+"CodeQL" code-scanning aggregator FAILED on a real new alert:
+`rb/csrf-protection-disabled` against
+`omniauth_callbacks_controller.rb:13` (the
+`skip_before_action :verify_authenticity_token` line). In api_only
+mode that line is a no-op — ActionController::API never installs
+CSRF in the first place. Removed the line + comment-explained why
+(commit 6d6ed92). Local rspec still 17/17 green. No `@codex` review
+came back since the 21:55 ping; PR is `reviewDecision: ""`. Per
+playbook §2 still need CI green AND approval; if codex doesn't
+respond by next tick, will ping `@shadoath` to clarify codex setup
+or apply `auto-merge-ok` manually. Next tick: re-check CI + review
+state.
+
 2026-04-28 22:35 — tick #2. PR #128 CI red: 17/17 specs failing 500.
 Root cause: api_only Rails strips session middleware → OmniAuth's
 strategy raises NoSessionError on every request (including /up).

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,13 @@ without spelunking GitHub.
 
 ---
 
+2026-04-28 21:55 — opened #128 phase-1.2-omniauth (+362/-3); 5 specs
+across google + apple (new/returning/failure). Created `claude-cd` +
+`auto-merge-ok` labels on the repo (referenced by playbook + auto-
+merge.yml but never created). Requested `@codex review`. CI checks
+in flight: ci-api (rspec/brakeman/rubocop), CodeQL (js + ruby),
+labeler, title-lint. Waiting for CI; next 30-min tick checks state.
+
 2026-04-28 21:30 — loop tick (resumed). Reconciled stale log: PR #124
 (phase-1.1) merged at 2026-04-29 01:16 UTC; `Done` already ticked in
 roadmap. Picked up Phase 1.2 — opened branch

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 08:30 — tick #22. Hold continues (18th in a row). No-op.
+
 2026-04-29 08:00 — tick #21. Hold continues (17th in a row). No-op.
 
 2026-04-29 07:30 — tick #20. Hold continues (16th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 02:30 — tick #10. Hold continues (6th in a row). No-op.
+
 2026-04-29 02:00 — tick #9. Hold continues (5th in a row). No-op.
 
 2026-04-29 01:30 — tick #8. Hold continues (4th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,18 @@ without spelunking GitHub.
 
 ---
 
+2026-04-28 23:30 — tick #4. PR #128 fully green: rspec 17/17,
+CodeQL js+ruby, **CodeQL umbrella also SUCCESS** (the CSRF alert
+cleared once I removed the no-op `skip_before_action`), labeler,
+title-lint. `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`. But
+`reviewDecision: ""` — codex hasn't responded ~1h post-ping. Per
+playbook auto-merge needs codex approval OR `auto-merge-ok` label
+OR shadoath approval; none present. Pinged `@shadoath` on the PR
+asking for approval, label, or hold-direction. Tick ends here per
+playbook §7 (no progress on Next-up while a `claude-cd` PR is
+waiting for review). Next tick: re-check for codex/shadoath
+response; if still no movement, hold.
+
 2026-04-28 23:00 — tick #3. PR #128 CI · API green (rspec 17/17) and
 CodeQL js+ruby green after the 22:35 push, but the umbrella
 "CodeQL" code-scanning aggregator FAILED on a real new alert:

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 07:00 — tick #19. Hold continues (15th in a row). No-op.
+
 2026-04-29 06:30 — tick #18. Hold continues (14th in a row). No-op.
 
 2026-04-29 06:00 — tick #17. Hold continues (13th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,19 @@ without spelunking GitHub.
 
 ---
 
+2026-04-28 21:30 — loop tick (resumed). Reconciled stale log: PR #124
+(phase-1.1) merged at 2026-04-29 01:16 UTC; `Done` already ticked in
+roadmap. Picked up Phase 1.2 — opened branch
+`claude/phase-1.2-omniauth`. Implemented: `:omniauthable` on User,
+`User.from_omniauth`, `OmniauthCallbacksController` (google_oauth2 +
+apple + failure), routes wired, `config/initializers/omniauth.rb`
+(allow GET request method, on_failure → controller), `.env.example`
+documenting GOOGLE_/APPLE_/DEVISE_JWT_ env vars, request specs in
+test_mode covering google new/returning/failure + apple
+new/returning. Local rspec deferred (no postgres service running on
+this dev box); CI's postgres container will exercise. Next: push +
+open PR + request `@codex review`.
+
 2026-04-28 20:05 — loop tick #1. PR #124 (phase-1.1) open, CI pending
 on all 5 checks after title-fix push, `area:api` label applied. Per
 playbook: wait for CI, no action. Subscribed to PR activity; webhook

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 13:00 — tick #31. Hold continues (27th in a row). No-op.
+
 2026-04-29 12:30 — tick #30. Hold continues (26th in a row). No-op.
 
 2026-04-29 12:00 — tick #29. Hold continues (25th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,17 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 00:00 — tick #5. Hold tick. PR #128 unchanged from #4:
+CLEAN/MERGEABLE, all 7 checks SUCCESS, `reviewDecision: ""`, no
+`auto-merge-ok` label, no shadoath response. Discovered structural
+issue: the loop's gh CLI authenticates as `shadoath` (same as the
+project owner), so `@shadoath` pings via `gh pr comment` are
+self-mentions and don't notify. Playbook's escalation channel needs
+either a separate bot account OR direct surfacing to the human via
+the agent conversation. Surfaced both in this tick's reply. Not
+re-pinging (no signal value). Not stacking Phase 1.3 PR (one PR per
+task per playbook). Holding until human acts on #128.
+
 2026-04-28 23:30 — tick #4. PR #128 fully green: rspec 17/17,
 CodeQL js+ruby, **CodeQL umbrella also SUCCESS** (the CSRF alert
 cleared once I removed the no-op `skip_before_action`), labeler,

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 01:30 — tick #8. Hold continues (4th in a row). No-op.
+
 2026-04-29 01:00 — tick #7. Hold continues (3rd in a row). No-op.
 
 2026-04-29 00:30 — tick #6. Hold continues. PR #128 unchanged from

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 04:00 — tick #13. Hold continues (9th in a row). No-op.
+
 2026-04-29 03:30 — tick #12. Hold continues (8th in a row). No-op.
 
 2026-04-29 03:00 — tick #11. Hold continues (7th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 13:30 — tick #32. Hold continues (28th in a row). No-op.
+
 2026-04-29 13:00 — tick #31. Hold continues (27th in a row). No-op.
 
 2026-04-29 12:30 — tick #30. Hold continues (26th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 09:00 — tick #23. Hold continues (19th in a row). No-op.
+
 2026-04-29 08:30 — tick #22. Hold continues (18th in a row). No-op.
 
 2026-04-29 08:00 — tick #21. Hold continues (17th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 04:30 — tick #14. Hold continues (10th in a row). No-op.
+
 2026-04-29 04:00 — tick #13. Hold continues (9th in a row). No-op.
 
 2026-04-29 03:30 — tick #12. Hold continues (8th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 03:30 — tick #12. Hold continues (8th in a row). No-op.
+
 2026-04-29 03:00 — tick #11. Hold continues (7th in a row). No-op.
 
 2026-04-29 02:30 — tick #10. Hold continues (6th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,19 @@ without spelunking GitHub.
 
 ---
 
+2026-04-28 22:35 — tick #2. PR #128 CI red: 17/17 specs failing 500.
+Root cause: api_only Rails strips session middleware → OmniAuth's
+strategy raises NoSessionError on every request (including /up).
+Diagnosed by starting postgres@16 locally, reproducing with
+`bin/rspec`, reading log/test.log. Pushed three fixes in one
+commit (06fc7c9): (a) reinjected ActionDispatch::Cookies + Session
+in application.rb, (b) skipped Devise's `/api/v1/auth/auth/:provider`
+double-prefix routes — set OmniAuth.config.path_prefix +
+custom clean routes for /api/v1/auth/:provider per phase-1.md spec,
+(c) `||=` was a no-op against the `default: ""` email column → use
+`if blank?`. Local rspec: 17 examples, 0 failures. Waiting on CI
+re-run to confirm green; next tick checks merge state.
+
 2026-04-28 21:55 — opened #128 phase-1.2-omniauth (+362/-3); 5 specs
 across google + apple (new/returning/failure). Created `claude-cd` +
 `auto-merge-ok` labels on the repo (referenced by playbook + auto-

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 07:30 — tick #20. Hold continues (16th in a row). No-op.
+
 2026-04-29 07:00 — tick #19. Hold continues (15th in a row). No-op.
 
 2026-04-29 06:30 — tick #18. Hold continues (14th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 05:00 — tick #15. Hold continues (11th in a row). No-op.
+
 2026-04-29 04:30 — tick #14. Hold continues (10th in a row). No-op.
 
 2026-04-29 04:00 — tick #13. Hold continues (9th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 10:00 — tick #25. Hold continues (21st in a row). No-op.
+
 2026-04-29 09:30 — tick #24. Hold continues (20th in a row). No-op.
 
 2026-04-29 09:00 — tick #23. Hold continues (19th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 10:30 — tick #26. Hold continues (22nd in a row). No-op.
+
 2026-04-29 10:00 — tick #25. Hold continues (21st in a row). No-op.
 
 2026-04-29 09:30 — tick #24. Hold continues (20th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 06:30 — tick #18. Hold continues (14th in a row). No-op.
+
 2026-04-29 06:00 — tick #17. Hold continues (13th in a row). No-op.
 
 2026-04-29 05:30 — tick #16. Hold continues (12th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 11:30 — tick #28. Hold continues (24th in a row). No-op.
+
 2026-04-29 11:00 — tick #27. Hold continues (23rd in a row). No-op.
 
 2026-04-29 10:30 — tick #26. Hold continues (22nd in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 05:30 — tick #16. Hold continues (12th in a row). No-op.
+
 2026-04-29 05:00 — tick #15. Hold continues (11th in a row). No-op.
 
 2026-04-29 04:30 — tick #14. Hold continues (10th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 03:00 — tick #11. Hold continues (7th in a row). No-op.
+
 2026-04-29 02:30 — tick #10. Hold continues (6th in a row). No-op.
 
 2026-04-29 02:00 — tick #9. Hold continues (5th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 02:00 — tick #9. Hold continues (5th in a row). No-op.
+
 2026-04-29 01:30 — tick #8. Hold continues (4th in a row). No-op.
 
 2026-04-29 01:00 — tick #7. Hold continues (3rd in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,9 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 00:30 — tick #6. Hold continues. PR #128 unchanged from
+#5 (CLEAN/MERGEABLE, no review, no label). No-op tick.
+
 2026-04-29 00:00 — tick #5. Hold tick. PR #128 unchanged from #4:
 CLEAN/MERGEABLE, all 7 checks SUCCESS, `reviewDecision: ""`, no
 `auto-merge-ok` label, no shadoath response. Discovered structural

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 09:30 — tick #24. Hold continues (20th in a row). No-op.
+
 2026-04-29 09:00 — tick #23. Hold continues (19th in a row). No-op.
 
 2026-04-29 08:30 — tick #22. Hold continues (18th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 06:00 — tick #17. Hold continues (13th in a row). No-op.
+
 2026-04-29 05:30 — tick #16. Hold continues (12th in a row). No-op.
 
 2026-04-29 05:00 — tick #15. Hold continues (11th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 08:00 — tick #21. Hold continues (17th in a row). No-op.
+
 2026-04-29 07:30 — tick #20. Hold continues (16th in a row). No-op.
 
 2026-04-29 07:00 — tick #19. Hold continues (15th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 14:00 — tick #33. Hold continues (29th in a row). No-op.
+
 2026-04-29 13:30 — tick #32. Hold continues (28th in a row). No-op.
 
 2026-04-29 13:00 — tick #31. Hold continues (27th in a row). No-op.

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,8 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 12:00 — tick #29. Hold continues (25th in a row). No-op.
+
 2026-04-29 11:30 — tick #28. Hold continues (24th in a row). No-op.
 
 2026-04-29 11:00 — tick #27. Hold continues (23rd in a row). No-op.


### PR DESCRIPTION
## Why

Phase 1.2 of the v2 delivery plan — `docs/plans/phase-1.md#12`. Apple Sign-In is required for App Store review; Google is the second most-requested. Both feed into the existing `users.provider` + `users.uid` columns added in Phase 1.1.

## What

- `:omniauthable` added to `User` devise modules with `omniauth_providers: [:google_oauth2, :apple]`.
- `User.from_omniauth(auth)` — finds-or-creates by `[provider, uid]`, sets email/display_name/confirmed_at, generates a one-time random password on creation only (so subsequent OAuth sign-ins don't re-rotate).
- `User#password_required?` overridden so OAuth users without an explicit password change skip the validation (otherwise re-loaded records 422 on every save).
- `Api::V1::Auth::OmniauthCallbacksController` — `google_oauth2`, `apple`, `failure` actions. Manually dispatches a JWT through `Warden::JWTAuth::UserEncoder` (matching the `SessionsController#refresh` pattern), 401s on missing payload, 422s on save failure.
- Routes pass `controllers: { omniauth_callbacks: "api/v1/auth/omniauth_callbacks" }` to `devise_for`. Final paths: `GET /api/v1/auth/google_oauth2`, `GET /api/v1/auth/google_oauth2/callback`, same for `apple`.
- `config/initializers/omniauth.rb`: `allowed_request_methods = [:get, :post]` (mobile/web hit start URLs as GET redirects), `silence_get_warning`, `test_mode` in test env, `on_failure` routed to controller.
- `config/initializers/devise.rb`: `config.omniauth :google_oauth2, ...` + `:apple, ...` reading from ENV.
- `apps/api/.env.example` documenting `GOOGLE_OAUTH_CLIENT_ID/SECRET`, `APPLE_OAUTH_CLIENT_ID/TEAM_ID/KEY_ID/PRIVATE_KEY`, plus `DEVISE_JWT_SECRET_KEY` and `DEVISE_MAILER_FROM` for completeness.
- `spec/support/omniauth_helpers.rb` + request specs for both providers (new user / returning user / failure path), all in `OmniAuth.config.test_mode = true` with mocked auth hashes.

## Test plan

- [ ] CI · API: `bundle exec rspec` green (5 new examples in `spec/requests/api/v1/auth/omniauth_*_spec.rb`).
- [ ] CI · API: existing 12 Phase 1.1 specs still green (no regressions in signup/login/logout/refresh).
- [ ] Verify `OmniAuth.config.allowed_request_methods` change doesn't break the omniauth-rails_csrf_protection callback defense.
- [ ] Manual: hit `GET /api/v1/auth/google_oauth2` in dev with `GOOGLE_OAUTH_CLIENT_ID/SECRET` filled — should redirect to Google's consent screen. (Deferred — needs real client_id; test_mode mocks cover the wiring.)

## Notes

- **Local rspec deferred**: no Postgres service running on the dev box this PR was authored from. CI's postgres:16 service container will exercise the full suite.
- **Apple live integration**: per phase-1.md §1.2 stop condition, Apple signing key is not in CI yet. Apple's strategy is wired identically to Google's and exercised through `OmniAuth.test_mode`; live VCR cassettes land when the signing key is provisioned.
- **JWT dispatch**: chose manual `Warden::JWTAuth::UserEncoder.call` over adding the callback path to `jwt.dispatch_requests`. Same pattern as `SessionsController#refresh`. Keeps the JWT initializer untouched.
- **Password handling**: random `Devise.friendly_token[0, 20]` on first OAuth sign-in only. Returning users never have their password rotated. `password_required?` returns `false` whenever `provider.present? && !encrypted_password_changed?`.
- **Labels**: created `claude-cd` and `auto-merge-ok` on the repo this tick — both are referenced by `.github/workflows/auto-merge.yml` and `docs/delivery-playbook.md` but had never been created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)