### PR TITLE
feat(api): admin verify UI + 80%-accepted publish (phase 2.5)

### DIFF
--- a/apps/api/app/avo/actions/ingestion_items/accept.rb
+++ b/apps/api/app/avo/actions/ingestion_items/accept.rb
@@ -1,0 +1,37 @@
+class Avo::Actions::IngestionItems::Accept < Avo::BaseAction
+  self.name = "Accept → promote to live menu"
+  self.message = "Materialize a real Item + ItemIngredient + ItemTag rows for the selected ingestion item(s)? confidence: confirmed, source: human."
+  self.confirm_button_label = "Accept"
+
+  def handle(query:, **)
+    promoted, skipped = self.class.accept_all(query)
+
+    msg = +"Promoted #{promoted} item(s) to live menu."
+    msg << " Skipped #{skipped} already-promoted." if skipped.positive?
+    succeed msg
+  end
+
+  # Pure logic; reusable by specs and by other call sites that don't
+  # come through Avo's controller lifecycle (which wires up #succeed).
+  def self.accept_all(items)
+    promoted = 0
+    skipped  = 0
+
+    items.each do |ingestion_item|
+      if ingestion_item.accepted? && ingestion_item.item.present?
+        skipped += 1
+        next
+      end
+
+      ingestion_item.promote!
+      promoted += 1
+    end
+
+    # Phase 2.5 acceptance criterion: ≥80% of decided items accepted
+    # → run flips to :published, restaurant flips to :published if not
+    # already.
+    items.map(&:ingestion_run).uniq.each(&:maybe_publish!)
+
+    [promoted, skipped]
+  end
+end

--- a/apps/api/app/avo/actions/ingestion_items/reject.rb
+++ b/apps/api/app/avo/actions/ingestion_items/reject.rb
@@ -1,0 +1,24 @@
+class Avo::Actions::IngestionItems::Reject < Avo::BaseAction
+  self.name = "Reject (do not promote)"
+  self.message = "Mark the selected ingestion item(s) as rejected. They stay in the audit log but no Item is materialized."
+  self.confirm_button_label = "Reject"
+
+  def handle(query:, **)
+    self.class.reject_all(query)
+    succeed "Rejected #{query.size} item(s)."
+  end
+
+  # Pure logic; same reason as Accept#accept_all (testable without
+  # the Avo controller lifecycle).
+  def self.reject_all(items)
+    items.each do |ingestion_item|
+      next if ingestion_item.rejected?
+
+      ingestion_item.update!(decision: "rejected", decided_at: Time.current)
+    end
+
+    # Same publication-threshold check as Accept — rejecting also
+    # moves the "decided" denominator forward.
+    items.map(&:ingestion_run).uniq.each(&:maybe_publish!)
+  end
+end

--- a/apps/api/app/avo/actions/ingestion_runs/re_extract.rb
+++ b/apps/api/app/avo/actions/ingestion_runs/re_extract.rb
@@ -1,0 +1,20 @@
+class Avo::Actions::IngestionRuns::ReExtract < Avo::BaseAction
+  self.name = "Re-run extraction"
+  self.message = "Reset this run to :extracting and fire ExtractMenuJob again? Useful when the original extraction returned bad output (the cassette didn't match a valid menu shape, or the model returned weirdness)."
+  self.confirm_button_label = "Re-extract"
+
+  def handle(query:, **)
+    query.each do |run|
+      next if run.published? # Don't blow up an already-published run
+
+      run.update!(staging: {}, failure_message: nil, latency_ms: nil,
+                  state_history: run.state_history.except("extracting", "resolving", "staged", "failed"))
+      # Force back to :queued via direct write (transition_to! enforces
+      # forward-only chains and we're rewinding).
+      run.update_columns(status: "queued")
+      ExtractMenuJob.perform_later(run.id)
+    end
+
+    succeed "Re-extraction enqueued for #{query.size} run(s)."
+  end
+end

--- a/apps/api/app/avo/resources/ingestion_item.rb
+++ b/apps/api/app/avo/resources/ingestion_item.rb
@@ -1,0 +1,41 @@
+class Avo::Resources::IngestionItem < Avo::BaseResource
+  # Phase 2.5 — admin verification surface. Each row shows the AI's
+  # extracted item alongside the resolved ingredient + tag slugs;
+  # Accept calls IngestionItem#promote! (added in Phase 2.2), which
+  # materializes a real Item + ItemIngredient + ItemTag rows.
+
+  self.includes = [:ingestion_run, :item]
+
+  def fields
+    main_panel do
+      field :id,          as: :id
+      field :name,        as: :text
+      field :description, as: :textarea
+      field :section_name, as: :text, name: "Section"
+      field :decision, as: :badge, options: {
+        info:    %w[pending edited],
+        success: %w[accepted],
+        danger:  %w[rejected]
+      }
+      field :decided_at, as: :date_time, only_on: %i[show]
+      field :ingestion_run, as: :belongs_to
+      field :item,          as: :belongs_to, help: "Set after promote!"
+    end
+
+    panel "AI suggestions" do
+      field :ingredients_payload, as: :code, language: "json", name: "Ingredients (slug + confidence)"
+      field :tags_payload,        as: :code, language: "json", name: "Tags (slug + confidence)"
+      field :prices_payload,      as: :code, language: "json", name: "Prices (size + cents)"
+    end
+
+    panel "Couldn't match" do
+      field :unresolved_ingredients, as: :code, language: "json"
+      field :unresolved_tags,         as: :code, language: "json"
+    end
+  end
+
+  def actions
+    action Avo::Actions::IngestionItems::Accept
+    action Avo::Actions::IngestionItems::Reject
+  end
+end

--- a/apps/api/app/avo/resources/ingestion_run.rb
+++ b/apps/api/app/avo/resources/ingestion_run.rb
@@ -1,0 +1,48 @@
+class Avo::Resources::IngestionRun < Avo::BaseResource
+  # Phase 2.5 — admin can see what the AI extracted, watch state
+  # transitions, and re-run a stuck extraction. The actual
+  # accept/reject happens at the per-item level (see Avo::Resources::IngestionItem).
+
+  self.includes = [:restaurant, :user]
+
+  def fields
+    main_panel do
+      field :id,         as: :id
+      field :status,     as: :badge, options: {
+        info:    %w[queued],
+        warning: %w[extracting resolving],
+        success: %w[staged published],
+        danger:  %w[failed]
+      }
+      field :input_kind,    as: :badge
+      field :restaurant,    as: :belongs_to
+      field :user,          as: :belongs_to
+      field :source_url,    as: :text, only_on: %i[show]
+      field :inputs,        as: :files, hide_on: %i[edit new]
+    end
+
+    panel "Pipeline" do
+      field :state_history,  as: :code, language: "json", only_on: %i[show]
+      field :latency_ms,     as: :number, only_on: %i[show], help: "Wall time of the most recent API call"
+      field :failure_message, as: :textarea, only_on: %i[show]
+    end
+
+    panel "Cost" do
+      field :api_cost_cents,        as: :number, name: "Cost (cents)"
+      field :cached_input_tokens,   as: :number
+      field :uncached_input_tokens, as: :number
+    end
+
+    panel "AI extraction" do
+      field :staging,    as: :code, language: "json", hide_on: %i[edit new]
+      field :raw_output, as: :code, language: "json", only_on: %i[show],
+            help: "Full Anthropic response, kept for debugging"
+    end
+
+    field :ingestion_items, as: :has_many
+  end
+
+  def actions
+    action Avo::Actions::IngestionRuns::ReExtract
+  end
+end

--- a/apps/api/app/controllers/avo/ingestion_items_controller.rb
+++ b/apps/api/app/controllers/avo/ingestion_items_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::IngestionItemsController < Avo::ResourcesController
+end

--- a/apps/api/app/controllers/avo/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/avo/ingestion_runs_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::IngestionRunsController < Avo::ResourcesController
+end

--- a/apps/api/app/models/ingestion_run.rb
+++ b/apps/api/app/models/ingestion_run.rb
@@ -77,6 +77,30 @@ class IngestionRun < ApplicationRecord
     self
   end
 
+  # Phase 2.5 — when a swipe-verify accept/reject crosses the
+  # acceptance threshold for this run, flip both the run AND the
+  # restaurant to :published. Threshold is 80% of *decided* items
+  # (accepted + rejected, i.e. anything not still :pending) being
+  # `:accepted`. Returns whether anything was published.
+  PUBLICATION_THRESHOLD = 0.80
+
+  def maybe_publish!
+    return false unless staged?
+    return false unless ingestion_items.exists?
+
+    decided = ingestion_items.where.not(decision: "pending").count
+    return false if decided.zero?
+
+    accepted = ingestion_items.where(decision: "accepted").count
+    return false if (accepted.to_f / decided) < PUBLICATION_THRESHOLD
+
+    transaction do
+      transition_to!(:published)
+      restaurant&.update!(status: "published") unless restaurant.nil? || restaurant.status == "published"
+    end
+    true
+  end
+
   private
 
   def record_state_entry!(new_status)

--- a/apps/api/spec/avo/actions/ingestion_items/accept_spec.rb
+++ b/apps/api/spec/avo/actions/ingestion_items/accept_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Avo::Actions::IngestionItems::Accept do
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:run)        { create(:ingestion_run, :staged, restaurant: restaurant) }
+
+  let!(:beef)  { create(:ingredient, slug: "meat-beef") }
+  let!(:vegan) { create(:tag, slug: "diet-vegan") }
+
+  let(:item) do
+    create(:ingestion_item, ingestion_run: run,
+           ingredients_payload: [{ "slug" => "meat-beef", "confidence" => 0.97 }],
+           tags_payload:        [{ "slug" => "diet-vegan", "confidence" => 0.10 }])
+  end
+
+  it "calls promote! and creates a real Item with confirmed sources" do
+    described_class.accept_all([item])
+
+    item.reload
+    expect(item.decision).to     eq("accepted")
+    expect(item.item).to         be_present
+    expect(item.item.ingredients).to contain_exactly(beef)
+    expect(item.item.tags).to        contain_exactly(vegan)
+    expect(item.item.item_ingredients.first.source).to eq("human")
+  end
+
+  it "is idempotent — re-accepting an already-promoted item doesn't dup" do
+    item.promote!
+    original_item_id = item.reload.item.id
+
+    expect {
+      described_class.accept_all([item])
+    }.not_to change(Item, :count)
+
+    expect(item.reload.item.id).to eq(original_item_id)
+  end
+
+  it "calls maybe_publish! on the run after accepting" do
+    # 5 items total: 4 already accepted, this Accept makes the 5th.
+    # → 100% accepted → run flips to :published.
+    4.times do |i|
+      ai = create(:ingestion_item, ingestion_run: run, decision: "accepted")
+      ai.update_column(:item_id, create(:item, restaurant: restaurant).id)
+    end
+
+    described_class.accept_all([item])
+
+    expect(run.reload.published?).to be true
+  end
+end

--- a/apps/api/spec/models/ingestion_run_publication_spec.rb
+++ b/apps/api/spec/models/ingestion_run_publication_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe IngestionRun, "#maybe_publish!", type: :model do
+  let(:restaurant) { create(:restaurant, status: "draft") }
+  let(:run)        { create(:ingestion_run, :staged, restaurant: restaurant) }
+
+  def add_items(decisions)
+    decisions.each do |d|
+      create(:ingestion_item, ingestion_run: run, decision: d)
+    end
+  end
+
+  it "publishes when ≥80% of decided items are accepted" do
+    # 4 accepted + 1 rejected = 80% accepted of 5 decided. Threshold met.
+    add_items(%w[accepted accepted accepted accepted rejected])
+
+    expect(run.maybe_publish!).to be true
+
+    run.reload
+    expect(run.published?).to        be true
+    expect(restaurant.reload.status).to eq("published")
+  end
+
+  it "does not publish when below the 80% threshold" do
+    # 3 accepted + 2 rejected = 60% accepted. No publish.
+    add_items(%w[accepted accepted accepted rejected rejected])
+
+    expect(run.maybe_publish!).to be false
+
+    run.reload
+    expect(run.staged?).to be true
+    expect(restaurant.reload.status).to eq("draft")
+  end
+
+  it "ignores pending items in the denominator" do
+    # 4 accepted + 1 rejected (decided) + 6 pending (not counted yet).
+    # 80% of decided = pass.
+    add_items(%w[accepted accepted accepted accepted rejected pending pending pending pending pending pending])
+
+    expect(run.maybe_publish!).to be true
+    expect(run.reload.published?).to be true
+  end
+
+  it "is a no-op if the run hasn't reached :staged yet" do
+    queued = create(:ingestion_run, status: "extracting", restaurant: restaurant)
+    create(:ingestion_item, ingestion_run: queued, decision: "accepted")
+
+    expect(queued.maybe_publish!).to be false
+    expect(queued.reload.extracting?).to be true
+  end
+
+  it "is a no-op when there are zero decided items" do
+    add_items(%w[pending pending pending])
+
+    expect(run.maybe_publish!).to be false
+    expect(run.reload.staged?).to be true
+  end
+
+  it "leaves restaurant alone if it's already published" do
+    restaurant.update!(status: "published")
+    add_items(%w[accepted accepted accepted accepted accepted])
+
+    expect { run.maybe_publish! }
+      .not_to change { restaurant.reload.updated_at }
+
+    expect(run.reload.published?).to be true
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,12 +13,11 @@ the merge / review / status rules.
 
 **Phase 2** ⭐ AI ingestion MVP. Subplan: `docs/plans/phase-2.md`. This batch is **proposed by the loop** (this PR is the plan-update PR); humans review it before the items auto-run.
 
-1. **Phase 2.4 — ResolveIngredients + ResolveTags jobs** (`docs/plans/phase-2.md#24`) — this PR; mocked-client coverage shipped, live VCR cassette deferred until `ANTHROPIC_API_KEY` is recorded
-2. **Phase 2.5 — Item promotion + admin verify UI** (`docs/plans/phase-2.md#25`)
-3. **Phase 2.6 — Mobile multi-page camera capture + upload** (`docs/plans/phase-2.md#26`)
-4. **Phase 2.7 — Mobile swipe-verify UI** (`docs/plans/phase-2.md#27`)
-5. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`)
-6. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
+1. **Phase 2.5 — Item promotion + admin verify UI** (`docs/plans/phase-2.md#25`) — this PR
+2. **Phase 2.6 — Mobile multi-page camera capture + upload** (`docs/plans/phase-2.md#26`)
+3. **Phase 2.7 — Mobile swipe-verify UI** (`docs/plans/phase-2.md#27`)
+4. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`)
+5. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
 
 ### Done
 
@@ -34,6 +33,7 @@ the merge / review / status rules.
 - ✅ Phase 2.1 — AnthropicClient service (#136)
 - ✅ Phase 2.2 — IngestionRun + IngestionItem state machine (#137)
 - ✅ Phase 2.3 — ExtractMenuJob + ActiveStorage wiring (#138)
+- ✅ Phase 2.4 — ResolveIngredients + ResolveTags jobs (#139)
 
 After Phase 2 ships, the loop will draft `docs/plans/phase-3.md` (dietary filter UI) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,25 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 00:15 — tick #45. PR #139 (Phase 2.4) merged at 23:20 UTC.
+Picked up Phase 2.5 — admin verify UI + auto-publish threshold.
+Generated Avo resources for IngestionRun + IngestionItem (Phase 1.5
+shipped without them — they only got generated for the data-model
+set explicitly in phase-1.md §1.5). Customized both: badge fields
+for status + decision; panels grouping pipeline / cost / AI extraction
+/ AI suggestions / unresolved; staging + raw_output as JSON code
+viewers. Three Avo Actions: `IngestionRuns::ReExtract` (resets
+state_history + staging, dispatches ExtractMenuJob), `IngestionItems
+::Accept` (calls IngestionItem#promote!, runs maybe_publish! after),
+`IngestionItems::Reject` (sets decision, runs maybe_publish! after).
+Action handle methods extracted into class methods (`accept_all`,
+`reject_all`) so specs can exercise them without Avo's controller
+lifecycle (which wires `succeed`). New `IngestionRun#maybe_publish!`:
+publishes the run + restaurant when ≥80% of decided items are
+accepted; pending items don't count toward the denominator. 9 new
+specs (6 publication-threshold + 3 Avo accept-action). Local rspec
+116/116 (1 pending). Pushing PR.
+
 2026-04-29 23:50 — tick #44. PR #138 (Phase 2.3) merged at 23:14 UTC.
 Picked up Phase 2.4 — Resolve jobs. Same ANTHROPIC_API_KEY stop
 condition handled the same way as 2.3 (mocked-client coverage,


### PR DESCRIPTION
## Why

Phase 2.5 of the v2 delivery plan — `docs/plans/phase-2.md#25`. Admin can now see the AI extraction in `/admin`, accept/reject items one by one (or in bulk), and the run + restaurant auto-publish once 80% of decided items are accepted.

This unblocks the Phase 2 demo: the admin team can run a Durango menu through the pipeline locally + click through the verify UI to validate everything wires up — even before the mobile camera + swipe-verify (2.6 + 2.7).

## What

### Avo resources

Phase 1.5 didn't generate these — only the data-model set listed in phase-1.md §1.5. Generated + customized both:

- **`Avo::Resources::IngestionRun`**: badge for status (info/warning/success/danger color-coded), panels grouping Pipeline (`state_history`, `latency_ms`, `failure_message`) / Cost (`api_cost_cents` + `cached_input_tokens` + `uncached_input_tokens`) / AI extraction (`staging` + `raw_output` as JSON code viewers).
- **`Avo::Resources::IngestionItem`**: badge for decision, panels for AI Suggestions (`ingredients_payload`, `tags_payload`, `prices_payload`) and Couldn't match (`unresolved_ingredients`, `unresolved_tags`).

### Avo Actions

| Action | Does |
|---|---|
| `IngestionRuns::ReExtract` | Resets `staging` + `state_history`, flips status back to `:queued`, dispatches `ExtractMenuJob`. For when the original extraction returned weirdness. |
| `IngestionItems::Accept` | Calls `IngestionItem#promote!` (added in Phase 2.2) → materializes a real `Item` + `ItemIngredient` + `ItemTag` rows with `confidence: confirmed, source: human`. Then calls `maybe_publish!` on the parent run. |
| `IngestionItems::Reject` | Marks `decision: rejected` + `decided_at`. Then calls `maybe_publish!` (rejecting also moves the "decided" denominator). |

Both action `handle` methods extracted into class methods (`Accept.accept_all`, `Reject.reject_all`) so specs can exercise the logic without invoking Avo's full controller lifecycle (which is where `succeed` gets wired).

### `IngestionRun#maybe_publish!`

- **Threshold**: ≥80% of *decided* items accepted (pending items don't count toward the denominator). Constant `PUBLICATION_THRESHOLD = 0.80`.
- Only fires when run is `:staged`.
- Publishes the run AND flips the restaurant to `:published` if not already. Single transaction.

### Specs (9 new)

- 6 publication-threshold tests (under/at/over the bar, pending ignored, no-decided no-op, restaurant already-published no-op).
- 3 Accept-action tests (promote! happy path, idempotence, threshold trigger after the final accept).

## Test plan

- [ ] CI · API rspec green (9 new + 107 prior = 116 examples, 1 pending).
- [ ] Local rspec: 116/116 confirmed.
- [ ] Manual sanity: hit `/admin/resources/ingestion_runs` in dev — staging + state_history render as JSON code viewers; the Re-extract action button is visible. Same for `/admin/resources/ingestion_items` with Accept/Reject buttons.

## Notes

- **Pipeline status post-merge**: `:queued → :extracting → :resolving → :staged → :published` is end-to-end functional with mocked AI clients, plus the admin can verify + auto-publish. The cassette gap from 2.3 + 2.4 is the only thing between this and live demo-ready ingestion.
- **Why class methods on actions**: Avo's `BaseAction.new` keyword signature is internal-ish (`current_user`, `arguments`, `resource`, etc. wired by the controller). Bypassing it via `allocate` then calling `handle` doesn't set up `succeed`. Extracting pure logic into a class method is cleaner than mocking Avo's internals — the action becomes a thin wrapper around testable code.
- **No Edit action yet**: the standard Avo edit form already handles "tweak the payload then accept." Adding a custom Edit modal is more work than it's worth for Phase 2; the swipe UI in 2.7 will provide the inline edit experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)