### PR TITLE
feat(api): ingestion state machine + item promotion (phase 2.2)

### DIFF
--- a/apps/api/app/models/ingestion_item.rb
+++ b/apps/api/app/models/ingestion_item.rb
@@ -5,4 +5,62 @@ class IngestionItem < ApplicationRecord
   belongs_to :item, optional: true
 
   validates :decision, inclusion: { in: DECISIONS }
+
+  DECISIONS.each do |d|
+    define_method("#{d}?") { decision == d }
+  end
+
+  # Materialize a staged ingestion item into a real Item +
+  # ItemIngredient + ItemTag join rows. Called from the swipe-verify
+  # UI (Phase 2.5) once a human has accepted (or edited then accepted)
+  # the AI's suggestion. The new associations are saved with
+  # `confidence: confirmed, source: human` because at this point a
+  # human has explicitly signed off.
+  #
+  # Idempotent: re-calling on an already-promoted IngestionItem
+  # returns the existing Item without creating duplicates.
+  #
+  # Returns the materialized Item; raises if the run has no
+  # restaurant attached (which means we don't know where to put it).
+  def promote!
+    return item if item.present?
+    raise "IngestionRun ##{ingestion_run_id} has no restaurant" if ingestion_run.restaurant_id.blank?
+
+    transaction do
+      created = Item.create!(
+        restaurant: ingestion_run.restaurant,
+        name:        name,
+        description: description.presence,
+        status:      "published",
+        confidence:  "confirmed"
+      )
+
+      Array(ingredients_payload).each do |row|
+        slug = row["slug"] || row[:slug]
+        next if slug.blank?
+        ingredient = Ingredient.find_by(slug: slug)
+        next if ingredient.nil?
+
+        ItemIngredient.create!(
+          item: created, ingredient: ingredient,
+          confidence: "confirmed", source: "human"
+        )
+      end
+
+      Array(tags_payload).each do |row|
+        slug = row["slug"] || row[:slug]
+        next if slug.blank?
+        tag = Tag.find_by(slug: slug)
+        next if tag.nil?
+
+        ItemTag.create!(
+          item: created, tag: tag,
+          confidence: "confirmed", source: "human"
+        )
+      end
+
+      update!(item: created, decision: "accepted", decided_at: Time.current)
+      created
+    end
+  end
 end

--- a/apps/api/app/models/ingestion_run.rb
+++ b/apps/api/app/models/ingestion_run.rb
@@ -2,10 +2,88 @@ class IngestionRun < ApplicationRecord
   INPUT_KINDS = %w[photo url pdf].freeze
   STATUSES    = %w[queued extracting resolving staged published failed].freeze
 
+  # The pipeline marches forward through these states. `failed` is
+  # reachable from any state but isn't in this map. The two stage
+  # entries that have a job_for value get a Solid Queue job kicked off
+  # automatically when transition_to! lands the run there.
+  #
+  # Job class names use safe_constantize so this model doesn't depend
+  # on the job classes existing yet — Phase 2.3 / 2.4 add them and
+  # the dispatch starts firing without further changes here.
+  NEXT_STATE = {
+    "queued"     => "extracting",
+    "extracting" => "resolving",
+    "resolving"  => "staged",
+    "staged"     => "published"
+  }.freeze
+
+  JOB_FOR = {
+    "extracting" => "ExtractMenuJob",
+    "resolving"  => "ResolveIngredientsJob"
+  }.freeze
+
+  class InvalidTransition < StandardError; end
+
   belongs_to :user, optional: true
   belongs_to :restaurant, optional: true
   has_many :ingestion_items, dependent: :destroy
 
   validates :input_kind, inclusion: { in: INPUT_KINDS }
   validates :status,     inclusion: { in: STATUSES }
+
+  STATUSES.each do |s|
+    define_method("#{s}?") { status == s }
+  end
+
+  # Move the run to `new_status` and record the entry timestamp in
+  # state_history (only the first entry per state — re-running the
+  # same transition is a no-op but timestamps don't get clobbered).
+  # Fires the next-stage Solid Queue job when one is registered for
+  # the new state.
+  #
+  # Raises InvalidTransition for forward-moves that aren't in the
+  # NEXT_STATE map (e.g., trying to jump from queued → published).
+  # `:failed` is always allowed.
+  def transition_to!(new_status)
+    new_status = new_status.to_s
+    raise ArgumentError, "Unknown status: #{new_status.inspect}" unless STATUSES.include?(new_status)
+    return self if status == new_status
+
+    unless new_status == "failed" || NEXT_STATE[status] == new_status
+      raise InvalidTransition,
+            "Cannot transition IngestionRun ##{id} from #{status.inspect} to #{new_status.inspect}"
+    end
+
+    transaction do
+      record_state_entry!(new_status)
+      update!(status: new_status)
+      enqueue_next_job!(new_status)
+    end
+    self
+  end
+
+  # Convenience for the failure path — records the message so
+  # operators can see what went wrong from /admin or the dashboard.
+  def fail!(message)
+    transaction do
+      assign_attributes(failure_message: message.to_s.truncate(2_000))
+      transition_to!(:failed)
+    end
+    self
+  end
+
+  private
+
+  def record_state_entry!(new_status)
+    return if state_history.key?(new_status) # idempotent — first entry wins
+
+    history = state_history.merge(new_status => Time.current.utc.iso8601)
+    self.state_history = history
+  end
+
+  def enqueue_next_job!(new_status)
+    job_name  = JOB_FOR[new_status]
+    job_class = job_name&.safe_constantize
+    job_class&.perform_later(id)
+  end
 end

--- a/apps/api/db/migrate/20260429221403_add_state_history_and_rename_failure_to_ingestion_runs.rb
+++ b/apps/api/db/migrate/20260429221403_add_state_history_and_rename_failure_to_ingestion_runs.rb
@@ -1,0 +1,17 @@
+class AddStateHistoryAndRenameFailureToIngestionRuns < ActiveRecord::Migration[8.1]
+  # Phase 2.2 wires up the IngestionRun state machine.
+  #
+  # `state_history` is an audit trail keyed by state name with the UTC
+  # timestamp of when the run entered that state — set once per state
+  # so repeated transition_to! calls don't overwrite the original
+  # entry timestamp. Used by the cost dashboard (Phase 2.9) to compute
+  # per-stage latency.
+  #
+  # `error_message` → `failure_message` aligns the column name with
+  # phase-2.md and with how the rest of the pipeline talks about
+  # failed runs ("the run's failure_message").
+  def change
+    add_column :ingestion_runs, :state_history, :jsonb, default: {}, null: false
+    rename_column :ingestion_runs, :error_message, :failure_message
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_194420) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_221403) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -105,7 +105,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_194420) do
   create_table "ingestion_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "cost_cents", default: 0
     t.datetime "created_at", null: false
-    t.text "error_message"
+    t.text "failure_message"
     t.datetime "finished_at"
     t.string "input_kind", null: false
     t.string "model"
@@ -113,6 +113,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_194420) do
     t.uuid "restaurant_id"
     t.string "source_url"
     t.datetime "started_at"
+    t.jsonb "state_history", default: {}, null: false
     t.string "status", default: "queued", null: false
     t.datetime "updated_at", null: false
     t.uuid "user_id"

--- a/apps/api/spec/factories/ingestion.rb
+++ b/apps/api/spec/factories/ingestion.rb
@@ -1,0 +1,47 @@
+FactoryBot.define do
+  factory :ingestion_run do
+    restaurant
+    input_kind { "photo" }
+    status     { "queued" }
+    state_history { {} }
+
+    trait :extracting do
+      status        { "extracting" }
+      state_history { { "queued" => 5.minutes.ago.utc.iso8601, "extracting" => Time.current.utc.iso8601 } }
+    end
+
+    trait :staged do
+      status        { "staged" }
+      state_history { { "queued" => 5.minutes.ago.utc.iso8601, "staged" => Time.current.utc.iso8601 } }
+    end
+
+    trait :failed do
+      status         { "failed" }
+      failure_message { "Anthropic returned 500: server overloaded" }
+    end
+  end
+
+  factory :ingestion_item do
+    ingestion_run
+    sequence(:name) { |n| ["Carne Asada Taco", "Pollo Burrito", "Cheese Quesadilla", "Pad Thai"][n % 4] }
+    description { "Grilled steak, cilantro, onion, lime." }
+    section_name { "Tacos" }
+    decision { "pending" }
+
+    # The shape Phase 2.4's resolve job will write here.
+    ingredients_payload do
+      [
+        { "slug" => "meat-beef",         "confidence" => 0.97 },
+        { "slug" => "vegetable-onion",   "confidence" => 0.93 },
+        { "slug" => "herb-cilantro",     "confidence" => 0.91 }
+      ]
+    end
+    tags_payload do
+      [{ "slug" => "cuisine-mexican", "confidence" => 0.99 }]
+    end
+    prices_payload { [{ "size" => nil, "price_cents" => 450 }] }
+
+    trait :pending  do; decision { "pending"  }; end
+    trait :rejected do; decision { "rejected" }; end
+  end
+end

--- a/apps/api/spec/models/ingestion_item_spec.rb
+++ b/apps/api/spec/models/ingestion_item_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe IngestionItem, type: :model do
+  describe "#promote!" do
+    let(:restaurant) { create(:restaurant, :published) }
+    let(:run)        { create(:ingestion_run, restaurant: restaurant, status: "staged") }
+
+    let!(:beef)         { create(:ingredient, slug: "meat-beef") }
+    let!(:onion)        { create(:ingredient, slug: "vegetable-onion") }
+    let!(:cilantro)     { create(:ingredient, slug: "herb-cilantro") }
+    let!(:mexican_tag)  { create(:tag, slug: "cuisine-mexican") }
+
+    let(:item) do
+      create(:ingestion_item,
+             ingestion_run: run, name: "Carne Asada Taco",
+             description: "Grilled steak, cilantro, onion, lime.")
+    end
+
+    it "creates a real Item with status=published, confidence=confirmed" do
+      promoted = item.promote!
+
+      expect(promoted).to be_a(Item)
+      expect(promoted.restaurant).to eq(restaurant)
+      expect(promoted.name).to       eq("Carne Asada Taco")
+      expect(promoted.status).to     eq("published")
+      expect(promoted.confidence).to eq("confirmed")
+    end
+
+    it "creates ItemIngredient rows for every resolvable slug in ingredients_payload" do
+      promoted = item.promote!
+
+      expect(promoted.ingredients).to contain_exactly(beef, onion, cilantro)
+      expect(promoted.item_ingredients.pluck(:confidence).uniq).to eq(["confirmed"])
+      expect(promoted.item_ingredients.pluck(:source).uniq).to eq(["human"])
+    end
+
+    it "creates ItemTag rows from tags_payload" do
+      promoted = item.promote!
+
+      expect(promoted.tags).to contain_exactly(mexican_tag)
+      expect(promoted.item_tags.first.source).to eq("human")
+    end
+
+    it "skips payload entries whose slug doesn't match the catalog (no-op)" do
+      item.update!(
+        ingredients_payload: [
+          { "slug" => "meat-beef",       "confidence" => 0.97 },
+          { "slug" => "vegetable-bigfoot", "confidence" => 0.01 } # not in catalog
+        ]
+      )
+
+      promoted = item.promote!
+
+      expect(promoted.ingredients).to contain_exactly(beef)
+    end
+
+    it "marks the IngestionItem accepted + records decided_at + links to item" do
+      promoted = item.promote!
+
+      item.reload
+      expect(item.decision).to    eq("accepted")
+      expect(item.item).to        eq(promoted)
+      expect(item.decided_at).to  be_within(5.seconds).of(Time.current)
+    end
+
+    it "is idempotent — re-calling returns the existing Item without dup join rows" do
+      first  = item.promote!
+      second = item.promote!
+
+      expect(second).to eq(first)
+      expect(first.item_ingredients.count).to eq(3)
+      expect(first.item_tags.count).to        eq(1)
+    end
+
+    it "raises if the IngestionRun has no restaurant" do
+      orphan_run  = create(:ingestion_run, restaurant: nil)
+      orphan_item = create(:ingestion_item, ingestion_run: orphan_run)
+
+      expect { orphan_item.promote! }.to raise_error(/no restaurant/)
+    end
+  end
+end

--- a/apps/api/spec/models/ingestion_run_spec.rb
+++ b/apps/api/spec/models/ingestion_run_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe IngestionRun, type: :model do
+  describe "#transition_to!" do
+    it "moves the run forward through the happy-path chain" do
+      run = create(:ingestion_run)
+
+      expect { run.transition_to!(:extracting) }
+        .to change(run, :status).from("queued").to("extracting")
+      run.transition_to!(:resolving)
+      run.transition_to!(:staged)
+      run.transition_to!(:published)
+
+      expect(run.published?).to be true
+    end
+
+    it "is idempotent — re-calling with the current state is a no-op" do
+      run = create(:ingestion_run, :extracting)
+      original_history = run.state_history.dup
+
+      expect { run.transition_to!(:extracting) }.not_to change(run, :status)
+      expect(run.reload.state_history).to eq(original_history)
+    end
+
+    it "writes an entry timestamp into state_history once per state" do
+      run = create(:ingestion_run)
+      run.transition_to!(:extracting)
+      first_extracting_at = run.state_history["extracting"]
+
+      # Calling transition_to!(:extracting) a second time must NOT
+      # bump the timestamp — first-entry semantics.
+      sleep 0.01
+      run.transition_to!(:extracting)
+      expect(run.state_history["extracting"]).to eq(first_extracting_at)
+    end
+
+    it "raises InvalidTransition on a non-adjacent forward move" do
+      run = create(:ingestion_run)
+
+      expect { run.transition_to!(:published) }
+        .to raise_error(IngestionRun::InvalidTransition, /from "queued" to "published"/)
+    end
+
+    it "raises ArgumentError on an unknown state name" do
+      run = create(:ingestion_run)
+      expect { run.transition_to!(:nonsense) }.to raise_error(ArgumentError)
+    end
+
+    it "fires Solid Queue jobs registered in JOB_FOR (when their classes exist)" do
+      stub_const("ExtractMenuJob", Class.new do
+        def self.perform_later(*); end
+      end)
+
+      run = create(:ingestion_run)
+      expect(ExtractMenuJob).to receive(:perform_later).with(run.id)
+
+      run.transition_to!(:extracting)
+    end
+
+    it "is a no-op on the job dispatch when the class doesn't exist" do
+      # Sanity: NEXT_STATE for :staged → :published has no JOB_FOR
+      # entry, so reaching :published shouldn't try to dispatch.
+      run = create(:ingestion_run, :staged)
+      expect { run.transition_to!(:published) }.not_to raise_error
+    end
+  end
+
+  describe "#fail!" do
+    it "transitions to failed from any state and stores the message" do
+      run = create(:ingestion_run, :extracting)
+
+      run.fail!("Anthropic returned 500: server overloaded")
+
+      expect(run.failed?).to be true
+      expect(run.failure_message).to eq("Anthropic returned 500: server overloaded")
+    end
+
+    it "truncates a wildly long failure message to 2000 chars" do
+      run = create(:ingestion_run)
+      huge = "x" * 5_000
+
+      run.fail!(huge)
+
+      expect(run.failure_message.length).to eq(2_000)
+    end
+
+    it "doesn't enqueue any next-stage job" do
+      stub_const("ExtractMenuJob", Class.new do
+        def self.perform_later(*); end
+      end)
+      expect(ExtractMenuJob).not_to receive(:perform_later)
+
+      create(:ingestion_run).fail!("anything")
+    end
+  end
+
+  describe "predicate methods" do
+    it "exposes a #{IngestionRun::STATUSES.first}? for every status" do
+      run = build(:ingestion_run, status: "extracting")
+      expect(run.extracting?).to be true
+      expect(run.queued?).to     be false
+      expect(run.failed?).to     be false
+    end
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,15 +13,14 @@ the merge / review / status rules.
 
 **Phase 2** ⭐ AI ingestion MVP. Subplan: `docs/plans/phase-2.md`. This batch is **proposed by the loop** (this PR is the plan-update PR); humans review it before the items auto-run.
 
-1. **Phase 2.1 — AnthropicClient service** (`docs/plans/phase-2.md#21`) — this PR
-2. **Phase 2.2 — IngestionRun + IngestionItem state machine** (`docs/plans/phase-2.md#22`)
-3. **Phase 2.3 — ExtractMenuJob** (`docs/plans/phase-2.md#23`) — depends on 2.1, 2.2; needs `ANTHROPIC_API_KEY` for VCR cassette recording
-4. **Phase 2.4 — ResolveIngredients + ResolveTags jobs** (`docs/plans/phase-2.md#24`) — depends on 2.3; needs `ANTHROPIC_API_KEY`
-5. **Phase 2.5 — Item promotion + admin verify UI** (`docs/plans/phase-2.md#25`)
-6. **Phase 2.6 — Mobile multi-page camera capture + upload** (`docs/plans/phase-2.md#26`)
-7. **Phase 2.7 — Mobile swipe-verify UI** (`docs/plans/phase-2.md#27`)
-8. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`)
-9. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
+1. **Phase 2.2 — IngestionRun + IngestionItem state machine** (`docs/plans/phase-2.md#22`) — this PR
+2. **Phase 2.3 — ExtractMenuJob** (`docs/plans/phase-2.md#23`) — depends on 2.2; needs `ANTHROPIC_API_KEY` for VCR cassette recording
+3. **Phase 2.4 — ResolveIngredients + ResolveTags jobs** (`docs/plans/phase-2.md#24`) — depends on 2.3; needs `ANTHROPIC_API_KEY`
+4. **Phase 2.5 — Item promotion + admin verify UI** (`docs/plans/phase-2.md#25`)
+5. **Phase 2.6 — Mobile multi-page camera capture + upload** (`docs/plans/phase-2.md#26`)
+6. **Phase 2.7 — Mobile swipe-verify UI** (`docs/plans/phase-2.md#27`)
+7. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`)
+8. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
 
 ### Done
 
@@ -34,6 +33,7 @@ the merge / review / status rules.
 - ✅ Phase 1.5 — Avo admin at `/admin` (#132)
 - ✅ Phase 1.6 — OpenAPI codegen for `packages/api-types` (#133)
 - ✅ Phase 1.7 — Restaurant + Item read endpoints with filter (#134)
+- ✅ Phase 2.1 — AnthropicClient service (#136)
 
 After Phase 2 ships, the loop will draft `docs/plans/phase-3.md` (dietary filter UI) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,26 @@ without spelunking GitHub.
 
 ---
 
+2026-04-29 22:25 — tick #42. PR #136 (Phase 2.1) merged at 21:48 UTC.
+Picked up Phase 2.2 — state machine. Migration adds
+`state_history :jsonb` + renames `error_message` → `failure_message`
+(no data lost, column was unused). `IngestionRun#transition_to!(state)`
+is idempotent (re-call = no-op, first-entry timestamp wins),
+records UTC iso8601 in state_history, raises InvalidTransition for
+non-adjacent forward moves (queued → published etc.), and dispatches
+NEXT-state Solid Queue jobs via `safe_constantize` so 2.3+ defining
+ExtractMenuJob/ResolveIngredientsJob "just works" with no further
+changes here. `#fail!(message)` truncates to 2000 chars + transitions
+to failed without enqueuing. Predicates auto-defined per status.
+`IngestionItem#promote!` materializes a staged item → real Item +
+ItemIngredient + ItemTag rows with confidence: confirmed, source:
+human (humans accepted, that's confirmed by definition); skips
+unresolvable slugs gracefully; idempotent (re-call returns existing
+Item, no dup join rows); raises if the IngestionRun has no
+restaurant. New ingestion factories (run + item) with realistic
+payloads matching what 2.4's resolve job will write. 18 model
+specs (11 run + 7 item). Local rspec 91/91 green.
+
 2026-04-29 22:00 — tick #41. Plan PR #135 merged at 21:16 UTC. Phase 2
 queue live. Picked up Phase 2.1 — AnthropicClient. Faraday wrapper
 at `app/services/anthropic_client.rb` with bearer auth, prompt


### PR DESCRIPTION
## Why

Phase 2.2 of the v2 delivery plan — `docs/plans/phase-2.md#22`. Wires up the IngestionRun state machine + IngestionItem promotion path. No live API calls; this is the spine the Phase 2.3+ jobs hang off of.

## What

### Migration

- `state_history :jsonb default: {} null: false` on `ingestion_runs` — per-state entry-timestamp audit trail. Phase 2.9's cost dashboard reads this for per-stage latency.
- Renames `error_message` → `failure_message` to match `phase-2.md` vocabulary. The column was unused so far — no data lost.

### `IngestionRun#transition_to!(new_status)`

- **Idempotent.** Re-calling with the current state is a no-op; the `state_history` timestamp is set ONLY on first entry, so repeated calls don't clobber the original entry timestamp.
- **Validates transitions.** Raises `IngestionRun::InvalidTransition` for non-adjacent forward moves (e.g. `queued → published`). `:failed` is reachable from any state.
- **Auto-dispatches the next-stage job** via `JOB_FOR[new_status]&.safe_constantize&.perform_later(id)`. The job class doesn't have to exist yet — Phase 2.3 + 2.4 add `ExtractMenuJob` + `ResolveIngredientsJob` and the dispatch starts firing without further changes here.

### `IngestionRun#fail!(message)`

- Truncates the message to 2000 chars (Anthropic stack traces can be huge), transitions to `:failed`, doesn't enqueue any next-stage job.

### Predicate methods

Auto-defined for every status: `queued?`, `extracting?`, `resolving?`, `staged?`, `published?`, `failed?`.

### `IngestionItem#promote!`

- Materializes a staged item into a real `Item` + `ItemIngredient` + `ItemTag` rows with `confidence: confirmed, source: human` (a human just clicked accept — that's confirmed by definition).
- Skips payload entries whose slug doesn't match the catalog — no-op, not an error. Phase 2.4 will surface these in `unresolved_ingredients[]` for human curation.
- **Idempotent**: re-calling on an already-promoted item returns the existing `Item` without creating duplicate join rows.
- Raises if the run has no `restaurant_id` (we don't know where to put the item).

### Specs (18 new)

| File | Coverage |
|---|---|
| `spec/models/ingestion_run_spec.rb` | happy-path chain, idempotence, state_history first-entry semantics, `InvalidTransition`, `ArgumentError` on unknown state, job dispatch (with stubbed `ExtractMenuJob`), no dispatch when class missing, `fail!` happy + truncation + no-job-enqueued, predicates |
| `spec/models/ingestion_item_spec.rb` | happy-path promotion, ingredient + tag materialization, slug-miss handling, decision/decided_at/item linkage, idempotence (no dup join rows), no-restaurant guard |

New factories: `:ingestion_run` (with `:extracting`, `:staged`, `:failed` traits) and `:ingestion_item` with realistic payloads matching what Phase 2.4's resolve job will write.

## Test plan

- [ ] CI · API rspec green (18 new + 73 prior = 91).
- [ ] Local rspec: 91/91 confirmed.
- [ ] Manual: `bin/rails console` → `r = IngestionRun.create!(input_kind: 'photo', restaurant: Restaurant.first)` → `r.transition_to!(:extracting)` → returns the run with `state_history["extracting"]` populated. (Won't actually fire ExtractMenuJob until 2.3 lands the class.)

## Notes

- The `JOB_FOR` map intentionally excludes `staged` and `published` — `staged` waits for a human verification step (the swipe-verify UI in 2.7), and `published` is a terminal state. Phase 2.5 wires the staging-threshold logic that flips `staged` → `published` on its own.
- `state_history` is intentionally a flat hash keyed by state name (`{"queued": "...", "extracting": "..."}`) rather than an array of events. Re-running the same transition is supposed to be invisible — there's no "re-entered extracting at 22:35" event to record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)