### PR TITLE
feat(api): user profile read/update with dietary preset (phase 1.3)

### DIFF
--- a/apps/api/app/controllers/api/v1/profiles_controller.rb
+++ b/apps/api/app/controllers/api/v1/profiles_controller.rb
@@ -1,24 +1,87 @@
 module Api
   module V1
-    # Minimal stub. Real GET/PATCH semantics — including avoid/prefer
-    # array round-trip and dietary-profile preset application — land
-    # in Phase 1.3 (`docs/plans/phase-1.md#13`). For now this just
-    # exists so authenticated callers can check that their token is
-    # still valid (and unauthenticated ones get a clean 401).
+    # GET   /api/v1/profile  → returns the caller's dietary settings.
+    # PATCH /api/v1/profile  → replaces the avoid/prefer arrays wholesale
+    #                          and/or applies a dietary_profile preset
+    #                          (additive — never destructive).
+    #
+    # Replacement semantics: PATCH treats avoid_ingredient_ids,
+    # avoid_tag_ids, prefer_tag_ids, and strictness as a wholesale
+    # overwrite of whatever's stored. The mobile + web clients build
+    # the final array client-side and POST the canonical state — they
+    # are not sending diffs.
+    #
+    # Preset application: if the body carries `dietary_profile_slug`,
+    # that preset's avoid_ingredients + avoid_tags are unioned onto
+    # whatever the client just sent. Presets only ADD; they never
+    # remove rules the user already chose. The chosen preset is also
+    # recorded as `primary_dietary_profile_id` so onboarding flows
+    # can show "you picked Vegan" later.
     class ProfilesController < BaseController
       def show
         render json: profile_payload(current_user.profile)
       end
 
+      def update
+        profile = current_user.profile
+        attrs   = profile_params
+
+        # Wholesale replacement happens first; the preset (if any)
+        # then unions on top so the user's POSTed list is never a
+        # subset of what gets saved.
+        profile.assign_attributes(attrs.except(:dietary_profile_slug))
+
+        if (slug = attrs[:dietary_profile_slug]).present?
+          preset = DietaryProfile.includes(:dietary_profile_ingredients,
+                                           :dietary_profile_tags)
+                                 .find_by!(slug: slug)
+          apply_preset!(profile, preset)
+        end
+
+        if profile.save
+          render json: profile_payload(profile)
+        else
+          render json: { errors: profile.errors.as_json },
+                 status: :unprocessable_entity
+        end
+      end
+
       private
+
+      def profile_params
+        params.permit(
+          :strictness,
+          :dietary_profile_slug,
+          avoid_ingredient_ids: [],
+          avoid_tag_ids:        [],
+          prefer_tag_ids:       []
+        )
+      end
+
+      def apply_preset!(profile, preset)
+        avoid_ingredients = preset.dietary_profile_ingredients
+                                  .where(rule: "avoid").pluck(:ingredient_id)
+        avoid_tags        = preset.dietary_profile_tags
+                                  .where(rule: "avoid").pluck(:tag_id)
+
+        profile.avoid_ingredient_ids = (profile.avoid_ingredient_ids + avoid_ingredients).uniq
+        profile.avoid_tag_ids        = (profile.avoid_tag_ids        + avoid_tags).uniq
+        profile.primary_dietary_profile_id = preset.id
+      end
 
       def profile_payload(profile)
         {
           avoid_ingredient_ids: profile.avoid_ingredient_ids,
           avoid_tag_ids:        profile.avoid_tag_ids,
           prefer_tag_ids:       profile.prefer_tag_ids,
-          strictness:           profile.strictness
+          strictness:           profile.strictness,
+          primary_dietary_profile: dietary_profile_summary(profile.primary_dietary_profile)
         }
+      end
+
+      def dietary_profile_summary(preset)
+        return nil if preset.nil?
+        { id: preset.id, slug: preset.slug, name: preset.name }
       end
     end
   end

--- a/apps/api/spec/factories/dietary_profile_associations.rb
+++ b/apps/api/spec/factories/dietary_profile_associations.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :dietary_profile_ingredient do
+    dietary_profile
+    ingredient
+    rule { "avoid" }
+  end
+
+  factory :dietary_profile_tag do
+    dietary_profile
+    tag
+    rule { "avoid" }
+  end
+end

--- a/apps/api/spec/factories/dietary_profiles.rb
+++ b/apps/api/spec/factories/dietary_profiles.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  # Real preset names users will pick during onboarding ("I'm
+  # vegetarian", "I have celiac"). Specs that exercise the
+  # dietary_profile preset application read more naturally when the
+  # presets are actually called Vegan / Celiac / Halal.
+  DIETARY_PROFILE_SAMPLES = [
+    { slug: "vegan",        name: "Vegan",        description: "No animal products of any kind." },
+    { slug: "vegetarian",   name: "Vegetarian",   description: "No meat, poultry, or seafood." },
+    { slug: "pescatarian",  name: "Pescatarian",  description: "Vegetarian + fish & shellfish." },
+    { slug: "celiac",       name: "Celiac",       description: "Strict gluten-free for celiac disease." },
+    { slug: "gluten-free",  name: "Gluten-Free",  description: "Avoids wheat-based gluten." },
+    { slug: "dairy-free",   name: "Dairy-Free",   description: "Avoids all dairy products." },
+    { slug: "halal",        name: "Halal",        description: "Halal dietary law." },
+    { slug: "kosher",       name: "Kosher",       description: "Kosher dietary law." },
+    { slug: "tree-nut-allergy", name: "Tree-Nut Allergy", description: "Avoids almonds, walnuts, cashews, and other tree nuts." },
+    { slug: "peanut-allergy",   name: "Peanut Allergy",   description: "Avoids peanuts and peanut-derived ingredients." }
+  ].freeze
+
+  factory :dietary_profile do
+    transient do
+      sequence(:rotation_idx) { |n| n }
+    end
+
+    slug { DIETARY_PROFILE_SAMPLES[(rotation_idx - 1) % DIETARY_PROFILE_SAMPLES.size][:slug] }
+
+    name        { (DIETARY_PROFILE_SAMPLES.find { |s| s[:slug] == slug } || {})[:name]        || slug.tr("-", " ").capitalize }
+    description { (DIETARY_PROFILE_SAMPLES.find { |s| s[:slug] == slug } || {})[:description] || "Custom dietary profile" }
+  end
+end

--- a/apps/api/spec/factories/ingredients.rb
+++ b/apps/api/spec/factories/ingredients.rb
@@ -1,0 +1,55 @@
+FactoryBot.define do
+  # Curated subset of the real ingredient taxonomy
+  # (apps/api/db/seeds/ingredients.yml is the production source). Keeps
+  # specs reading like real menu data — "dairy.cheese" instead of
+  # "ingredient-7" — without coupling to whatever seeds exist at the
+  # time the test runs.
+  INGREDIENT_SAMPLES = [
+    { slug: "dairy",            name: "Dairy",         path: "dairy",           allergen: true,  aliases: %w[milk lactose] },
+    { slug: "dairy-cheese",     name: "Cheese",        path: "dairy.cheese",    allergen: true,  aliases: %w[fromage queso] },
+    { slug: "dairy-butter",     name: "Butter",        path: "dairy.butter",    allergen: true,  aliases: %w[ghee] },
+    { slug: "dairy-cream",      name: "Cream",         path: "dairy.cream",     allergen: true,  aliases: %w[creme half-and-half] },
+    { slug: "egg",              name: "Egg",           path: "egg",             allergen: true,  aliases: %w[eggs] },
+    { slug: "fish-salmon",      name: "Salmon",        path: "fish.salmon",     allergen: true,  aliases: %w[lox] },
+    { slug: "fish-tuna",        name: "Tuna",          path: "fish.tuna",       allergen: true,  aliases: %w[ahi] },
+    { slug: "shellfish-shrimp", name: "Shrimp",        path: "shellfish.shrimp", allergen: true, aliases: %w[prawn] },
+    { slug: "tree-nut-almond",  name: "Almond",        path: "tree_nut.almond", allergen: true,  aliases: %w[almonds] },
+    { slug: "tree-nut-walnut",  name: "Walnut",        path: "tree_nut.walnut", allergen: true,  aliases: %w[walnuts] },
+    { slug: "peanut",           name: "Peanut",        path: "peanut",          allergen: true,  aliases: %w[groundnut] },
+    { slug: "soy",              name: "Soy",           path: "soy",             allergen: true,  aliases: %w[soya] },
+    { slug: "wheat",            name: "Wheat",         path: "wheat",           allergen: true,  aliases: %w[gluten flour] },
+    { slug: "sesame",           name: "Sesame",        path: "sesame",          allergen: true,  aliases: %w[tahini] },
+    { slug: "meat-beef",        name: "Beef",          path: "meat.beef",       allergen: false, aliases: %w[steak] },
+    { slug: "meat-pork",        name: "Pork",          path: "meat.pork",       allergen: false, aliases: %w[bacon ham] },
+    { slug: "poultry-chicken",  name: "Chicken",       path: "poultry.chicken", allergen: false, aliases: %w[hen] },
+    { slug: "vegetable-onion",  name: "Onion",         path: "vegetable.onion", allergen: false, aliases: %w[onions scallion] },
+    { slug: "vegetable-garlic", name: "Garlic",        path: "vegetable.garlic", allergen: false, aliases: %w[ajo] },
+    { slug: "vegetable-tomato", name: "Tomato",        path: "vegetable.tomato", allergen: false, aliases: %w[tomatoes] },
+    { slug: "fruit-lime",       name: "Lime",          path: "fruit.lime",      allergen: false, aliases: %w[limes] },
+    { slug: "herb-cilantro",    name: "Cilantro",      path: "herb.cilantro",   allergen: false, aliases: %w[coriander] },
+    { slug: "spice-cumin",      name: "Cumin",         path: "spice.cumin",     allergen: false, aliases: %w[jeera] },
+    { slug: "grain-rice",       name: "Rice",          path: "grain.rice",      allergen: false, aliases: %w[arroz] },
+    { slug: "grain-corn",       name: "Corn",          path: "grain.corn",      allergen: false, aliases: %w[maize] },
+    { slug: "legume-bean-black",name: "Black Bean",    path: "legume.bean.black", allergen: false, aliases: %w[frijoles_negros] }
+  ].freeze
+
+  factory :ingredient do
+    transient do
+      sequence(:rotation_idx) { |n| n }
+    end
+
+    # When the caller doesn't specify a slug, rotate through the curated
+    # list. When they do, the explicit slug wins and the other attributes
+    # below look it up so name/path/aliases/allergen stay coherent.
+    slug { INGREDIENT_SAMPLES[(rotation_idx - 1) % INGREDIENT_SAMPLES.size][:slug] }
+
+    name     { (INGREDIENT_SAMPLES.find { |s| s[:slug] == slug } || {})[:name]     || slug.tr("-", " ").capitalize }
+    path     { (INGREDIENT_SAMPLES.find { |s| s[:slug] == slug } || {})[:path]     || slug.tr("-", "_") }
+    aliases  { (INGREDIENT_SAMPLES.find { |s| s[:slug] == slug } || {})[:aliases]  || [] }
+    allergen { (INGREDIENT_SAMPLES.find { |s| s[:slug] == slug } || {}).fetch(:allergen, false) }
+
+    trait :allergen do
+      allergen { true }
+    end
+  end
+end

--- a/apps/api/spec/factories/tags.rb
+++ b/apps/api/spec/factories/tags.rb
@@ -1,0 +1,44 @@
+FactoryBot.define do
+  # Curated tag taxonomy mirroring the five families documented in
+  # docs/schema.md (diet | allergen | cuisine | prep | flavor). Tags
+  # in tests should look like the real thing — "diet.vegan",
+  # "cuisine.mexican" — so failures read like menu data.
+  TAG_SAMPLES = [
+    { slug: "diet-vegan",         name: "Vegan",         family: "diet",     path: "diet.vegan" },
+    { slug: "diet-vegetarian",    name: "Vegetarian",    family: "diet",     path: "diet.vegetarian" },
+    { slug: "diet-pescatarian",   name: "Pescatarian",   family: "diet",     path: "diet.pescatarian" },
+    { slug: "diet-gluten-free",   name: "Gluten-Free",   family: "diet",     path: "diet.gluten_free" },
+    { slug: "diet-keto",          name: "Keto",          family: "diet",     path: "diet.keto" },
+    { slug: "diet-halal",         name: "Halal",         family: "diet",     path: "diet.halal" },
+    { slug: "diet-kosher",        name: "Kosher",        family: "diet",     path: "diet.kosher" },
+    { slug: "allergen-contains-dairy",   name: "Contains Dairy",   family: "allergen", path: "allergen.contains_dairy" },
+    { slug: "allergen-contains-egg",     name: "Contains Egg",     family: "allergen", path: "allergen.contains_egg" },
+    { slug: "allergen-contains-tree-nut",name: "Contains Tree Nut",family: "allergen", path: "allergen.contains_tree_nut" },
+    { slug: "allergen-contains-peanut",  name: "Contains Peanut",  family: "allergen", path: "allergen.contains_peanut" },
+    { slug: "allergen-contains-shellfish",name: "Contains Shellfish",family: "allergen",path: "allergen.contains_shellfish" },
+    { slug: "cuisine-mexican",    name: "Mexican",       family: "cuisine",  path: "cuisine.mexican" },
+    { slug: "cuisine-italian",    name: "Italian",       family: "cuisine",  path: "cuisine.italian" },
+    { slug: "cuisine-japanese",   name: "Japanese",      family: "cuisine",  path: "cuisine.japanese" },
+    { slug: "cuisine-thai",       name: "Thai",          family: "cuisine",  path: "cuisine.thai" },
+    { slug: "cuisine-american",   name: "American",      family: "cuisine",  path: "cuisine.american" },
+    { slug: "prep-grilled",       name: "Grilled",       family: "prep",     path: "prep.grilled" },
+    { slug: "prep-fried",         name: "Fried",         family: "prep",     path: "prep.fried" },
+    { slug: "prep-raw",           name: "Raw",           family: "prep",     path: "prep.raw" },
+    { slug: "prep-baked",         name: "Baked",         family: "prep",     path: "prep.baked" },
+    { slug: "flavor-spicy",       name: "Spicy",         family: "flavor",   path: "flavor.spicy" },
+    { slug: "flavor-sweet",       name: "Sweet",         family: "flavor",   path: "flavor.sweet" },
+    { slug: "flavor-umami",       name: "Umami",         family: "flavor",   path: "flavor.umami" }
+  ].freeze
+
+  factory :tag do
+    transient do
+      sequence(:rotation_idx) { |n| n }
+    end
+
+    slug { TAG_SAMPLES[(rotation_idx - 1) % TAG_SAMPLES.size][:slug] }
+
+    name   { (TAG_SAMPLES.find { |s| s[:slug] == slug } || {})[:name]   || slug.tr("-", " ").capitalize }
+    family { (TAG_SAMPLES.find { |s| s[:slug] == slug } || {})[:family] || "diet" }
+    path   { (TAG_SAMPLES.find { |s| s[:slug] == slug } || {})[:path]   || slug.tr("-", "_") }
+  end
+end

--- a/apps/api/spec/factories/users.rb
+++ b/apps/api/spec/factories/users.rb
@@ -1,9 +1,18 @@
 FactoryBot.define do
+  # Per-process counter to disambiguate Faker-generated emails/handles
+  # — Faker repeats values, but the schema requires uniqueness on
+  # both columns. The counter is appended to whatever Faker returns.
+  sequence(:user_disambig) { |n| n }
+
   factory :user do
-    sequence(:email)  { |n| "user#{n}@example.com" }
-    sequence(:handle) { |n| "user_#{n}" }
-    display_name      { "Test User" }
-    password          { "password123" }
+    transient do
+      disambig { generate(:user_disambig) }
+    end
+
+    email         { "#{Faker::Internet.username(specifier: 5..14, separators: %w[_])}_#{disambig}@#{Faker::Internet.domain_name}" }
+    display_name  { Faker::Name.name }
+    handle        { "#{Faker::Internet.username(specifier: 4..12, separators: %w[_]).downcase.tr('.', '_')}_#{disambig}" }
+    password              { "password123" }
     password_confirmation { "password123" }
 
     # Compatibility trait — reserved for when :confirmable comes back

--- a/apps/api/spec/requests/api/v1/profile_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_spec.rb
@@ -1,0 +1,148 @@
+require "rails_helper"
+
+RSpec.describe "GET/PATCH /api/v1/profile", type: :request do
+  let(:user) { create(:user, :confirmed) }
+  let(:headers) { auth_headers_for(user).merge("Content-Type" => "application/json") }
+
+  describe "GET /api/v1/profile" do
+    it "returns the caller's profile with defaults" do
+      get "/api/v1/profile", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body).to include(
+        "avoid_ingredient_ids" => [],
+        "avoid_tag_ids"        => [],
+        "prefer_tag_ids"       => [],
+        "strictness"           => "balanced",
+        "primary_dietary_profile" => nil
+      )
+    end
+
+    it "rejects an unauthenticated caller with 401" do
+      get "/api/v1/profile"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "PATCH /api/v1/profile" do
+    # Real ingredients/tags from the curated factory lists so the
+    # specs read like menu data — "dairy.cheese" and "diet.vegan"
+    # instead of "ingredient-1" / "tag-2".
+    let(:cheese)    { create(:ingredient, slug: "dairy-cheese") }
+    let(:wheat)     { create(:ingredient, slug: "wheat") }
+    let(:vegan_tag) { create(:tag, slug: "diet-vegan") }
+    let(:fried_tag) { create(:tag, slug: "prep-fried") }
+
+    it "round-trips avoid_ingredient_ids" do
+      patch "/api/v1/profile",
+            params: { avoid_ingredient_ids: [cheese.id, wheat.id] }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["avoid_ingredient_ids"])
+        .to contain_exactly(cheese.id, wheat.id)
+
+      expect(user.reload.profile.avoid_ingredient_ids)
+        .to contain_exactly(cheese.id, wheat.id)
+    end
+
+    it "round-trips avoid_tag_ids and prefer_tag_ids" do
+      patch "/api/v1/profile",
+            params: { avoid_tag_ids: [fried_tag.id], prefer_tag_ids: [vegan_tag.id] }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["avoid_tag_ids"]).to  contain_exactly(fried_tag.id)
+      expect(body["prefer_tag_ids"]).to contain_exactly(vegan_tag.id)
+    end
+
+    it "round-trips strictness" do
+      patch "/api/v1/profile",
+            params: { strictness: "strict" }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["strictness"]).to eq("strict")
+    end
+
+    it "rejects an unknown strictness value with 422" do
+      patch "/api/v1/profile",
+            params: { strictness: "yolo" }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["errors"]).to have_key("strictness")
+    end
+
+    it "replaces arrays wholesale (does not append)" do
+      user.profile.update!(avoid_ingredient_ids: [cheese.id])
+
+      patch "/api/v1/profile",
+            params: { avoid_ingredient_ids: [wheat.id] }.to_json,
+            headers: headers
+
+      expect(response.parsed_body["avoid_ingredient_ids"])
+        .to contain_exactly(wheat.id)
+    end
+
+    context "with a dietary_profile_slug" do
+      let!(:vegan_preset) do
+        preset = create(:dietary_profile, slug: "vegan")
+        create(:dietary_profile_ingredient,
+               dietary_profile: preset, ingredient: cheese, rule: "avoid")
+        create(:dietary_profile_tag,
+               dietary_profile: preset, tag: fried_tag, rule: "avoid")
+        preset
+      end
+
+      it "additively unions the preset's avoid lists onto the user's" do
+        # User started with wheat in avoid; preset adds cheese + fried.
+        patch "/api/v1/profile",
+              params: {
+                avoid_ingredient_ids: [wheat.id],
+                dietary_profile_slug: "vegan"
+              }.to_json,
+              headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["avoid_ingredient_ids"]).to contain_exactly(wheat.id, cheese.id)
+        expect(body["avoid_tag_ids"]).to        contain_exactly(fried_tag.id)
+        expect(body["primary_dietary_profile"]).to include(
+          "slug" => "vegan",
+          "name" => "Vegan"
+        )
+      end
+
+      it "is idempotent — re-applying does not duplicate ids" do
+        2.times do
+          patch "/api/v1/profile",
+                params: { dietary_profile_slug: "vegan" }.to_json,
+                headers: headers
+        end
+
+        body = response.parsed_body
+        expect(body["avoid_ingredient_ids"]).to contain_exactly(cheese.id)
+        expect(body["avoid_tag_ids"]).to        contain_exactly(fried_tag.id)
+      end
+    end
+
+    it "404s on an unknown dietary_profile_slug" do
+      patch "/api/v1/profile",
+            params: { dietary_profile_slug: "no-such-preset" }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "rejects an unauthenticated caller with 401" do
+      patch "/api/v1/profile",
+            params: { strictness: "strict" }.to_json,
+            headers: { "Content-Type" => "application/json" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,17 +11,18 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
-1. **Phase 1.2 — OmniAuth Apple + Google** (`docs/plans/phase-1.md#12`)
-2. **Phase 1.3 — `GET/PATCH /api/v1/profile`** (`docs/plans/phase-1.md#13`) — stubbed in 1.1; full impl here
-3. **Phase 1.4 — full ingredient port** (`docs/plans/phase-1.md#14`)
-4. **Phase 1.5 — Rails admin dashboard** (`docs/plans/phase-1.md#15`)
-5. **Phase 1.6 — OpenAPI codegen for `packages/api-types`** (`docs/plans/phase-1.md#16`)
-6. **Phase 1.7 — Restaurant + Item read endpoints with filter** (`docs/plans/phase-1.md#17`)
+1. **Phase 1.3 — `GET/PATCH /api/v1/profile`** (`docs/plans/phase-1.md#13`) — stubbed in 1.1; full impl here (this PR)
+2. **Phase 1.4 — full ingredient port** (`docs/plans/phase-1.md#14`)
+3. **Phase 1.5 — Rails admin dashboard** (`docs/plans/phase-1.md#15`)
+4. **Phase 1.6 — OpenAPI codegen for `packages/api-types`** (`docs/plans/phase-1.md#16`)
+5. **Phase 1.7 — Restaurant + Item read endpoints with filter** (`docs/plans/phase-1.md#17`)
 
 ### Done
 
 - ✅ subtask: master CI green (#112)
-- ✅ Phase 1.1 — Devise JWT signup/login/logout/refresh (this PR)
+- ✅ Phase 1.1 — Devise JWT signup/login/logout/refresh (#124)
+- ✅ Phase 1.2 — OmniAuth Apple + Google (#128)
+- ✅ chore: default all PRs to auto-merge (#129)
 
 After Phase 1 ships, the loop pulls Phase 2 items into "Next up" via a
 plan-update PR (so a human reviews the next batch before they auto-run).

--- a/docs/status.md
+++ b/docs/status.md
@@ -15,6 +15,17 @@ without spelunking GitHub.
 
 2026-04-29 14:00 — tick #33. Hold continues (29th in a row). No-op.
 
+2026-04-29 18:00 — tick #34 (resumed). Owner unblocked: directly
+merged PR #128 (phase-1.2). Owner directive: drop approval gate
+entirely. Opened + merged PR #129 (chore/auto-merge-default) which
+(a) updates `.github/workflows/auto-merge.yml` to enable auto-merge
+on every non-draft PR, (b) rewrites `docs/delivery-playbook.md`
+auto-merge policy + §2 state table to match. Started Phase 1.3 on
+`claude/phase-1.3-user-profile`: full GET/PATCH `/api/v1/profile`
+with wholesale array replacement + additive dietary_profile_slug
+preset application, plus ingredient/tag/dietary_profile factories.
+Local rspec 28/28 green (11 new in profile_spec). Pushing PR next.
+
 2026-04-29 13:30 — tick #32. Hold continues (28th in a row). No-op.
 
 2026-04-29 13:00 — tick #31. Hold continues (27th in a row). No-op.


### PR DESCRIPTION
## Why

Phase 1.3 of the v2 delivery plan — `docs/plans/phase-1.md#13`. Mobile + web both need authenticated callers to read and write their dietary profile (the avoid/prefer arrays + strictness) and to apply a curated preset like Vegan or Celiac in one tap during onboarding. Phase 1.1 stubbed the controller; this PR is the full implementation.

## What

- `Api::V1::ProfilesController#show`: returns `avoid_ingredient_ids`, `avoid_tag_ids`, `prefer_tag_ids`, `strictness`, plus a `primary_dietary_profile` summary (`{ id, slug, name }` or `nil`).
- `Api::V1::ProfilesController#update`: wholesale replacement of the avoid/prefer arrays + strictness. Optional `dietary_profile_slug` triggers additive union of that preset's avoid_ingredients + avoid_tags (never destructive) and records `primary_dietary_profile_id`.
- Replacement semantics: the client builds the canonical state and POSTs it; we don't process diffs. Preset application runs *after* the wholesale write so what the client sent is never truncated.
- Unknown `dietary_profile_slug` → 404 (cleanly handled by `BaseController#render_not_found`). Invalid `strictness` → 422.
- Idempotency: re-PATCHing the same preset doesn't duplicate ids (uniq union).

### Factories made realistic (owner request)

- `:ingredient`, `:tag`, `:dietary_profile` all sample from curated lists matching the real schema: `dairy.cheese`, `diet.vegan`, `cuisine.mexican`, etc.
- Slug-aware: `create(:ingredient, slug: "dairy-cheese")` looks up the curated row so `name`/`path`/`aliases`/`allergen` stay coherent. Without an explicit slug, factories rotate through the lists for variety.
- `:user` factory uses Faker for email/name/handle with a per-suite disambig sequence to keep uniqueness without "user1@example.com" boilerplate.
- New `:dietary_profile_ingredient` + `:dietary_profile_tag` factories for preset wiring.

### Roadmap

Ticked Phase 1.2 + the auto-merge chore in `docs/roadmap.md`'s Done section. Phase 1.3 is now the topmost Next-up item (linked back to this PR).

## Test plan

- [ ] CI · API: `bundle exec rspec` green (11 new examples in `spec/requests/api/v1/profile_spec.rb` covering GET defaults, GET unauth, each PATCH round-trip, wholesale replacement, invalid strictness, preset application, preset idempotency, unknown slug, PATCH unauth).
- [ ] Existing 17 specs (signup/login/logout/refresh/omniauth/boot) still green.
- [ ] Local rspec confirmed 28/28 across two seeds (40875 and 19773).

## Notes

- This is the first PR opened under the new "auto-merge by default" policy from #129. CI green = merge.
- Factory `name` lookup falls back to a humanized slug when an explicit slug isn't in the curated list, so callers can still pass arbitrary slugs without breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)