### PR TITLE
feat(api,web): web URL/PDF ingestion entrypoint (phase 2.8)

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
@@ -13,22 +13,19 @@ module Api
 
       def create
         restaurant = Restaurant.find(params.require(:restaurant_id))
-        files      = Array(params[:inputs])
+        files      = Array(params[:inputs]).reject(&:blank?)
+        source_url = params[:source_url].to_s.presence
 
-        if files.empty?
+        if files.empty? && source_url.nil?
           render json: { error: "no_inputs" }, status: :unprocessable_entity
           return
         end
 
-        run = IngestionRun.create!(
-          user:       current_user,
-          restaurant: restaurant,
-          input_kind: detect_input_kind(files.first)
-        )
-        run.inputs.attach(files)
-        run.transition_to!(:extracting)
-
-        render json: serialize_run(run), status: :created
+        if source_url
+          create_from_url(restaurant, source_url)
+        else
+          create_from_files(restaurant, files)
+        end
       end
 
       def show
@@ -42,6 +39,39 @@ module Api
       end
 
       private
+
+      def create_from_files(restaurant, files)
+        run = IngestionRun.create!(
+          user:       current_user,
+          restaurant: restaurant,
+          input_kind: detect_input_kind(files.first)
+        )
+        run.inputs.attach(files)
+        run.transition_to!(:extracting)
+
+        render json: serialize_run(run), status: :created
+      end
+
+      def create_from_url(restaurant, source_url)
+        result = UrlFetcher.fetch(source_url)
+        run = IngestionRun.create!(
+          user:       current_user,
+          restaurant: restaurant,
+          input_kind: result.content_type.include?("pdf") ? "pdf" : "url",
+          source_url: source_url
+        )
+        run.inputs.attach(
+          io:           result.io,
+          filename:     result.filename,
+          content_type: result.content_type
+        )
+        run.transition_to!(:extracting)
+
+        render json: serialize_run(run), status: :created
+      rescue UrlFetcher::FetchError => e
+        render json: { error: "url_fetch_failed", reason: e.reason, status: e.status },
+               status: :unprocessable_entity
+      end
 
       def ensure_admin!
         return if current_user&.is_admin?

--- a/apps/api/app/services/url_fetcher.rb
+++ b/apps/api/app/services/url_fetcher.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Phase 2.8 — fetch a remote menu URL (HTML or PDF) and return
+# enough info for the controller to attach as an ActiveStorage blob.
+#
+# Anthropic vision handles PDFs directly, so for PDF responses we
+# pass the bytes through. For HTML pages, the bytes pass through too
+# — Anthropic's vision API also accepts HTML when wrapped as a
+# document, and Phase 2 isn't trying to do JS-rendered scraping.
+#
+# Hard limits:
+#   * 10 MB max — protects the API server from accidentally fetching
+#     a multi-hundred-meg PDF.
+#   * Follows up to 3 redirects.
+#   * 15-second timeout.
+class UrlFetcher
+  MAX_BYTES   = 10 * 1024 * 1024
+  TIMEOUT_SEC = 15
+
+  class FetchError < StandardError
+    attr_reader :status, :reason
+    def initialize(reason, status: nil)
+      @reason = reason
+      @status = status
+      super("UrlFetcher: #{reason}#{status ? " (status #{status})" : ''}")
+    end
+  end
+
+  Result = Struct.new(:io, :content_type, :filename, :byte_size, keyword_init: true)
+
+  def self.fetch(url, conn: nil)
+    new(conn: conn).fetch(url)
+  end
+
+  def initialize(conn: nil)
+    @conn = conn || default_connection
+  end
+
+  def fetch(url)
+    raise FetchError.new("invalid_url") unless url.to_s.match?(/\Ahttps?:\/\//)
+
+    response = @conn.get(url)
+    unless (200..299).cover?(response.status)
+      raise FetchError.new("non_2xx", status: response.status)
+    end
+
+    body = response.body.to_s
+    if body.bytesize > MAX_BYTES
+      raise FetchError.new("response_too_large")
+    end
+
+    Result.new(
+      io:           StringIO.new(body),
+      content_type: detect_content_type(response, body),
+      filename:     filename_for(url, response),
+      byte_size:    body.bytesize
+    )
+  end
+
+  private
+
+  def default_connection
+    Faraday.new do |f|
+      f.request  :retry, max: 2,
+                          interval: 0.5,
+                          backoff_factor: 2,
+                          retry_statuses: [429, 500, 502, 503, 504],
+                          methods: %i[get]
+      f.response :follow_redirects, limit: 3
+      f.options.timeout = TIMEOUT_SEC
+      f.options.open_timeout = TIMEOUT_SEC
+      f.adapter Faraday.default_adapter
+    end
+  rescue NameError, LoadError
+    # `follow_redirects` middleware is in faraday-follow_redirects (a
+    # separate gem). If unavailable, fall back to a plain connection;
+    # callers that need redirects can supply their own conn:.
+    Faraday.new do |f|
+      f.options.timeout = TIMEOUT_SEC
+      f.options.open_timeout = TIMEOUT_SEC
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def detect_content_type(response, body)
+    header = response.headers["content-type"].to_s.split(";").first&.strip
+    return header if header.present?
+
+    # Sniff PDF magic bytes when the server didn't tell us.
+    body.start_with?("%PDF") ? "application/pdf" : "text/html"
+  end
+
+  def filename_for(url, response)
+    raw  = File.basename(URI.parse(url).path)
+    name = raw.presence && raw != "/" ? raw : "menu"
+
+    if response.headers["content-type"].to_s.include?("pdf") && !name.end_with?(".pdf")
+      name = "#{name}.pdf"
+    end
+    name = "#{name}.html" unless name.include?(".")
+    name
+  end
+end

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -80,6 +80,64 @@ RSpec.describe "Ingestion runs API", type: :request do
       expect(response).to have_http_status(:created)
       expect(response.parsed_body["input_kind"]).to eq("pdf")
     end
+
+    context "with source_url (Phase 2.8)" do
+      let(:menu_url) { "https://durango-restaurants.example/cream-bean-berry/menu" }
+
+      it "fetches the URL, attaches the response, and 201s with input_kind=url for HTML" do
+        allow(ExtractMenuJob).to receive(:perform_later)
+        stub_request(:get, menu_url).to_return(
+          status: 200,
+          body: "<html>menu html</html>",
+          headers: { "Content-Type" => "text/html" }
+        )
+
+        expect {
+          post "/api/v1/ingestion_runs",
+               params: { restaurant_id: restaurant.id, source_url: menu_url },
+               headers: auth_for(admin)
+        }.to change(IngestionRun, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body
+        expect(body["input_kind"]).to    eq("url")
+        expect(body["input_count"]).to   eq(1)
+
+        run = IngestionRun.last
+        expect(run.source_url).to eq(menu_url)
+        expect(run.inputs).to be_attached
+      end
+
+      it "uses input_kind=pdf when the URL serves a PDF" do
+        allow(ExtractMenuJob).to receive(:perform_later)
+        stub_request(:get, "#{menu_url}.pdf").to_return(
+          status: 200,
+          body: "%PDF-1.4 fake",
+          headers: { "Content-Type" => "application/pdf" }
+        )
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id, source_url: "#{menu_url}.pdf" },
+             headers: auth_for(admin)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body["input_kind"]).to eq("pdf")
+      end
+
+      it "422s when the upstream URL returns non-2xx" do
+        stub_request(:get, menu_url).to_return(status: 503)
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id, source_url: menu_url },
+             headers: auth_for(admin)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        body = response.parsed_body
+        expect(body["error"]).to  eq("url_fetch_failed")
+        expect(body["reason"]).to eq("non_2xx")
+        expect(body["status"]).to eq(503)
+      end
+    end
   end
 
   describe "GET /api/v1/ingestion_runs/:id" do

--- a/apps/api/spec/services/url_fetcher_spec.rb
+++ b/apps/api/spec/services/url_fetcher_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe UrlFetcher do
+  describe ".fetch" do
+    let(:url) { "https://example.com/menu" }
+
+    it "returns the body wrapped in a Result with content_type from headers" do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: "<html>menu html</html>",
+        headers: { "Content-Type" => "text/html; charset=utf-8" }
+      )
+
+      result = described_class.fetch(url)
+
+      expect(result.io.read).to eq("<html>menu html</html>")
+      expect(result.content_type).to eq("text/html")
+      expect(result.byte_size).to eq("<html>menu html</html>".bytesize)
+    end
+
+    it "sniffs PDF magic bytes when the server omits content-type" do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: "%PDF-1.4 fake bytes",
+        headers: {}
+      )
+
+      result = described_class.fetch(url)
+
+      expect(result.content_type).to eq("application/pdf")
+    end
+
+    it "rejects non-2xx responses with FetchError" do
+      stub_request(:get, url).to_return(status: 404, body: "missing")
+
+      expect { described_class.fetch(url) }
+        .to raise_error(UrlFetcher::FetchError) { |e|
+          expect(e.reason).to eq("non_2xx")
+          expect(e.status).to eq(404)
+        }
+    end
+
+    it "rejects responses larger than MAX_BYTES" do
+      stub_request(:get, url).to_return(status: 200, body: "x" * (described_class::MAX_BYTES + 1))
+
+      expect { described_class.fetch(url) }
+        .to raise_error(UrlFetcher::FetchError, /response_too_large/)
+    end
+
+    it "rejects non-http(s) URLs without making a request" do
+      expect { described_class.fetch("file:///etc/passwd") }
+        .to raise_error(UrlFetcher::FetchError, /invalid_url/)
+    end
+
+    it "infers a sensible filename from the URL path" do
+      stub_request(:get, "https://example.com/menus/dinner.pdf").to_return(
+        status: 200,
+        body: "%PDF",
+        headers: { "Content-Type" => "application/pdf" }
+      )
+
+      result = described_class.fetch("https://example.com/menus/dinner.pdf")
+
+      expect(result.filename).to eq("dinner.pdf")
+    end
+
+    it "falls back to 'menu.html' when the URL has no path tail" do
+      stub_request(:get, "https://example.com/").to_return(
+        status: 200,
+        body: "<html></html>",
+        headers: { "Content-Type" => "text/html" }
+      )
+
+      expect(described_class.fetch("https://example.com/").filename).to eq("menu.html")
+    end
+  end
+end

--- a/apps/web/src/app/ingest/page.tsx
+++ b/apps/web/src/app/ingest/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import {
+  ingestFromFile,
+  ingestFromUrl,
+  type IngestionRunPayload,
+} from '../../lib/ingestion';
+
+/**
+ * Phase 2.8 — admin entrypoint for AI ingestion via web.
+ *
+ * Two parallel ways to start a run:
+ *   1. Paste a restaurant menu URL (HTML or PDF). Server-side
+ *      `UrlFetcher` downloads it and attaches the body.
+ *   2. Drop a PDF file. Same backend pipeline from the multipart side.
+ *
+ * Either way, the response carries the IngestionRun id; admin then
+ * polls `/admin` (Avo) or, eventually, a follow-up web verify view
+ * that mirrors the mobile swipe deck (out of scope for 2.8).
+ */
+export default function IngestPage() {
+  const [restaurantId, setRestaurantId] = useState('');
+  const [jwt, setJwt] = useState('');
+  const [sourceUrl, setSourceUrl] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<IngestionRunPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (mode: 'url' | 'file') => {
+    setError(null);
+    setResult(null);
+    if (!restaurantId || !jwt) {
+      setError('Restaurant id + JWT are required.');
+      return;
+    }
+    if (mode === 'url' && !sourceUrl) {
+      setError('Paste a URL.');
+      return;
+    }
+    if (mode === 'file' && !file) {
+      setError('Drop a file.');
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const run =
+        mode === 'url'
+          ? await ingestFromUrl({ restaurantId, sourceUrl, jwt })
+          : await ingestFromFile({ restaurantId, file: file!, jwt });
+      setResult(run);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-8 p-6">
+      <header>
+        <p className="text-sm font-semibold uppercase tracking-widest text-orange-600">
+          Ingest a menu
+        </p>
+        <h1 className="mt-1 text-3xl font-bold">Web upload entrypoint</h1>
+        <p className="mt-2 text-zinc-600">
+          Paste a restaurant menu URL OR drop a PDF. Either way, the AI extracts the
+          items and stages them for swipe-verify in <code>/admin</code>.
+        </p>
+      </header>
+
+      <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
+        <label className="block">
+          <span className="text-sm font-medium text-zinc-700">Restaurant UUID</span>
+          <input
+            type="text"
+            value={restaurantId}
+            onChange={(e) => setRestaurantId(e.target.value)}
+            className="mt-1 w-full rounded border border-zinc-300 px-3 py-2 font-mono text-sm"
+            placeholder="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-zinc-700">JWT</span>
+          <input
+            type="password"
+            value={jwt}
+            onChange={(e) => setJwt(e.target.value)}
+            className="mt-1 w-full rounded border border-zinc-300 px-3 py-2 font-mono text-sm"
+            placeholder="paste the bearer token from /api/v1/auth/login"
+          />
+        </label>
+      </section>
+
+      <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
+        <h2 className="text-lg font-semibold">From a URL</h2>
+        <form
+          onSubmit={(e: FormEvent) => {
+            e.preventDefault();
+            void submit('url');
+          }}
+          className="space-y-3"
+        >
+          <input
+            type="url"
+            value={sourceUrl}
+            onChange={(e) => setSourceUrl(e.target.value)}
+            placeholder="https://restaurant.example/menu"
+            className="w-full rounded border border-zinc-300 px-3 py-2"
+          />
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded bg-orange-600 px-4 py-2 font-semibold text-white disabled:opacity-50"
+          >
+            {submitting ? 'Submitting…' : 'Scrape this URL'}
+          </button>
+        </form>
+      </section>
+
+      <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
+        <h2 className="text-lg font-semibold">Or drop a PDF</h2>
+        <input
+          type="file"
+          accept="application/pdf,image/*"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="block"
+        />
+        <button
+          type="button"
+          onClick={() => void submit('file')}
+          disabled={submitting}
+          className="rounded bg-orange-600 px-4 py-2 font-semibold text-white disabled:opacity-50"
+        >
+          {submitting ? 'Uploading…' : 'Upload file'}
+        </button>
+      </section>
+
+      {error && (
+        <div className="rounded border border-red-300 bg-red-50 p-4 text-red-900" role="alert">
+          {error}
+        </div>
+      )}
+      {result && (
+        <div className="rounded border border-green-300 bg-green-50 p-4 text-green-900" role="status">
+          <p>
+            Run <code>{result.id}</code> → <strong>{result.status}</strong> (
+            {result.input_kind})
+          </p>
+          <p className="mt-1 text-sm">
+            Find it in /admin/resources/ingestion_runs.
+          </p>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/lib/__tests__/ingestion.test.ts
+++ b/apps/web/src/lib/__tests__/ingestion.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ingestFromFile,
+  ingestFromUrl,
+  IngestionRequestError,
+  type IngestionRunPayload,
+} from '../ingestion';
+
+const sampleRun: IngestionRunPayload = {
+  id: 'rrrr-1111',
+  status: 'extracting',
+  input_kind: 'url',
+  restaurant_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  state_history: { extracting: '2026-04-30T01:00:00Z' },
+  failure_message: null,
+  api_cost_cents: 0,
+  latency_ms: null,
+  input_count: 1,
+  ingestion_items_count: 0,
+  created_at: '2026-04-30T01:00:00Z',
+  updated_at: '2026-04-30T01:00:00Z',
+};
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(async () =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Response,
+  );
+}
+
+describe('ingestFromUrl', () => {
+  it('POSTs JSON body with restaurant_id + source_url and returns the run', async () => {
+    const fetchImpl = fakeFetch(201, sampleRun);
+
+    const result = await ingestFromUrl({
+      restaurantId: 'rest-1',
+      sourceUrl: 'https://restaurant.example/menu',
+      jwt: 'jwt-x',
+      fetchImpl,
+    });
+
+    expect(result.id).toBe(sampleRun.id);
+    const calls = fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>;
+    const [url, init] = calls[0]!;
+    expect(url).toContain('/api/v1/ingestion_runs');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer jwt-x',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      restaurant_id: 'rest-1',
+      source_url: 'https://restaurant.example/menu',
+    });
+  });
+
+  it('throws IngestionRequestError carrying status + parsed body on failure', async () => {
+    const fetchImpl = fakeFetch(422, { error: 'url_fetch_failed', reason: 'non_2xx', status: 503 });
+
+    await expect(
+      ingestFromUrl({
+        restaurantId: 'rest-1',
+        sourceUrl: 'https://broken.example/menu',
+        jwt: 'jwt-x',
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+      body: { error: 'url_fetch_failed', reason: 'non_2xx', status: 503 },
+    });
+  });
+});
+
+describe('ingestFromFile', () => {
+  it('POSTs multipart with the file under inputs[]', async () => {
+    const fetchImpl = fakeFetch(201, { ...sampleRun, input_kind: 'pdf' });
+    const file = new File(['%PDF-1.4'], 'menu.pdf', { type: 'application/pdf' });
+
+    const result = await ingestFromFile({
+      restaurantId: 'rest-1',
+      file,
+      jwt: 'jwt-x',
+      fetchImpl,
+    });
+
+    expect(result.input_kind).toBe('pdf');
+    const calls = fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>;
+    const [, init] = calls[0]!;
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer jwt-x' });
+    // No Content-Type — let fetch set the multipart boundary itself.
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    expect(init.body).toBeInstanceOf(FormData);
+  });
+
+  it('returns a typed IngestionRequestError on non-JSON 5xx', async () => {
+    const fetchImpl = vi.fn(async () =>
+      ({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error('not json');
+        },
+      }) as unknown as Response,
+    );
+    const file = new File(['x'], 'x.pdf', { type: 'application/pdf' });
+
+    await expect(
+      ingestFromFile({
+        restaurantId: 'rest-1',
+        file,
+        jwt: 'jwt-x',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toBeInstanceOf(IngestionRequestError);
+  });
+});

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -1,0 +1,91 @@
+/**
+ * Phase 2.8 — web client for `POST /api/v1/ingestion_runs`.
+ * Supports both source-URL and file-upload (PDF) modes.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export interface IngestionRunPayload {
+  id: string;
+  status: 'queued' | 'extracting' | 'resolving' | 'staged' | 'published' | 'failed';
+  input_kind: 'photo' | 'url' | 'pdf';
+  restaurant_id: string;
+  state_history: Record<string, string>;
+  failure_message: string | null;
+  api_cost_cents: number;
+  latency_ms: number | null;
+  input_count: number;
+  ingestion_items_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IngestionApiError {
+  error: string;
+  reason?: string;
+  status?: number;
+}
+
+export class IngestionRequestError extends Error {
+  status: number;
+  body: IngestionApiError | null;
+  constructor(status: number, body: IngestionApiError | null) {
+    super(`Ingestion request failed: ${status}${body?.error ? ` (${body.error})` : ''}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function postIngestionRun(
+  body: BodyInit,
+  jwt: string,
+  fetchImpl: typeof fetch,
+  isMultipart: boolean,
+): Promise<IngestionRunPayload> {
+  const headers: Record<string, string> = { Authorization: `Bearer ${jwt}` };
+  if (!isMultipart) headers['Content-Type'] = 'application/json';
+
+  const res = await fetchImpl(`${API_BASE}/api/v1/ingestion_runs`, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  if (!res.ok) {
+    let parsed: IngestionApiError | null = null;
+    try {
+      parsed = (await res.json()) as IngestionApiError;
+    } catch {
+      // ignore
+    }
+    throw new IngestionRequestError(res.status, parsed);
+  }
+  return (await res.json()) as IngestionRunPayload;
+}
+
+export async function ingestFromUrl(opts: {
+  restaurantId: string;
+  sourceUrl: string;
+  jwt: string;
+  fetchImpl?: typeof fetch;
+}): Promise<IngestionRunPayload> {
+  const { restaurantId, sourceUrl, jwt, fetchImpl = fetch } = opts;
+  return postIngestionRun(
+    JSON.stringify({ restaurant_id: restaurantId, source_url: sourceUrl }),
+    jwt,
+    fetchImpl,
+    false,
+  );
+}
+
+export async function ingestFromFile(opts: {
+  restaurantId: string;
+  file: File;
+  jwt: string;
+  fetchImpl?: typeof fetch;
+}): Promise<IngestionRunPayload> {
+  const { restaurantId, file, jwt, fetchImpl = fetch } = opts;
+  const form = new FormData();
+  form.append('restaurant_id', restaurantId);
+  form.append('inputs[]', file, file.name);
+  return postIngestionRun(form, jwt, fetchImpl, true);
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,9 +13,8 @@ the merge / review / status rules.
 
 **Phase 2** ⭐ AI ingestion MVP. Subplan: `docs/plans/phase-2.md`. This batch is **proposed by the loop** (this PR is the plan-update PR); humans review it before the items auto-run.
 
-1. **Phase 2.7 — Mobile swipe-verify UI** (`docs/plans/phase-2.md#27`) — this PR
-2. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`)
-3. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
+1. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`) — this PR
+2. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
 
 ### Done
 
@@ -34,6 +33,7 @@ the merge / review / status rules.
 - ✅ Phase 2.4 — ResolveIngredients + ResolveTags jobs (#139)
 - ✅ Phase 2.5 — admin verify UI + 80%-accepted publish (#140)
 - ✅ Phase 2.6 — mobile camera + ingestion runs API (#141)
+- ✅ Phase 2.7 — mobile swipe-verify UI + ingestion item PATCH (#142)
 
 After Phase 2 ships, the loop will draft `docs/plans/phase-3.md` (dietary filter UI) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,34 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 02:25 — tick #48. PR #142 (Phase 2.7) merged at 00:48 UTC.
+Picked up Phase 2.8 — web URL/PDF entrypoint. New `UrlFetcher`
+service: faraday GET with 15s timeout, 10MB max bytes, sniffs PDF
+magic bytes when content-type is missing, raises
+`UrlFetcher::FetchError(reason:, status:)` on non-2xx / oversize /
+invalid scheme. Updated `Api::V1::IngestionRunsController#create`
+to branch on `inputs[]` (multipart) vs `source_url` (URL-fetch
+path), populating `input_kind` (url|pdf) accordingly. Bug caught
+locally: `File.basename("/")` returns `"/"` → my filename
+fallback produced `"/.html"` instead of `"menu.html"`.
+
+Web: `apps/web/src/lib/ingestion.ts` exposes `ingestFromUrl`
+(JSON body) + `ingestFromFile` (multipart FormData) + a typed
+`IngestionRequestError`. New page at `apps/web/src/app/ingest/page.tsx`
+('use client', Tailwind-styled): restaurant_id + JWT inputs +
+two side-by-side panels (URL submit / file dropzone), success
+panel links to `/admin/resources/ingestion_runs`.
+
+Specs: 7 URL-fetcher specs (header content-type, magic-byte sniff,
+404 + oversize + invalid-scheme rejection, filename inference) +
+3 new controller specs (URL happy path HTML, URL happy path PDF,
+422 on upstream non-2xx) = 10 new Rails specs. 4 web vitest tests
+(ingestFromUrl POST shape + error, ingestFromFile multipart +
+non-JSON error path).
+
+Local: rspec 146/146 (1 pending), pnpm typecheck/lint/test all
+green. Pushing PR.
+
 2026-05-01 01:45 — tick #47. PR #141 (Phase 2.6) merged at 00:22 UTC.
 Picked up Phase 2.7 — swipe-verify UI + ingestion-item PATCH/INDEX
 endpoints. API: new `Api::V1::IngestionItemsController` with #index


### PR DESCRIPTION
## Why

Phase 2.8 of the v2 delivery plan — `docs/plans/phase-2.md#28`. Adds the second entrypoint for AI ingestion (after Phase 2.6's mobile camera): an admin-gated web page that takes either a restaurant menu URL or a PDF upload and feeds it into the same backend pipeline.

## What

### API (`apps/api`)

- **`UrlFetcher` service** — Faraday GET with 15s timeout, 10MB max bytes, sniffs PDF magic bytes when `Content-Type` is missing, raises `UrlFetcher::FetchError(reason:, status:)` on non-2xx / oversize / invalid scheme. Filename inferred from URL path (`menu.html` fallback when there's no path tail).
- **`Api::V1::IngestionRunsController#create`** now branches on `inputs[]` (multipart, existing) vs `source_url` (URL-fetch, new). URL path stores the fetched bytes via ActiveStorage and records `source_url` on the run. `input_kind` becomes `pdf` when the response is PDF, else `url`.
- **Bug caught locally**: `File.basename("/")` returns `"/"`, so the filename fallback was producing `"/.html"` instead of `"menu.html"`. Fixed by checking `raw == "/"` explicitly.

### Web (`apps/web`)

- **`src/lib/ingestion.ts`** — typed `ingestFromUrl({ restaurantId, sourceUrl, jwt })` (JSON body) + `ingestFromFile({ ..., file })` (multipart FormData). Shared `IngestionRequestError` carries status + parsed body.
- **`src/app/ingest/page.tsx`** — `'use client'` page at `/ingest` with Tailwind layout. Restaurant ID + JWT inputs; two side-by-side panels (URL submit form / file dropzone with PDF accept). On 201 surfaces the run id + a link to `/admin/resources/ingestion_runs`.

### Specs

- **7 URL-fetcher specs**: header content-type, magic-byte sniff, 404 + oversize + invalid-scheme rejection, filename inference.
- **3 new controller specs**: URL happy path HTML, URL happy path PDF, 422 on upstream non-2xx (returns `{ error: "url_fetch_failed", reason: "non_2xx", status: 503 }`).
- **4 web vitest tests**: ingestFromUrl POST shape + error path, ingestFromFile multipart + non-JSON error survival.

## Test plan

- [ ] CI · API rspec green (10 new + 136 prior = 146 examples, 1 pending).
- [ ] CI · JS typecheck/lint/test green; web vitest goes from 0 → 4 tests.
- [ ] Local rspec confirmed 146/146.
- [ ] Manual sanity (deferred to bench testing): `cd apps/web && pnpm dev` → `http://localhost:3001/ingest`, paste a real Durango menu URL + JWT → 201 → run shows up in `/admin/resources/ingestion_runs` with `input_kind: url`.

## Notes

- **JWT-in-input is a hack** — same one as Phase 2.6/2.7. Phase 4 wires real web auth (cookie session on top of the JWT pair); until then `/ingest` is admin-bench-only.
- **No web-side verify/swipe deck**: per phase-2.md, the web surface in 2.8 is the entrypoint only; admins verify via `/admin` (Avo, from 2.5). A web-side swipe deck mirroring the mobile one can land in Phase 3 if mobile-only verify proves insufficient for web menu uploads.
- **Pipeline status post-merge**: web URL/PDF → extract → resolve → stage → admin verify → publish all functional with mocked AI clients. Cassette gap from 2.3+2.4 still the only thing between this and live demo-ready ingestion.
- Phase 2.9 (cost dashboard) is the last task; after it ships, the loop drafts the Phase 3 plan PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)