### PR TITLE
feat(api): cost + latency dashboard at /admin/dashboard (phase 2.9)

### DIFF
--- a/apps/api/app/controllers/admin/dashboard_controller.rb
+++ b/apps/api/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,37 @@
+module Admin
+  # Phase 2.9 cost + latency dashboard at /admin/dashboard.
+  #
+  # Hand-rolled instead of an Avo Pro Dashboard (Community license
+  # only — see Phase 1.5). Mounted at the same `/admin` prefix and
+  # gated by the same HTTP Basic credentials Avo uses, so navigating
+  # in from `/admin` is seamless.
+  #
+  # Inherits from ActionController::Base (not ::API) because we
+  # render an ERB template; the rest of the app stays api_only.
+  class DashboardController < ActionController::Base
+    layout false # keep it self-contained — no app-wide layout file
+
+    before_action :require_admin_basic_auth!
+
+    def index
+      @metrics       = Ingestion::CostMetrics.by_period
+      @target_target = Ingestion::CostMetrics::TARGET_CENTS_PER_ITEM
+    end
+
+    private
+
+    # Reuses the same env vars the Avo initializer reads (Phase 1.5).
+    # Keeping the gate logic local to this controller — Avo doesn't
+    # expose a "run my own request through your auth check" hook in
+    # Community, so we duplicate the few lines here.
+    def require_admin_basic_auth!
+      expected_user     = ENV.fetch("ADMIN_USERNAME", "admin")
+      expected_password = ENV.fetch("ADMIN_PASSWORD", "admin")
+
+      authenticate_or_request_with_http_basic("BiteWorthy Admin") do |user, password|
+        ActiveSupport::SecurityUtils.secure_compare(user,     expected_user) &&
+          ActiveSupport::SecurityUtils.secure_compare(password, expected_password)
+      end
+    end
+  end
+end

--- a/apps/api/app/services/ingestion/cost_metrics.rb
+++ b/apps/api/app/services/ingestion/cost_metrics.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Phase 2.9 — aggregations behind the /admin/dashboard cost view.
+#
+# All numbers come straight from the IngestionRun columns Phase 2.3
+# added (api_cost_cents / latency_ms / cached_input_tokens /
+# uncached_input_tokens). Kept as a separate service so the spec
+# can test the math without rendering HTML.
+#
+# Target line: $0.25 per 50-item menu = 0.5¢ per item. Anything
+# above this in the dashboard's per-item-cost row should raise an
+# eyebrow.
+module Ingestion
+  class CostMetrics
+    TARGET_CENTS_PER_ITEM = 0.5  # $0.25 / 50 items
+
+    PERIODS = {
+      today:        { label: "Today",        range: -> { Time.current.beginning_of_day..Time.current.end_of_day } },
+      last_7_days:  { label: "Last 7 days",  range: -> { 7.days.ago.beginning_of_day..Time.current.end_of_day } },
+      last_30_days: { label: "Last 30 days", range: -> { 30.days.ago.beginning_of_day..Time.current.end_of_day } }
+    }.freeze
+
+    Bucket = Struct.new(
+      :label, :run_count, :item_count, :total_cost_cents,
+      :cost_per_item_cents, :avg_latency_ms, :p95_latency_ms,
+      :cache_hit_rate, keyword_init: true
+    )
+
+    # Returns a hash keyed by period name → Bucket.
+    def self.by_period
+      PERIODS.each_with_object({}) do |(key, defn), out|
+        out[key] = bucket_for(defn[:range].call, label: defn[:label])
+      end
+    end
+
+    def self.bucket_for(range, label:)
+      runs = IngestionRun.where(created_at: range)
+      run_count   = runs.count
+      total_cents = runs.sum(:api_cost_cents)
+      cached      = runs.sum(:cached_input_tokens)
+      uncached    = runs.sum(:uncached_input_tokens)
+      total_in    = cached + uncached
+      latencies   = runs.where.not(latency_ms: nil).pluck(:latency_ms)
+
+      # Item count is denormalized from the run's IngestionItems —
+      # `IngestionRun.has_many :ingestion_items`. Single COUNT join.
+      item_count =
+        if runs.exists?
+          IngestionItem.where(ingestion_run_id: runs.select(:id)).count
+        else
+          0
+        end
+
+      Bucket.new(
+        label:               label,
+        run_count:           run_count,
+        item_count:          item_count,
+        total_cost_cents:    total_cents,
+        cost_per_item_cents: item_count.zero? ? 0.0 : total_cents.to_f / item_count,
+        avg_latency_ms:      latencies.empty? ? nil : (latencies.sum.to_f / latencies.size).round,
+        p95_latency_ms:      percentile(latencies, 0.95),
+        cache_hit_rate:      total_in.zero? ? 0.0 : cached.to_f / total_in
+      )
+    end
+
+    # Nearest-rank percentile, returns nil for empty arrays.
+    # k = 0.95 → 95th percentile.
+    def self.percentile(values, k)
+      return nil if values.empty?
+
+      sorted = values.sort
+      idx = ((sorted.size * k).ceil - 1).clamp(0, sorted.size - 1)
+      sorted[idx]
+    end
+  end
+end

--- a/apps/api/app/views/admin/dashboard/index.html.erb
+++ b/apps/api/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>BiteWorthy admin · Cost dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+           background: #f7f5f2; color: #1a1a1a; margin: 0; padding: 32px; }
+    .container { max-width: 1100px; margin: 0 auto; }
+    h1 { margin: 0 0 4px; font-size: 28px; }
+    .crumbs { color: #5c5c5c; font-size: 14px; margin-bottom: 32px; }
+    .crumbs a { color: #e14e2a; text-decoration: none; }
+    .grid { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+    .card { background: #fff; border: 1px solid #e6e2dd; border-radius: 12px; padding: 24px; }
+    .card h2 { margin: 0 0 16px; font-size: 18px; color: #1a1a1a; }
+    .stat { display: flex; justify-content: space-between; align-items: baseline;
+            padding: 8px 0; border-bottom: 1px dashed #e6e2dd; }
+    .stat:last-child { border-bottom: 0; }
+    .stat .label { color: #5c5c5c; font-size: 14px; }
+    .stat .value { font-weight: 600; font-size: 16px; font-variant-numeric: tabular-nums; }
+    .stat .value.warn { color: #e03131; }
+    .stat .value.ok   { color: #2f9e44; }
+    .target-line { font-size: 13px; color: #5c5c5c; margin-top: 16px;
+                   padding-top: 12px; border-top: 1px solid #e6e2dd; }
+    .empty { color: #868e96; font-style: italic; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="crumbs"><a href="/admin">← Back to /admin</a></div>
+    <h1>Cost &amp; latency dashboard</h1>
+    <p class="crumbs">
+      Live numbers from <code>IngestionRun</code> (Phase 2.9). Target: $0.25 per
+      50-item menu = <strong><%= @target_target %>¢ per item</strong>.
+    </p>
+
+    <div class="grid">
+      <% @metrics.each do |period_key, b| %>
+        <div class="card" data-period="<%= period_key %>">
+          <h2><%= b.label %></h2>
+
+          <div class="stat">
+            <span class="label">Runs</span>
+            <span class="value"><%= b.run_count %></span>
+          </div>
+          <div class="stat">
+            <span class="label">Items extracted</span>
+            <span class="value"><%= b.item_count %></span>
+          </div>
+
+          <% over_target = b.cost_per_item_cents > @target_target %>
+          <div class="stat">
+            <span class="label">Total cost</span>
+            <span class="value">$<%= sprintf("%.2f", b.total_cost_cents.to_f / 100) %></span>
+          </div>
+          <div class="stat">
+            <span class="label">Cost per item</span>
+            <span class="value <%= over_target ? "warn" : "ok" %>">
+              <%= sprintf("%.2f", b.cost_per_item_cents) %>¢
+            </span>
+          </div>
+
+          <div class="stat">
+            <span class="label">Avg latency</span>
+            <span class="value">
+              <% if b.avg_latency_ms.nil? %>
+                <span class="empty">—</span>
+              <% else %>
+                <%= b.avg_latency_ms %> ms
+              <% end %>
+            </span>
+          </div>
+          <div class="stat">
+            <span class="label">p95 latency</span>
+            <span class="value">
+              <% if b.p95_latency_ms.nil? %>
+                <span class="empty">—</span>
+              <% else %>
+                <%= b.p95_latency_ms %> ms
+              <% end %>
+            </span>
+          </div>
+
+          <div class="stat">
+            <span class="label">Cache hit rate</span>
+            <span class="value <%= b.cache_hit_rate >= 0.5 ? "ok" : "warn" %>">
+              <%= sprintf("%.1f%%", b.cache_hit_rate * 100) %>
+            </span>
+          </div>
+
+          <p class="target-line">
+            Target: ≤ <%= @target_target %>¢ per item. Cache hit rate &gt; 50% means
+            most calls are reading the cached taxonomy block.
+          </p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</body>
+</html>

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   mount_avo
+  # Phase 2.9 cost dashboard. Lives at /admin/dashboard so the admin
+  # nav bar can link straight to it from Avo.
+  get "/admin/dashboard", to: "admin/dashboard#index", as: :admin_dashboard
+
   # Health check for uptime monitors and load balancers.
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/apps/api/spec/requests/admin/dashboard_spec.rb
+++ b/apps/api/spec/requests/admin/dashboard_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Dashboard", type: :request do
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:basic_auth) do
+    creds = ActionController::HttpAuthentication::Basic.encode_credentials("admin", "admin")
+    { "Authorization" => creds }
+  end
+
+  it "challenges for HTTP Basic auth without credentials" do
+    get "/admin/dashboard"
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(response.headers["WWW-Authenticate"]).to match(/\ABasic realm=/)
+  end
+
+  it "rejects wrong credentials with 401" do
+    bad = ActionController::HttpAuthentication::Basic.encode_credentials("admin", "wrong-pass")
+    get "/admin/dashboard", headers: { "Authorization" => bad }
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "renders the dashboard with metrics for an authorized caller" do
+    create(:ingestion_run, restaurant: restaurant,
+           api_cost_cents: 25, latency_ms: 3_200,
+           cached_input_tokens: 5_000, uncached_input_tokens: 5_000)
+
+    get "/admin/dashboard", headers: basic_auth
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Cost &amp; latency dashboard")
+    expect(response.body).to include("Today")
+    expect(response.body).to include("Last 7 days")
+    expect(response.body).to include("Last 30 days")
+    expect(response.body).to include("Cache hit rate")
+  end
+end

--- a/apps/api/spec/services/ingestion/cost_metrics_spec.rb
+++ b/apps/api/spec/services/ingestion/cost_metrics_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe Ingestion::CostMetrics do
+  let(:restaurant) { create(:restaurant, :published) }
+
+  describe ".by_period" do
+    it "returns a Bucket per defined period (today / 7d / 30d)" do
+      result = described_class.by_period
+
+      expect(result.keys).to eq(%i[today last_7_days last_30_days])
+      expect(result.values).to all(be_a(Ingestion::CostMetrics::Bucket))
+    end
+
+    it "computes totals across runs in the period" do
+      run_today = create(:ingestion_run, restaurant: restaurant,
+                         api_cost_cents: 12, latency_ms: 4_000,
+                         cached_input_tokens: 8_000, uncached_input_tokens: 2_000)
+      create(:ingestion_item, ingestion_run: run_today)
+      create(:ingestion_item, ingestion_run: run_today)
+
+      old_run = create(:ingestion_run, restaurant: restaurant,
+                       api_cost_cents: 99, latency_ms: 9_999,
+                       cached_input_tokens: 0, uncached_input_tokens: 50_000)
+      old_run.update_column(:created_at, 60.days.ago)
+      create(:ingestion_item, ingestion_run: old_run)
+
+      bucket = described_class.by_period[:today]
+
+      expect(bucket.run_count).to        eq(1)
+      expect(bucket.item_count).to       eq(2)
+      expect(bucket.total_cost_cents).to eq(12)
+      expect(bucket.cost_per_item_cents).to eq(6.0)
+      expect(bucket.avg_latency_ms).to   eq(4_000)
+      expect(bucket.p95_latency_ms).to   eq(4_000)
+      expect(bucket.cache_hit_rate).to   be_within(0.001).of(0.8) # 8000 / 10000
+    end
+
+    it "returns zero/nil safely when there are no runs in a period" do
+      bucket = described_class.by_period[:today]
+
+      expect(bucket.run_count).to        eq(0)
+      expect(bucket.item_count).to       eq(0)
+      expect(bucket.total_cost_cents).to eq(0)
+      expect(bucket.cost_per_item_cents).to eq(0.0)
+      expect(bucket.avg_latency_ms).to   be_nil
+      expect(bucket.p95_latency_ms).to   be_nil
+      expect(bucket.cache_hit_rate).to   eq(0.0)
+    end
+
+    it "handles a run with zero items (cost-per-item stays at 0, no division)" do
+      create(:ingestion_run, restaurant: restaurant,
+             api_cost_cents: 8, latency_ms: 1_500,
+             cached_input_tokens: 1_000, uncached_input_tokens: 500)
+
+      bucket = described_class.by_period[:today]
+
+      expect(bucket.cost_per_item_cents).to eq(0.0)
+    end
+  end
+
+  describe ".percentile" do
+    it "returns nil for empty input" do
+      expect(described_class.percentile([], 0.95)).to be_nil
+    end
+
+    it "returns the nearest-rank p95 for a 10-value sample" do
+      values = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1_000]
+      expect(described_class.percentile(values, 0.95)).to eq(1_000)
+    end
+
+    it "returns the nearest-rank p50 for a 10-value sample" do
+      values = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1_000]
+      expect(described_class.percentile(values, 0.5)).to eq(500)
+    end
+
+    it "returns the only value when the sample size is 1" do
+      expect(described_class.percentile([42], 0.95)).to eq(42)
+    end
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,10 +11,9 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
-**Phase 2** ⭐ AI ingestion MVP. Subplan: `docs/plans/phase-2.md`. This batch is **proposed by the loop** (this PR is the plan-update PR); humans review it before the items auto-run.
+1. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`) — this PR
 
-1. **Phase 2.8 — Web: paste-URL / upload-PDF entrypoint** (`docs/plans/phase-2.md#28`) — this PR
-2. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`)
+After this merges, **Phase 2 is complete** — the loop drafts a `docs/plans/phase-3.md` PR proposing the dietary-filter-UI queue (same plan-PR pattern as #135).
 
 ### Done
 
@@ -34,8 +33,7 @@ the merge / review / status rules.
 - ✅ Phase 2.5 — admin verify UI + 80%-accepted publish (#140)
 - ✅ Phase 2.6 — mobile camera + ingestion runs API (#141)
 - ✅ Phase 2.7 — mobile swipe-verify UI + ingestion item PATCH (#142)
-
-After Phase 2 ships, the loop will draft `docs/plans/phase-3.md` (dietary filter UI) the same way.
+- ✅ Phase 2.8 — web URL/PDF entrypoint (#143)
 
 ## Phase 0 — Foundation ✅
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,30 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 03:00 — tick #49. PR #143 (Phase 2.8) merged at 01:18 UTC.
+Picked up Phase 2.9 — cost + latency dashboard. New
+`Ingestion::CostMetrics` service: aggregates IngestionRun columns
+(api_cost_cents/latency_ms/cached+uncached_input_tokens) over
+today/last_7_days/last_30_days buckets, computes total_cost,
+items_extracted, cost_per_item, avg + p95 latency (nearest-rank),
+cache_hit_rate. Target line $0.25/50-item-menu = 0.5¢/item.
+New `Admin::DashboardController` (inherits from
+ActionController::Base for ERB rendering since the rest of the app
+is api_only) at `/admin/dashboard`, gated with the same HTTP Basic
+auth Avo uses (re-reads ADMIN_USERNAME/ADMIN_PASSWORD ENV).
+Self-contained ERB layout with three period cards, color-coded
+cost-per-item warning when above the 0.5¢ target, color-coded
+cache-hit rate. Bug caught locally: my period_label_for computed
+days from `(end - begin) / 1.day` and the half-day tail rounded
+7→8 → restructured PERIODS to carry explicit labels. 8 metric
+specs (totals, zero-safety, zero-items no-divide, percentile +
+edge cases) + 3 dashboard request specs (auth challenge / wrong
+creds / right creds renders metrics). Local rspec 157/157
+(1 pending), pnpm typecheck/lint/test all green.
+
+**Phase 2 feature-complete after this merges.** Next tick will draft
+the phase-3 plan PR (same pattern as #135).
+
 2026-05-01 02:25 — tick #48. PR #142 (Phase 2.7) merged at 00:48 UTC.
 Picked up Phase 2.8 — web URL/PDF entrypoint. New `UrlFetcher`
 service: faraday GET with 15s timeout, 10MB max bytes, sniffs PDF


### PR DESCRIPTION
## Why

Phase 2.9 of the v2 delivery plan — `docs/plans/phase-2.md#29`. **Last Phase 2 task.** Hand-rolled cost dashboard since the project runs Avo Community (no Pro Dashboards license).

## What

### `Ingestion::CostMetrics` service

Aggregates IngestionRun columns added in Phase 2.3 (`api_cost_cents` / `latency_ms` / `cached_input_tokens` / `uncached_input_tokens`) over today / last_7_days / last_30_days buckets.

Per bucket:
- `run_count`, `item_count` (denormalized COUNT join through ingestion_items)
- `total_cost_cents`, `cost_per_item_cents`
- `avg_latency_ms`, nearest-rank `p95_latency_ms`
- `cache_hit_rate` = `cached / (cached + uncached)`
- `label`

Target line: $0.25 per 50-item menu = **0.5¢ per item** (the line cost-per-item rows turn red against).

Pure logic, separate from the view, so the math is testable without ERB.

### `Admin::DashboardController` at `/admin/dashboard`

- Inherits from `ActionController::Base` (the rest of the app is `api_only`); ERB layout opt-out via `layout false`.
- Reuses the same `ADMIN_USERNAME` / `ADMIN_PASSWORD` HTTP Basic auth Avo uses (Phase 1.5). Avo Community doesn't expose a "run my request through your auth" hook, so the few lines are duplicated rather than refactored.
- Self-contained inline-CSS template — three period cards, color-coded: **cost-per-item turns red above 0.5¢**, **cache hit rate turns green at ≥50%**. Crumb link back to `/admin`.

### Bug caught locally

My first cut of `period_label_for` computed days from `((range.end - range.begin) / 1.day).round` and the half-day tail in `7.days.ago.beginning_of_day..Time.current.end_of_day` rounded 7 → 8, so the dashboard would have rendered "8 days" as the heading. Restructured `PERIODS` to carry explicit labels.

### Specs

- **8 metric tests** at `spec/services/ingestion/cost_metrics_spec.rb`: per-period totals, zero-safety, zero-items no-divide, percentile (empty/single/p50/p95).
- **3 dashboard request tests** at `spec/requests/admin/dashboard_spec.rb`: auth challenge / wrong creds / right creds renders all three period headings.

## Test plan

- [ ] CI · API rspec green (11 new + 146 prior = 157 examples, 1 pending).
- [ ] Local rspec confirmed 157/157.
- [ ] Local pnpm typecheck/lint/test cached green (no JS changes).
- [ ] Manual sanity (deferred): `cd apps/api && bin/rails s -p 3000` → `open http://admin:admin@localhost:3000/admin/dashboard` shows three empty cards (zeros across the board) until real ingestion data lands.

## Notes

- **Phase 2 feature-complete after this merges.** End-to-end pipeline: web URL/PDF or mobile camera → API → ExtractMenuJob → Resolve jobs → IngestionItems → admin verify (Avo) or mobile swipe → 80%-accepted threshold → publish. Cost dashboard sits on top.
- **The cassette gap from 2.3+2.4 is the one remaining thing** before live demo-ready ingestion. Until those are recorded with a real `ANTHROPIC_API_KEY`, every Phase 2 spec uses mocked AnthropicClient — wiring is verified, the actual model output isn't.
- **Next tick will draft the phase-3 plan PR** (same pattern as #135). Phase 3 = dietary-filter UI on web + mobile, which is where actual users will start interacting with what Phase 1 + 2 built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)