### PR TITLE
feat(api): anthropic client service (phase 2.1)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,6 +37,15 @@ APPLE_OAUTH_PRIVATE_KEY=
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
 
+# --- AI ingestion (Anthropic) ------------------------------------------------
+# Console: https://console.anthropic.com/
+#
+# Used by app/services/anthropic_client.rb (Phase 2.1) and the
+# vision/resolve jobs (Phase 2.3+). Required to RECORD VCR cassettes
+# locally — CI replays from the recorded cassettes with `record: :none`
+# so it doesn't need the key. Production must set it.
+ANTHROPIC_API_KEY=
+
 # --- Mailer ------------------------------------------------------------------
 # Used by Devise for password-reset emails. The mailer itself isn't
 # wired in until Phase 4; this is documented now so .env stays canonical.

--- a/apps/api/Gemfile
+++ b/apps/api/Gemfile
@@ -36,6 +36,11 @@ gem "aws-sdk-s3", require: false
 gem "faraday", "~> 2.10"
 gem "faraday-retry"
 
+# Validates Anthropic's structured-output responses against the JSON Schema
+# we send up — catches model drift before the rest of the ingestion pipeline
+# tries to read fields that aren't there.
+gem "json-schema", "~> 5.1"
+
 # --- Admin -------------------------------------------------------------------
 # Avo at /admin for menu data CRUD. Phase 1.5 gates with HTTP basic auth
 # (ADMIN_USERNAME / ADMIN_PASSWORD env vars). Phase 4 will swap to
@@ -64,4 +69,8 @@ end
 group :test do
   gem "shoulda-matchers", "~> 7.0"
   gem "webmock"
+  # Cassette-based playback for the live Anthropic calls in Phase 2.3+.
+  # Cassettes are recorded locally with ANTHROPIC_API_KEY; CI replays them
+  # with `record: :none`.
+  gem "vcr", "~> 6.3"
 end

--- a/apps/api/Gemfile.lock
+++ b/apps/api/Gemfile.lock
@@ -226,9 +226,8 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    json-schema (6.2.0)
+    json-schema (5.1.0)
       addressable (~> 2.8)
-      bigdecimal (>= 3.1, < 5)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -493,6 +492,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
+    vcr (6.4.0)
     version_gem (1.1.9)
     view_component (4.8.0)
       actionview (>= 7.1.0)
@@ -542,6 +542,7 @@ DEPENDENCIES
   faraday-retry
   image_processing (~> 1.13)
   jbuilder
+  json-schema (~> 5.1)
   omniauth (~> 2.1)
   omniauth-apple
   omniauth-google-oauth2
@@ -560,6 +561,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   tzinfo-data
+  vcr (~> 6.3)
   webmock
 
 CHECKSUMS
@@ -641,7 +643,7 @@ CHECKSUMS
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
   json-jwt (1.17.0) sha256=6ff99026b4c54281a9431179f76ceb81faa14772d710ef6169785199caadc4cc
-  json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
+  json-schema (5.1.0) sha256=c12729e346dce58ecc9be07301f4f247aeba1e3daae208e867278f3d27c64eb7
   jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
@@ -744,6 +746,7 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  vcr (6.4.0) sha256=077ac92cc16efc5904eb90492a18153b5e6ca5398046d8a249a7c96a9ea24ae6
   version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   view_component (4.8.0) sha256=0a1b716cce87f8f6799d7aefb57911ef6eee5ef8214466a7ca22c421853f7309
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0

--- a/apps/api/app/services/anthropic_client.rb
+++ b/apps/api/app/services/anthropic_client.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "base64"
+
+# Thin Faraday wrapper around Anthropic's `/v1/messages` endpoint.
+# This is the foundation for the Phase 2 ingestion pipeline — the
+# vision-extraction and ingredient/tag-resolution jobs (Phase 2.3 +
+# 2.4) all hit this client.
+#
+# Design choices worth knowing:
+#
+# * **Prompt caching** is the difference between a $0.001 menu and a
+#   $0.05 menu. Every system block we build can carry
+#   `cache_control: { type: "ephemeral" }`; Anthropic caches the prefix
+#   of system content for 5 minutes. The `system_blocks` helper makes it
+#   one keyword arg.
+#
+# * **Vision input** accepts anything that responds to `download` (the
+#   ActiveStorage::Blob shape) or to `read` (raw IO). The bytes are
+#   base64-encoded and shipped as `{type: "image", source: {...}}`. We
+#   never write the image to disk in this layer.
+#
+# * **Structured output** is enforced after the response by validating
+#   against a JSON Schema (see `ResponseParser`). Anthropic doesn't have
+#   a native "JSON mode" the way OpenAI does, so we lean on the system
+#   prompt instructing the model to return strict JSON and then
+#   validate. Failures raise `AnthropicClient::ValidationError` so the
+#   ingestion job can transition the run to `:failed` cleanly.
+#
+# * **Retries**: faraday-retry on 429 + 5xx with exponential backoff,
+#   3 attempts. Auth errors (401 / 403) are not retried — they're
+#   raised as `ApiError` immediately.
+#
+# Usage:
+#
+#     client = AnthropicClient.new
+#     response = client.messages_create(
+#       system: client.system_blocks(
+#         { text: "You are an OCR for restaurant menus...",
+#           cache: true }
+#       ),
+#       messages: [
+#         { role: "user", content: [
+#           client.image_block(blob),
+#           { type: "text", text: "Extract every menu item." }
+#         ] }
+#       ],
+#       response_schema: MenuExtractionSchema
+#     )
+class AnthropicClient
+  ENDPOINT          = "https://api.anthropic.com"
+  MESSAGES_PATH     = "/v1/messages"
+  ANTHROPIC_VERSION = "2023-06-01"
+  DEFAULT_MODEL     = "claude-sonnet-4-6"
+  DEFAULT_MAX_TOKENS = 8_000
+
+  # Raised whenever the upstream API returns a non-2xx status. The
+  # `status` and `body` fields let callers decide whether to surface
+  # the error to the user or retry on the next tick.
+  class ApiError < StandardError
+    attr_reader :status, :body, :response_headers
+
+    def initialize(status:, body:, response_headers: {}, message: nil)
+      @status           = status
+      @body             = body
+      @response_headers = response_headers
+      super(message || "Anthropic API returned #{status}: #{body.is_a?(String) ? body[0, 200] : body.inspect}")
+    end
+  end
+
+  # Raised when the response body parses as JSON but doesn't satisfy
+  # the schema we sent up. Carries the raw body + the validator's
+  # error list so the ingestion job can include them in failure_message.
+  class ValidationError < StandardError
+    attr_reader :raw_body, :errors
+
+    def initialize(raw_body:, errors:)
+      @raw_body = raw_body
+      @errors   = errors
+      super("Anthropic response failed JSON Schema validation: #{errors.join('; ')}")
+    end
+  end
+
+  attr_reader :api_key, :model, :base_url
+
+  def initialize(api_key: nil, model: nil, base_url: nil, conn: nil)
+    @api_key  = api_key  || ENV["ANTHROPIC_API_KEY"] || ""
+    @model    = model    || DEFAULT_MODEL
+    @base_url = base_url || ENDPOINT
+    @conn     = conn # tests can inject a stubbed Faraday connection
+  end
+
+  # Low-level pass-through to /v1/messages. Returns a parsed Hash on
+  # success; raises ApiError (with status + body) on non-2xx and
+  # ValidationError if response_schema is supplied and the response
+  # text doesn't match.
+  def messages_create(system:, messages:, max_tokens: DEFAULT_MAX_TOKENS, response_schema: nil, model: nil, **extra)
+    body = {
+      model:      model || @model,
+      max_tokens: max_tokens,
+      system:     system,
+      messages:   messages
+    }.merge(extra)
+
+    response = connection.post(MESSAGES_PATH, body.to_json)
+
+    unless (200..299).cover?(response.status)
+      raise ApiError.new(
+        status: response.status,
+        body: response.body,
+        response_headers: response.headers
+      )
+    end
+
+    parsed = response.body.is_a?(Hash) ? response.body : JSON.parse(response.body)
+    return parsed if response_schema.nil?
+
+    text = ResponseParser.first_text(parsed)
+    ResponseParser.parse_and_validate(text, response_schema)
+  end
+
+  # Build a `system` array of content blocks. Each input is a Hash like
+  # `{text: "...", cache: true}`; cache: true means add the
+  # `cache_control: {type: "ephemeral"}` block-level attribute.
+  #
+  # Anthropic counts cache breakpoints, not blocks — only mark the
+  # final block of the cacheable prefix to maximize the cached span.
+  def system_blocks(*blocks)
+    blocks.flatten.map do |b|
+      block = { type: "text", text: b.fetch(:text) }
+      block[:cache_control] = { type: "ephemeral" } if b[:cache]
+      block
+    end
+  end
+
+  # Build an image content block from an ActiveStorage::Blob (responds
+  # to #download + #content_type) OR from a raw IO/String.
+  def image_block(source, media_type: nil)
+    if source.respond_to?(:download)
+      data       = source.download
+      media_type ||= source.content_type
+    elsif source.respond_to?(:read)
+      data = source.read
+    else
+      data = source.to_s
+    end
+
+    {
+      type: "image",
+      source: {
+        type:       "base64",
+        media_type: media_type || "image/jpeg",
+        data:       Base64.strict_encode64(data)
+      }
+    }
+  end
+
+  private
+
+  def connection
+    @conn ||= Faraday.new(url: @base_url) do |f|
+      f.request  :retry, max: 3,
+                          interval: 0.5,
+                          backoff_factor: 2,
+                          retry_statuses: [429, 500, 502, 503, 504],
+                          methods: %i[post]
+      f.response :json, content_type: /\bjson$/
+      f.headers["x-api-key"]         = @api_key
+      f.headers["anthropic-version"] = ANTHROPIC_VERSION
+      f.headers["content-type"]      = "application/json"
+      f.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/apps/api/app/services/anthropic_client/response_parser.rb
+++ b/apps/api/app/services/anthropic_client/response_parser.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "json"
+require "json-schema"
+
+# Pulls the first text content block out of an Anthropic /v1/messages
+# response and validates it against a JSON Schema.
+#
+# Anthropic responses look like:
+#   {
+#     "id": "msg_...",
+#     "content": [
+#       { "type": "text", "text": "{\"sections\": [...]}" }
+#     ],
+#     ...
+#   }
+#
+# We grab the first text block, parse it as JSON, and validate against
+# the schema. The Anthropic system prompt is responsible for telling
+# the model "respond with strict JSON, no prose" — JSON Schema
+# validation catches the cases where it doesn't comply.
+class AnthropicClient::ResponseParser
+  class << self
+    def first_text(parsed_response)
+      content = parsed_response.is_a?(Hash) ? (parsed_response["content"] || parsed_response[:content]) : nil
+      block   = content&.find { |b| (b["type"] || b[:type]) == "text" }
+      block&.fetch("text") { block[:text] } || ""
+    end
+
+    # Returns the parsed response data on success; raises
+    # AnthropicClient::ValidationError on either JSON parse failure
+    # or schema mismatch.
+    def parse_and_validate(text, schema)
+      payload = JSON.parse(text)
+    rescue JSON::ParserError => e
+      raise AnthropicClient::ValidationError.new(
+        raw_body: text, errors: ["JSON parse failed: #{e.message}"]
+      )
+    else
+      errors = JSON::Validator.fully_validate(schema, payload)
+      raise AnthropicClient::ValidationError.new(raw_body: text, errors: errors) if errors.any?
+
+      payload
+    end
+  end
+end

--- a/apps/api/spec/services/anthropic_client_spec.rb
+++ b/apps/api/spec/services/anthropic_client_spec.rb
@@ -1,0 +1,216 @@
+require "rails_helper"
+
+RSpec.describe AnthropicClient do
+  let(:api_key)    { "sk-ant-test-key" }
+  let(:base_url)   { "https://api.anthropic.test" }
+  let(:client)     { described_class.new(api_key: api_key, base_url: base_url) }
+
+  describe "#system_blocks" do
+    it "wraps text into Anthropic content blocks" do
+      blocks = client.system_blocks({ text: "Hello" }, { text: "World" })
+
+      expect(blocks).to eq([
+        { type: "text", text: "Hello" },
+        { type: "text", text: "World" }
+      ])
+    end
+
+    it "marks cache: true blocks with ephemeral cache_control" do
+      blocks = client.system_blocks(
+        { text: "uncached preamble" },
+        { text: "huge taxonomy", cache: true }
+      )
+
+      expect(blocks.last).to include(
+        type: "text",
+        text: "huge taxonomy",
+        cache_control: { type: "ephemeral" }
+      )
+      expect(blocks.first).not_to have_key(:cache_control)
+    end
+  end
+
+  describe "#image_block" do
+    it "base64-encodes an ActiveStorage::Blob-shaped object" do
+      blob = double("Blob", download: "binary-image-bytes", content_type: "image/png")
+
+      block = client.image_block(blob)
+
+      expect(block).to include(
+        type: "image",
+        source: include(
+          type: "base64",
+          media_type: "image/png",
+          data: Base64.strict_encode64("binary-image-bytes")
+        )
+      )
+    end
+
+    it "accepts a raw IO and defaults media_type to image/jpeg" do
+      io = StringIO.new("jpg-bytes")
+
+      block = client.image_block(io)
+
+      expect(block[:source][:media_type]).to eq("image/jpeg")
+      expect(block[:source][:data]).to        eq(Base64.strict_encode64("jpg-bytes"))
+    end
+
+    it "honors an explicit media_type override" do
+      block = client.image_block(StringIO.new("p"), media_type: "image/webp")
+      expect(block[:source][:media_type]).to eq("image/webp")
+    end
+  end
+
+  describe "#messages_create" do
+    let(:happy_response_body) do
+      {
+        id:    "msg_01abc",
+        model: "claude-sonnet-4-6",
+        role:  "assistant",
+        content: [
+          { type: "text", text: '{"sections":[{"name":"Tacos","items":[]}]}' }
+        ],
+        usage: { input_tokens: 10, output_tokens: 5,
+                 cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }
+      }.to_json
+    end
+
+    it "POSTs to /v1/messages with auth + version headers and the right body" do
+      stub = stub_request(:post, "#{base_url}/v1/messages")
+        .with(
+          headers: {
+            "X-Api-Key"         => api_key,
+            "Anthropic-Version" => described_class::ANTHROPIC_VERSION,
+            "Content-Type"      => "application/json"
+          },
+          body: hash_including(
+            "model"      => described_class::DEFAULT_MODEL,
+            "max_tokens" => described_class::DEFAULT_MAX_TOKENS
+          )
+        )
+        .to_return(status: 200, body: happy_response_body,
+                   headers: { "Content-Type" => "application/json" })
+
+      result = client.messages_create(
+        system:   client.system_blocks({ text: "you are a menu OCR" }),
+        messages: [{ role: "user", content: [{ type: "text", text: "extract" }] }]
+      )
+
+      expect(stub).to have_been_requested
+      expect(result["id"]).to eq("msg_01abc")
+    end
+
+    it "returns the parsed payload on a 200 (no schema given)" do
+      stub_request(:post, "#{base_url}/v1/messages")
+        .to_return(status: 200, body: happy_response_body,
+                   headers: { "Content-Type" => "application/json" })
+
+      result = client.messages_create(
+        system:   [{ type: "text", text: "x" }],
+        messages: [{ role: "user", content: "hello" }]
+      )
+
+      expect(result["content"].first["text"]).to include("Tacos")
+    end
+
+    context "with response_schema" do
+      let(:menu_schema) do
+        {
+          type: "object",
+          required: ["sections"],
+          properties: {
+            sections: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["name", "items"],
+                properties: { name: { type: "string" }, items: { type: "array" } }
+              }
+            }
+          }
+        }
+      end
+
+      it "validates + returns the parsed JSON when the model returns valid output" do
+        stub_request(:post, "#{base_url}/v1/messages")
+          .to_return(status: 200, body: happy_response_body,
+                     headers: { "Content-Type" => "application/json" })
+
+        result = client.messages_create(
+          system: [{ type: "text", text: "x" }],
+          messages: [{ role: "user", content: "y" }],
+          response_schema: menu_schema
+        )
+
+        expect(result).to include("sections")
+        expect(result["sections"].first["name"]).to eq("Tacos")
+      end
+
+      it "raises ValidationError when the response doesn't satisfy the schema" do
+        bad_body = {
+          id: "msg_x", model: "x", role: "assistant",
+          content: [{ type: "text", text: '{"wrong_key": []}' }]
+        }.to_json
+        stub_request(:post, "#{base_url}/v1/messages")
+          .to_return(status: 200, body: bad_body,
+                     headers: { "Content-Type" => "application/json" })
+
+        expect {
+          client.messages_create(
+            system: [{ type: "text", text: "x" }],
+            messages: [{ role: "user", content: "y" }],
+            response_schema: menu_schema
+          )
+        }.to raise_error(AnthropicClient::ValidationError) { |error|
+          expect(error.errors).not_to be_empty
+        }
+      end
+
+      it "raises ValidationError when the response text isn't JSON at all" do
+        prose_body = {
+          id: "msg_x", model: "x", role: "assistant",
+          content: [{ type: "text", text: "Sorry, I can't help with that." }]
+        }.to_json
+        stub_request(:post, "#{base_url}/v1/messages")
+          .to_return(status: 200, body: prose_body,
+                     headers: { "Content-Type" => "application/json" })
+
+        expect {
+          client.messages_create(
+            system: [{ type: "text", text: "x" }],
+            messages: [{ role: "user", content: "y" }],
+            response_schema: menu_schema
+          )
+        }.to raise_error(AnthropicClient::ValidationError, /JSON parse failed/)
+      end
+    end
+
+    context "error handling" do
+      it "raises ApiError on a 401 (and does not retry)" do
+        stub = stub_request(:post, "#{base_url}/v1/messages")
+          .to_return(status: 401, body: { error: "invalid api key" }.to_json,
+                     headers: { "Content-Type" => "application/json" })
+
+        expect {
+          client.messages_create(system: [], messages: [{ role: "user", content: "x" }])
+        }.to raise_error(AnthropicClient::ApiError) { |error|
+          expect(error.status).to eq(401)
+        }
+
+        expect(stub).to have_been_requested.once
+      end
+
+      it "retries 429 then raises if it stays bad" do
+        stub = stub_request(:post, "#{base_url}/v1/messages")
+          .to_return(status: 429, body: "rate limited")
+
+        expect {
+          client.messages_create(system: [], messages: [{ role: "user", content: "x" }])
+        }.to raise_error(AnthropicClient::ApiError)
+
+        # faraday-retry default is up to (1 + max=3) = 4 attempts
+        expect(stub).to have_been_requested.at_least_times(2)
+      end
+    end
+  end
+end

--- a/apps/api/spec/support/vcr.rb
+++ b/apps/api/spec/support/vcr.rb
@@ -1,0 +1,21 @@
+require "vcr"
+require "webmock/rspec"
+
+VCR.configure do |c|
+  c.cassette_library_dir       = Rails.root.join("spec/cassettes").to_s
+  c.hook_into                  :webmock
+  c.configure_rspec_metadata!
+  c.allow_http_connections_when_no_cassette = false
+
+  # Anthropic creds get scrubbed before cassettes are written.
+  c.filter_sensitive_data("<ANTHROPIC_API_KEY>") { ENV["ANTHROPIC_API_KEY"] }
+  c.filter_sensitive_data("<X_API_KEY_HEADER>") do |interaction|
+    interaction.request.headers["X-Api-Key"]&.first
+  end
+
+  # CI runs replay-only — no live calls allowed even by accident.
+  c.default_cassette_options = {
+    record: ENV["CI"] ? :none : :once,
+    match_requests_on: [:method, :uri, :body]
+  }
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ the merge / review / status rules.
 
 **Phase 2** ⭐ AI ingestion MVP. Subplan: `docs/plans/phase-2.md`. This batch is **proposed by the loop** (this PR is the plan-update PR); humans review it before the items auto-run.
 
-1. **Phase 2.1 — AnthropicClient service** (`docs/plans/phase-2.md#21`)
+1. **Phase 2.1 — AnthropicClient service** (`docs/plans/phase-2.md#21`) — this PR
 2. **Phase 2.2 — IngestionRun + IngestionItem state machine** (`docs/plans/phase-2.md#22`)
 3. **Phase 2.3 — ExtractMenuJob** (`docs/plans/phase-2.md#23`) — depends on 2.1, 2.2; needs `ANTHROPIC_API_KEY` for VCR cassette recording
 4. **Phase 2.4 — ResolveIngredients + ResolveTags jobs** (`docs/plans/phase-2.md#24`) — depends on 2.3; needs `ANTHROPIC_API_KEY`

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,25 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 22:00 — tick #41. Plan PR #135 merged at 21:16 UTC. Phase 2
+queue live. Picked up Phase 2.1 — AnthropicClient. Faraday wrapper
+at `app/services/anthropic_client.rb` with bearer auth, prompt
+caching helper (`#system_blocks` marks blocks with
+`cache_control: {type: ephemeral}`), vision input helper
+(`#image_block` accepts ActiveStorage::Blob OR raw IO/String,
+base64-encodes), structured output validation via json-schema gem
+(raises `AnthropicClient::ValidationError` with the validator's
+errors[]), retries via faraday-retry (3 attempts on 429/5xx,
+auth errors NOT retried). Default model claude-sonnet-4-6 per
+ADR 0001. Helper class `AnthropicClient::ResponseParser` extracts
+the first text block from /v1/messages responses. Added vcr gem
++ `spec/support/vcr.rb` config for Phase 2.3+ cassette recording
+(record: :once locally, :none in CI, sensitive-header scrubbing).
+12 unit specs at `spec/services/anthropic_client_spec.rb` covering
+all public methods + happy/auth-fail/retry paths via WebMock
+stubs. ANTHROPIC_API_KEY documented in .env.example. Local rspec
+73/73 green. Pushing PR.
+
 2026-04-29 21:25 — tick #40. PR #134 (Phase 1.7) merged at 20:57 UTC.
 **Phase 1 complete end-to-end.** Demo unblocked: admin builds a menu
 in /admin, web/mobile call /api/v1/restaurants/:id/items, items


### PR DESCRIPTION
## Why

Phase 2.1 of the v2 delivery plan — `docs/plans/phase-2.md#21`. Foundation for the Phase 2 ingestion pipeline. Vision-extraction (2.3) and ingredient/tag-resolve jobs (2.4) all hit this client; `ApiError` + `ValidationError` flow into `IngestionRun.failure_message` once 2.2 lands the state machine.

## What

### `app/services/anthropic_client.rb`

Faraday wrapper around `/v1/messages`:

- Bearer auth via `x-api-key` (reads `ANTHROPIC_API_KEY` ENV; defaults to empty so the gem loads in test without a key).
- `anthropic-version: 2023-06-01` header.
- `faraday-retry` on 429 + 5xx (3 attempts, exp backoff). Auth errors (401/403) are NOT retried — they're raised immediately as `AnthropicClient::ApiError`.
- Default model `claude-sonnet-4-6` (per ADR 0001).

### Helpers

| Method | Purpose |
|---|---|
| `#system_blocks(*blocks)` | Build the `system` content array. `cache: true` marks a block with `cache_control: {type: "ephemeral"}` — Anthropic caches that prefix for 5 min. **This is the difference between a $0.001 menu and a $0.05 menu.** |
| `#image_block(source)` | Accept ActiveStorage::Blob (`#download` + `#content_type`), raw IO (`StringIO`), or String. Base64-encode and emit `{type: "image", source: {type: "base64", media_type, data}}`. |
| `#messages_create(system:, messages:, response_schema: nil, ...)` | Low-level POST. With `response_schema:`, validates the first text content block against the schema via `json-schema` and returns the parsed payload. |
| `AnthropicClient::ResponseParser` | Extracts the first text block + runs `JSON::Validator.fully_validate`. |

### Errors

- `AnthropicClient::ApiError` — non-2xx upstream. Carries `status`, `body`, and `response_headers`.
- `AnthropicClient::ValidationError` — JSON parse failed OR schema mismatch. Carries `raw_body` + the validator's `errors[]`.

### New deps

- `json-schema` (~> 5.1, production) — validates structured-output responses.
- `vcr` (~> 6.3, test-only) — set up now so 2.3+ inherit the config. `spec/support/vcr.rb` puts cassettes in `spec/cassettes/`, `record: :once` locally / `:none` in CI, scrubs the `X-Api-Key` header.

### Specs

12 unit tests at `spec/services/anthropic_client_spec.rb` covering every public method via WebMock stubs — no live calls needed:

- `system_blocks` wraps text + marks cache_control correctly
- `image_block` handles both ActiveStorage::Blob and raw IO/String shapes; honors media_type override
- `messages_create` POSTs with the right headers + body
- happy 200 returns the parsed payload
- with `response_schema`: validates + returns parsed JSON; raises `ValidationError` on schema mismatch; raises `ValidationError` on non-JSON output
- 401 raises `ApiError` and is **not** retried (single request)
- 429 triggers the retry chain, raises after exhausting attempts

## Test plan

- [ ] CI · API: rspec green (12 new + 61 prior = 73).
- [ ] CI · API: brakeman doesn't flag the http header injection paths.
- [ ] Local rspec: 73/73 confirmed.

## Notes

- **No live API calls in this PR.** Cassette recording starts in 2.3 (`ExtractMenuJob`) where we'll need real responses for the vision path. `ANTHROPIC_API_KEY` is documented in `.env.example` for that.
- **Why not `ruby-anthropic` gem?**: `Gemfile` already comments "Anthropic does not yet ship an official Ruby SDK; we use Faraday and call the REST API directly." Sticking with that — third-party gems lag the API and we want full control over the cache_control + structured-output paths.
- **Cache breakpoint guidance**: `system_blocks` lets you mark each block individually but the doc-comment explains that Anthropic counts breakpoints (not blocks) — only mark the LAST block of the cacheable prefix to maximize the cached span. Phase 2.3's PromptBuilder will follow that pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)