### PR TITLE
feat(api,mobile): swipe-verify UI + ingestion item PATCH (phase 2.7)

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
@@ -1,0 +1,94 @@
+module Api
+  module V1
+    # PATCH /api/v1/ingestion_runs/:run_id/items/:id
+    #
+    # Phase 2.7 — the mobile swipe-verify UI hits this endpoint when
+    # an admin accepts / edits / rejects an item. Accept also fires
+    # IngestionItem#promote! (materializes the real Item) and runs
+    # IngestionRun#maybe_publish! (the 80%-accepted threshold from
+    # Phase 2.5).
+    class IngestionItemsController < BaseController
+      before_action :ensure_admin!
+
+      def index
+        run = IngestionRun.find(params[:ingestion_run_id])
+        items = run.ingestion_items.order(:created_at)
+        render json: { items: items.map { |it| serialize_item(it) } }
+      end
+
+      def update
+        run  = IngestionRun.find(params[:ingestion_run_id])
+        item = run.ingestion_items.find(params[:id])
+
+        decision = params[:decision].to_s
+        unless IngestionItem::DECISIONS.include?(decision)
+          render json: { error: "invalid_decision",
+                         allowed: IngestionItem::DECISIONS }, status: :unprocessable_entity
+          return
+        end
+
+        # Edits override fields BEFORE accept fires promote!, so the
+        # materialized Item carries the human's tweaks rather than
+        # the AI's original suggestions.
+        if decision == "edited" || decision == "accepted"
+          item.assign_attributes(edit_params) if edit_params.to_h.any?
+        end
+
+        case decision
+        when "accepted", "edited"
+          # Edited+then-accepted: a separate request will resubmit
+          # decision: accepted. Editing alone records the change but
+          # doesn't promote — keeps the human in control of the final
+          # promotion step.
+          if decision == "accepted"
+            item.save! if item.changed?
+            item.promote!
+          else
+            item.update!(decision: "edited", decided_at: Time.current)
+          end
+        when "rejected"
+          item.update!(decision: "rejected", decided_at: Time.current)
+        end
+
+        run.maybe_publish!
+
+        render json: serialize_item(item.reload)
+      end
+
+      private
+
+      def ensure_admin!
+        return if current_user&.is_admin?
+        render json: { error: "forbidden" }, status: :forbidden
+      end
+
+      def edit_params
+        params.permit(
+          :name, :description,
+          ingredients_payload:    [:slug, :confidence],
+          tags_payload:           [:slug, :confidence],
+          unresolved_ingredients: [],
+          unresolved_tags:        []
+        )
+      end
+
+      def serialize_item(item)
+        {
+          id:                     item.id,
+          ingestion_run_id:       item.ingestion_run_id,
+          item_id:                item.item_id,
+          name:                   item.name,
+          description:            item.description,
+          section_name:           item.section_name,
+          decision:               item.decision,
+          decided_at:             item.decided_at,
+          ingredients_payload:    item.ingredients_payload,
+          tags_payload:           item.tags_payload,
+          prices_payload:         item.prices_payload,
+          unresolved_ingredients: item.unresolved_ingredients,
+          unresolved_tags:        item.unresolved_tags
+        }
+      end
+    end
+  end
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -54,7 +54,9 @@ Rails.application.routes.draw do
       resources :ingredients, only: [:index]
       resources :tags, only: [:index]
       resources :dietary_profiles, only: [:index]
-      resources :ingestion_runs, only: [:create, :show]
+      resources :ingestion_runs, only: [:create, :show] do
+        resources :items, only: [:index, :update], controller: "ingestion_items"
+      end
     end
   end
 

--- a/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
@@ -1,0 +1,144 @@
+require "rails_helper"
+
+RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:admin)      { create(:user, password: "password123", is_admin: true) }
+  let(:non_admin)  { create(:user, password: "password123", is_admin: false) }
+  let(:run)        { create(:ingestion_run, :staged, restaurant: restaurant) }
+
+  let!(:beef)  { create(:ingredient, slug: "meat-beef") }
+  let!(:taco_tag) { create(:tag, slug: "cuisine-mexican") }
+
+  let!(:item) do
+    create(:ingestion_item,
+           ingestion_run: run, name: "Carne Asada Taco",
+           ingredients_payload: [{ "slug" => "meat-beef", "confidence" => 0.97 }],
+           tags_payload:        [{ "slug" => "cuisine-mexican", "confidence" => 0.99 }])
+  end
+
+  def auth_for(user)
+    token, _ = Warden::JWTAuth::UserEncoder.new.call(user, :user, nil)
+    { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
+  end
+
+  describe "GET /api/v1/ingestion_runs/:run_id/items" do
+    it "lists items for the run" do
+      get "/api/v1/ingestion_runs/#{run.id}/items", headers: auth_for(admin)
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["items"].length).to eq(1)
+      expect(body["items"].first["name"]).to eq("Carne Asada Taco")
+    end
+
+    it "rejects non-admins with 403" do
+      get "/api/v1/ingestion_runs/#{run.id}/items", headers: auth_for(non_admin)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "PATCH /api/v1/ingestion_runs/:run_id/items/:id" do
+    context "decision: accepted" do
+      it "promotes the item, fills in decision/decided_at/item_id" do
+        expect {
+          patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+                params: { decision: "accepted" }.to_json,
+                headers: auth_for(admin)
+        }.to change(Item, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["decision"]).to     eq("accepted")
+        expect(body["item_id"]).to      be_present
+        expect(body["decided_at"]).to    be_present
+
+        promoted = Item.find(body["item_id"])
+        expect(promoted.ingredients).to contain_exactly(beef)
+        expect(promoted.tags).to        contain_exactly(taco_tag)
+      end
+
+      it "applies edit overrides BEFORE promoting (so the live Item has the human's tweaks)" do
+        patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+              params: {
+                decision:    "accepted",
+                name:        "Steak Taco",
+                description: "Hand-shredded carne asada with house chimichurri."
+              }.to_json,
+              headers: auth_for(admin)
+
+        expect(response).to have_http_status(:ok)
+        promoted = Item.find(response.parsed_body["item_id"])
+        expect(promoted.name).to eq("Steak Taco")
+        expect(promoted.description).to include("chimichurri")
+      end
+    end
+
+    context "decision: edited (without accepting)" do
+      it "saves the edited fields but does NOT materialize an Item" do
+        expect {
+          patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+                params: { decision: "edited", name: "Veggie Taco" }.to_json,
+                headers: auth_for(admin)
+        }.not_to change(Item, :count)
+
+        item.reload
+        expect(item.decision).to eq("edited")
+        expect(item.name).to     eq("Veggie Taco")
+        expect(item.item).to     be_nil
+      end
+    end
+
+    context "decision: rejected" do
+      it "marks the item rejected, no Item created" do
+        expect {
+          patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+                params: { decision: "rejected" }.to_json,
+                headers: auth_for(admin)
+        }.not_to change(Item, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["decision"]).to eq("rejected")
+      end
+    end
+
+    it "422s on an unknown decision value" do
+      patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+            params: { decision: "yolo" }.to_json,
+            headers: auth_for(admin)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to eq("invalid_decision")
+    end
+
+    it "rejects a non-admin caller with 403" do
+      patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+            params: { decision: "accepted" }.to_json,
+            headers: auth_for(non_admin)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "401s without a token" do
+      patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+            params: { decision: "accepted" }.to_json,
+            headers: { "Content-Type" => "application/json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "triggers maybe_publish! on the run when the threshold is crossed" do
+      # Pre-populate 4 already-accepted items so this is the 5th decision
+      # → 5/5 accepted → above threshold.
+      4.times do
+        ai = create(:ingestion_item, ingestion_run: run, decision: "accepted")
+        ai.update_column(:item_id, create(:item, restaurant: restaurant).id)
+      end
+
+      patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+            params: { decision: "accepted" }.to_json,
+            headers: auth_for(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(run.reload.published?).to be true
+    end
+  end
+end

--- a/apps/mobile/__tests__/lib/decide-ingestion-item.test.ts
+++ b/apps/mobile/__tests__/lib/decide-ingestion-item.test.ts
@@ -1,0 +1,147 @@
+import {
+  decideIngestionItem,
+  getIngestionRun,
+  listIngestionItems,
+  IngestionUploadError,
+} from '../../lib/api/ingestion-runs';
+
+describe('decideIngestionItem', () => {
+  function fakeFetch(status: number, body: unknown) {
+    return jest.fn(async () =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+      }) as unknown as Response,
+    );
+  }
+
+  const samplePayload = {
+    id: 'iiii-1111',
+    ingestion_run_id: 'rrrr-1111',
+    item_id: 'item-1111',
+    name: 'Carne Asada Taco',
+    description: 'Grilled steak.',
+    section_name: 'Tacos',
+    decision: 'accepted',
+    decided_at: '2026-04-30T00:00:00Z',
+    ingredients_payload: [{ slug: 'meat-beef', confidence: 0.97 }],
+    tags_payload: [{ slug: 'cuisine-mexican', confidence: 0.99 }],
+    prices_payload: [{ size: null, price_cents: 450 }],
+    unresolved_ingredients: [],
+    unresolved_tags: [],
+  };
+
+  it('PATCHes /ingestion_runs/:run/items/:id with the decision', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+
+    await decideIngestionItem({
+      runId: 'rrrr-1111',
+      itemId: 'iiii-1111',
+      decision: 'accepted',
+      jwt: 'jwt-x',
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const calls = fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>;
+    const [url, init] = calls[0]!;
+    expect(url).toContain('/api/v1/ingestion_runs/rrrr-1111/items/iiii-1111');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body as string)).toEqual({ decision: 'accepted' });
+  });
+
+  it('includes edits payload when provided', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+
+    await decideIngestionItem({
+      runId: 'rrrr-1111',
+      itemId: 'iiii-1111',
+      decision: 'accepted',
+      edits: { name: 'Steak Taco', description: 'House-marinated.' },
+      jwt: 'jwt-x',
+      fetchImpl,
+    });
+
+    const calls = fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>;
+    const body = JSON.parse(calls[0]![1].body as string);
+    expect(body).toEqual({
+      decision: 'accepted',
+      name: 'Steak Taco',
+      description: 'House-marinated.',
+    });
+  });
+
+  it('throws IngestionUploadError on non-2xx', async () => {
+    const fetchImpl = fakeFetch(403, { error: 'forbidden' });
+
+    await expect(
+      decideIngestionItem({
+        runId: 'rrrr-1111',
+        itemId: 'iiii-1111',
+        decision: 'accepted',
+        jwt: 'no-good-jwt',
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(IngestionUploadError);
+  });
+});
+
+describe('getIngestionRun (poll target)', () => {
+  it('returns the run payload on 200', async () => {
+    const sample = {
+      id: 'rrrr-1111',
+      status: 'staged',
+      input_kind: 'photo',
+      restaurant_id: 'rest-1111',
+      state_history: { staged: '2026-04-30T00:00:00Z' },
+      failure_message: null,
+      api_cost_cents: 12,
+      latency_ms: 4500,
+      input_count: 2,
+      ingestion_items_count: 5,
+      created_at: '2026-04-30T00:00:00Z',
+      updated_at: '2026-04-30T00:00:00Z',
+    };
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => sample,
+    })) as unknown as typeof fetch;
+
+    const result = await getIngestionRun('rrrr-1111', { jwt: 'jwt-x', fetchImpl });
+    expect(result.status).toBe('staged');
+    expect(result.ingestion_items_count).toBe(5);
+  });
+});
+
+describe('listIngestionItems', () => {
+  it('unwraps the items array', async () => {
+    const sampleItems = [
+      {
+        id: 'i1',
+        ingestion_run_id: 'rrrr-1111',
+        item_id: null,
+        name: 'A',
+        description: null,
+        section_name: null,
+        decision: 'pending',
+        decided_at: null,
+        ingredients_payload: [],
+        tags_payload: [],
+        prices_payload: [],
+        unresolved_ingredients: [],
+        unresolved_tags: [],
+      },
+    ];
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: sampleItems }),
+    })) as unknown as typeof fetch;
+
+    const items = await listIngestionItems('rrrr-1111', { jwt: 'jwt-x', fetchImpl });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id).toBe('i1');
+  });
+});

--- a/apps/mobile/app/ingest/verify.tsx
+++ b/apps/mobile/app/ingest/verify.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import {
+  decideIngestionItem,
+  getIngestionRun,
+  listIngestionItems,
+  type IngestionItemPayload,
+  type IngestionRunPayload,
+} from '../../lib/api/ingestion-runs';
+
+const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Phase 2.7 — swipe-verify deck.
+ *
+ * Routed at `/ingest/verify?runId=...&jwt=...`. While the run is in
+ * `:queued / :extracting / :resolving`, polls every 2s. Once status
+ * hits `:staged`, fetches the items and shows a one-at-a-time card
+ * with Accept / Reject / Edit buttons.
+ *
+ * Phase 2.7 ships the tap-to-decide flow + the polling. The
+ * Tinder-style swipe gestures (react-native-gesture-handler +
+ * reanimated worklets) come in a follow-up after the on-device
+ * testing pass — the data wiring is what matters for end-to-end.
+ */
+export default function VerifyScreen() {
+  const params = useLocalSearchParams<{ runId?: string; jwt?: string }>();
+  const runId = params.runId ?? '';
+  const jwt = params.jwt ?? '';
+
+  const [run, setRun] = useState<IngestionRunPayload | null>(null);
+  const [items, setItems] = useState<IngestionItemPayload[]>([]);
+  const [cursor, setCursor] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+
+  // Poll the run until staged, then load items once.
+  useEffect(() => {
+    if (!runId || !jwt) return;
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      try {
+        const fresh = await getIngestionRun(runId, { jwt });
+        if (cancelled) return;
+        setRun(fresh);
+        if (fresh.status === 'staged' || fresh.status === 'published') {
+          const list = await listIngestionItems(runId, { jwt });
+          if (!cancelled) setItems(list.filter((it) => it.decision === 'pending'));
+          return;
+        }
+        if (fresh.status === 'failed') return;
+        timeoutId = setTimeout(poll, POLL_INTERVAL_MS);
+      } catch (e) {
+        if (cancelled) return;
+        Alert.alert('Polling error', (e as Error).message);
+      }
+    };
+
+    poll();
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [runId, jwt]);
+
+  const current = items[cursor];
+
+  const decide = useCallback(
+    async (decision: 'accepted' | 'rejected' | 'edited') => {
+      if (!current) return;
+      try {
+        const edits =
+          decision === 'edited' || decision === 'accepted'
+            ? { name: editName || current.name, description: editDescription || current.description || undefined }
+            : undefined;
+        await decideIngestionItem({
+          runId,
+          itemId: current.id,
+          decision,
+          edits,
+          jwt,
+        });
+        setCursor((i) => i + 1);
+        setEditing(false);
+        setEditName('');
+        setEditDescription('');
+      } catch (e) {
+        Alert.alert('Failed to record decision', (e as Error).message);
+      }
+    },
+    [current, runId, jwt, editName, editDescription],
+  );
+
+  if (!runId || !jwt) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.body}>Missing runId or jwt query params.</Text>
+      </View>
+    );
+  }
+
+  if (!run) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={colors.bite} testID="initial-loading" />
+        <Text style={styles.body}>Loading run…</Text>
+      </View>
+    );
+  }
+
+  if (run.status === 'failed') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.headline}>Extraction failed</Text>
+        <Text style={styles.body}>{run.failure_message}</Text>
+      </View>
+    );
+  }
+
+  if (run.status !== 'staged' && run.status !== 'published') {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={colors.bite} testID="extracting-loading" />
+        <Text style={styles.headline}>{run.status}…</Text>
+        <Text style={styles.body}>
+          Polling every {POLL_INTERVAL_MS / 1000}s. The deck opens as soon as the AI finishes.
+        </Text>
+      </View>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.headline}>Nothing to verify</Text>
+        <Text style={styles.body}>
+          Either every item is already decided, or the run produced no items.
+        </Text>
+      </View>
+    );
+  }
+
+  if (!current) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.headline}>All done!</Text>
+        <Text style={styles.body}>
+          You decided on {items.length} item{items.length === 1 ? '' : 's'}. The run will
+          auto-publish at the 80% threshold.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.eyebrow}>
+        Item {cursor + 1} of {items.length}
+      </Text>
+
+      <ScrollView style={styles.card} contentContainerStyle={{ gap: space['3'] }}>
+        <Text style={styles.headline} testID="card-name">
+          {current.name}
+        </Text>
+        {current.description ? (
+          <Text style={styles.body} testID="card-description">
+            {current.description}
+          </Text>
+        ) : null}
+        {current.section_name ? (
+          <Text style={styles.muted}>Section: {current.section_name}</Text>
+        ) : null}
+
+        <View style={styles.divider} />
+        <Text style={styles.label}>Ingredients</Text>
+        {current.ingredients_payload.map((ing) => (
+          <Text style={styles.row} key={ing.slug}>
+            • {ing.slug} ({Math.round(ing.confidence * 100)}%)
+          </Text>
+        ))}
+        {current.unresolved_ingredients.length > 0 && (
+          <Text style={styles.warn}>
+            Couldn't match: {current.unresolved_ingredients.join(', ')}
+          </Text>
+        )}
+
+        <View style={styles.divider} />
+        <Text style={styles.label}>Tags</Text>
+        {current.tags_payload.map((tag) => (
+          <Text style={styles.row} key={tag.slug}>
+            • {tag.slug} ({Math.round(tag.confidence * 100)}%)
+          </Text>
+        ))}
+        {current.unresolved_tags.length > 0 && (
+          <Text style={styles.warn}>
+            Couldn't match: {current.unresolved_tags.join(', ')}
+          </Text>
+        )}
+
+        {editing && (
+          <View style={{ gap: space['3'], marginTop: space['3'] }}>
+            <TextInput
+              accessibilityLabel="edit-name"
+              placeholder="Override name"
+              value={editName}
+              onChangeText={setEditName}
+              style={styles.input}
+            />
+            <TextInput
+              accessibilityLabel="edit-description"
+              placeholder="Override description"
+              value={editDescription}
+              onChangeText={setEditDescription}
+              multiline
+              style={[styles.input, { minHeight: 60 }]}
+            />
+          </View>
+        )}
+      </ScrollView>
+
+      <View style={styles.actions}>
+        <Pressable
+          accessibilityLabel="reject"
+          onPress={() => decide('rejected')}
+          style={[styles.actionButton, { backgroundColor: colors.danger }]}
+        >
+          <Text style={styles.actionText}>✗ Reject</Text>
+        </Pressable>
+        <Pressable
+          accessibilityLabel="edit"
+          onPress={() => {
+            if (editing) decide('edited');
+            else {
+              setEditName(current.name);
+              setEditDescription(current.description ?? '');
+              setEditing(true);
+            }
+          }}
+          style={[styles.actionButton, { backgroundColor: colors.warn }]}
+        >
+          <Text style={styles.actionText}>{editing ? '✎ Save edit' : '✎ Edit'}</Text>
+        </Pressable>
+        <Pressable
+          accessibilityLabel="accept"
+          onPress={() => decide('accepted')}
+          style={[styles.actionButton, { backgroundColor: colors.ok }]}
+        >
+          <Text style={styles.actionText}>✓ Accept</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 60,
+    paddingHorizontal: space['6'],
+    backgroundColor: colors.bg,
+    gap: space['3'],
+  },
+  eyebrow: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  card: {
+    flex: 1,
+    backgroundColor: colors.bgAlt,
+    borderRadius: 16,
+    padding: space['4'],
+  },
+  headline: {
+    fontSize: fontSize['2xl'],
+    fontWeight: '700',
+    color: colors.text,
+  },
+  body: {
+    fontSize: fontSize.base,
+    color: colors.text,
+  },
+  muted: {
+    color: colors.textMuted,
+    fontSize: fontSize.sm,
+  },
+  label: {
+    color: colors.textMuted,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  row: {
+    color: colors.text,
+    fontSize: fontSize.base,
+  },
+  warn: {
+    color: colors.warn,
+    fontSize: fontSize.sm,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginVertical: space['2'],
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: space['3'],
+    fontSize: fontSize.base,
+    color: colors.text,
+    backgroundColor: colors.bg,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: space['3'],
+    paddingVertical: space['4'],
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: space['4'],
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  actionText: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.base,
+  },
+});

--- a/apps/mobile/lib/api/ingestion-runs.ts
+++ b/apps/mobile/lib/api/ingestion-runs.ts
@@ -50,6 +50,117 @@ export class IngestionUploadError extends Error {
   }
 }
 
+export interface IngestionItemPayload {
+  id: string;
+  ingestion_run_id: string;
+  item_id: string | null;
+  name: string;
+  description: string | null;
+  section_name: string | null;
+  decision: 'pending' | 'accepted' | 'rejected' | 'edited';
+  decided_at: string | null;
+  ingredients_payload: Array<{ slug: string; confidence: number }>;
+  tags_payload: Array<{ slug: string; confidence: number }>;
+  prices_payload: Array<{ size: string | null; price_cents: number | null }>;
+  unresolved_ingredients: string[];
+  unresolved_tags: string[];
+}
+
+export interface FetchOptions {
+  jwt: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Poll-friendly read of the run state. Use to wait until status === "staged". */
+export async function getIngestionRun(
+  runId: string,
+  opts: FetchOptions,
+): Promise<IngestionRunPayload> {
+  const { jwt, fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/ingestion_runs/${runId}`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new IngestionUploadError(res.status, body);
+  }
+  return (await res.json()) as IngestionRunPayload;
+}
+
+/** List the staged items for the swipe deck. */
+export async function listIngestionItems(
+  runId: string,
+  opts: FetchOptions,
+): Promise<IngestionItemPayload[]> {
+  const { jwt, fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/ingestion_runs/${runId}/items`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new IngestionUploadError(res.status, body);
+  }
+  const json = (await res.json()) as { items: IngestionItemPayload[] };
+  return json.items;
+}
+
+export type Decision = 'accepted' | 'rejected' | 'edited';
+
+export interface DecideOptions extends FetchOptions {
+  runId: string;
+  itemId: string;
+  decision: Decision;
+  /** Edit overrides — applied before promotion. Optional. */
+  edits?: Partial<{
+    name: string;
+    description: string;
+    ingredients_payload: Array<{ slug: string; confidence: number }>;
+    tags_payload: Array<{ slug: string; confidence: number }>;
+  }>;
+}
+
+/**
+ * Update an ingestion item's decision. Accept fires promote! on the
+ * Rails side (materializes a real Item). Edit overrides apply BEFORE
+ * promotion, so the live Item carries the human's tweaks.
+ */
+export async function decideIngestionItem(
+  opts: DecideOptions,
+): Promise<IngestionItemPayload> {
+  const { runId, itemId, decision, edits, jwt, fetchImpl = fetch } = opts;
+  const res = await fetchImpl(
+    `${API_BASE}/api/v1/ingestion_runs/${runId}/items/${itemId}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ decision, ...edits }),
+    },
+  );
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new IngestionUploadError(res.status, body);
+  }
+  return (await res.json()) as IngestionItemPayload;
+}
+
 export async function uploadIngestionRun(opts: UploadOptions): Promise<IngestionRunPayload> {
   const { restaurantId, pages, jwt, fetchImpl = fetch } = opts;
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,10 +13,9 @@ the merge / review / status rules.
 
 **Phase 2** ⭐ AI ingestion MVP. Subplan: `docs/plans/phase-2.md`. This batch is **proposed by the loop** (this PR is the plan-update PR); humans review it before the items auto-run.
 
-1. **Phase 2.6 — Mobile multi-page camera capture + upload** (`docs/plans/phase-2.md#26`) — this PR
-2. **Phase 2.7 — Mobile swipe-verify UI** (`docs/plans/phase-2.md#27`)
-3. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`)
-4. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
+1. **Phase 2.7 — Mobile swipe-verify UI** (`docs/plans/phase-2.md#27`) — this PR
+2. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`)
+3. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
 
 ### Done
 
@@ -34,6 +33,7 @@ the merge / review / status rules.
 - ✅ Phase 2.3 — ExtractMenuJob + ActiveStorage wiring (#138)
 - ✅ Phase 2.4 — ResolveIngredients + ResolveTags jobs (#139)
 - ✅ Phase 2.5 — admin verify UI + 80%-accepted publish (#140)
+- ✅ Phase 2.6 — mobile camera + ingestion runs API (#141)
 
 After Phase 2 ships, the loop will draft `docs/plans/phase-3.md` (dietary filter UI) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,32 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 01:45 — tick #47. PR #141 (Phase 2.6) merged at 00:22 UTC.
+Picked up Phase 2.7 — swipe-verify UI + ingestion-item PATCH/INDEX
+endpoints. API: new `Api::V1::IngestionItemsController` with #index
+(list run's items) + #update (PATCH decision). Update validates
+decision ∈ {pending,accepted,rejected,edited}, applies edit overrides
+(name/description/payloads) before promote!, fires
+maybe_publish! after every decision. Routes nested under
+`ingestion_runs/:run_id/items`. Bug caught locally:
+`ActionController::Parameters` doesn't have `#any?` — switched to
+`params.to_h.any?`. 10 request specs covering happy/edit/reject/
+auth/validation/threshold-trigger paths.
+
+Mobile: extended `lib/api/ingestion-runs.ts` with `getIngestionRun`,
+`listIngestionItems`, `decideIngestionItem`. New screen
+`app/ingest/verify.tsx`: polls run state every 2s while
+extracting/resolving, opens a one-card-at-a-time deck on :staged,
+Accept/Edit/Reject buttons with full decision wiring. Deferred:
+Tinder-style swipe gestures (gesture-handler/reanimated) — the
+data wiring is what matters for end-to-end; gestures are pure
+visual sugar best added during on-device polish. 5 new Jest tests
+(decideIngestionItem PATCH shape + edits + error path,
+getIngestionRun, listIngestionItems).
+
+Local: rspec 136/136 (1 pending), pnpm typecheck/lint/test all
+green. Pushing PR.
+
 2026-05-01 01:00 — tick #46. PR #140 (Phase 2.5) merged at 23:49 UTC.
 Picked up Phase 2.6 — mobile camera + upload. Two surfaces in one PR:
 


### PR DESCRIPTION
## Why

Phase 2.7 of the v2 delivery plan — `docs/plans/phase-2.md#27`. Closes the loop on mobile-side ingestion. After Phase 2.6 captures + uploads pages, this PR adds the polling + verify deck so an admin can accept / reject / edit each item end-to-end on mobile.

## What

### API (`apps/api`)

New `Api::V1::IngestionItemsController`:

| Action | Route | Notes |
|---|---|---|
| `index` | `GET /api/v1/ingestion_runs/:run_id/items` | Lists every IngestionItem for the run; mobile deck uses this once status hits `:staged`. |
| `update` | `PATCH /api/v1/ingestion_runs/:run_id/items/:id` | Validates `decision ∈ DECISIONS`, applies optional edit overrides BEFORE promotion (so the materialized Item carries human tweaks). Accept fires `IngestionItem#promote!`; **every decision** fires `IngestionRun#maybe_publish!` so the 80% threshold check runs after each swipe. |

Nested under `resources :ingestion_runs do; resources :items end` with `controller: "ingestion_items"` so it doesn't collide with the existing `/restaurants/:id/items` resource.

Edit overrides accepted: `name`, `description`, `ingredients_payload`, `tags_payload`, `unresolved_ingredients`, `unresolved_tags`.

**Bug caught locally**: `ActionController::Parameters` doesn't have `#any?` — fixed with `params.to_h.any?`.

### Mobile (`apps/mobile`)

Extended `lib/api/ingestion-runs.ts`:

- `getIngestionRun(runId, {jwt})` for the polling loop.
- `listIngestionItems(runId, {jwt})` returns the deck data.
- `decideIngestionItem({runId, itemId, decision, edits, jwt})` PATCHes with optional edit overrides.

New screen `app/ingest/verify.tsx`:

- Polls `getIngestionRun` every 2s while status is `queued`/`extracting`/`resolving`.
- Once `:staged`, fetches the items + opens a **one-card-at-a-time deck** showing name, description, ingredients/tags with confidence %, and unresolved strings.
- Three buttons: **✗ Reject**, **✎ Edit** (toggles inline name/description inputs, second tap saves edited), **✓ Accept** (PATCHes decision + advances cursor).

### Specs

- **10 API request specs** at `spec/requests/api/v1/ingestion_items_api_spec.rb` covering happy / edit / reject / auth (401/403) / validation / threshold-trigger paths.
- **5 mobile Jest tests** at `__tests__/lib/decide-ingestion-item.test.ts` covering `decideIngestionItem` PATCH shape + edits + error path, `getIngestionRun`, `listIngestionItems`.

## Test plan

- [ ] CI · API rspec green (10 new + 126 prior = 136 examples, 1 pending).
- [ ] CI · JS typecheck/lint/test green; mobile suite goes from 4 → 9 tests.
- [ ] Local rspec confirmed 136/136.
- [ ] Manual sanity (deferred to on-device pass): from `/ingest`, capture pages + upload → navigate to `/ingest/verify?runId=...&jwt=...` → wait while extracting → deck appears → accept all → restaurant + run flip to `:published` at the threshold.

## Notes

- **Swipe gestures deferred.** A real Tinder-style deck needs `react-native-gesture-handler` + `react-native-reanimated` worklets. The tap-to-decide deck in this PR uses the **same decision API** — the data wiring is what matters for end-to-end. Gesture polish belongs with the on-device testing pass.
- **Polling, not websockets.** Phase 2 stays simple with a 2-second poll. Phase 3 will likely move to Solid Cable for instant push when `:staged` lands.
- **End-to-end flow now functional with mocks**: capture (2.6) → upload (2.6) → extract (2.3, mocked) → resolve (2.4, mocked) → stage (2.4) → verify deck (this PR) → promote (2.5) → publish (2.5). Cassette gap from 2.3+2.4 is the only thing between this and live demo-ready ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)