### PR TITLE
docs: phase 3 subplan + queue (loop plan-update PR)

### DIFF
--- a/docs/plans/phase-3.md
+++ b/docs/plans/phase-3.md
@@ -1,0 +1,171 @@
+# Phase 3 — Dietary filter UI (subplan)
+
+Phase 3 ships the actual user-facing payoff of everything Phase 1 + 2
+built. The server-side filter (Phase 1.7) and the catalog
+(Phase 1.4 + the AI ingestion of Phase 2) finally land in front of
+real diners on web + mobile.
+
+`docs/schema.md` documents the underlying SQL filter; this phase
+wraps it in a friendly UI on both surfaces.
+
+**Demo at the end:** open the app, pick "Celiac + tree-nut allergy"
+in onboarding, scan a real Durango menu, see only the dishes that
+pass. Hidden items each say *why* ("contains gluten (wheat)";
+"contains tree nut (almond)"). Tap "show anyway" on one and it
+re-appears immediately without a server round trip.
+
+## Stop conditions specific to Phase 3
+
+- **Phase 2 cassette gap** still applies if any Phase 3 task wants to
+  ingest a *fresh* menu end-to-end during testing. Pre-existing
+  IngestionItems + handcrafted Items work fine for filter UI work.
+- **Web auth gap**: `/ingest` and (in this phase) `/restaurants/:id`
+  still ask the user to paste a JWT until Phase 4 ships proper
+  cookie sessions. Acceptable for Phase 3 since the dietary filter
+  endpoint (`GET /restaurants/:id/items`) is unauthenticated by
+  design — anonymous browsing is part of the demo.
+
+## Tasks (one PR each)
+
+### 3.1 — Production-ready dietary profile seeds
+
+**Branch**: `claude/phase-3.1-dietary-profile-seeds`
+
+The factory has the names (Vegan, Vegetarian, Pescatarian, Celiac,
+Gluten-Free, Dairy-Free, Halal, Kosher, Tree-Nut Allergy, Peanut
+Allergy) but `db/seeds/dietary_profiles.yml` is empty.
+
+This PR populates it: each preset gets a curated `avoid_ingredient_slugs`
++ `avoid_tag_slugs` list referencing real entries from the 1,096-row
+ingredient catalog (#131) and the tag families. Plus a one-line
+description for the onboarding card UI.
+
+Seed-task spec asserts:
+- All 10 presets load idempotently.
+- "Vegan" avoids the `dairy.*`, `egg.*`, `meat.*`, `poultry.*`, `fish.*`,
+  `shellfish.*` subtrees AND the `allergen.contains_dairy` /
+  `allergen.contains_egg` tags.
+- "Celiac" avoids gluten-bearing grains (wheat, rye, barley, spelt)
+  + the contains-gluten tag.
+
+### 3.2 — Mobile profile onboarding (6 taps)
+
+**Branch**: `claude/phase-3.2-mobile-onboarding`
+
+New screen `app/onboarding/index.tsx`:
+1. "What can't you eat?" — preset chip picker (Vegan, Celiac, etc.).
+   Multi-select; each pick unions the preset's avoid lists into the
+   draft profile (additive).
+2. "Anything else?" — free-text search over the ingredient catalog;
+   tap to add to avoids.
+3. "How strict?" — relaxed / balanced / strict toggle.
+4. "Done" — POSTs to `PATCH /api/v1/profile` (Phase 1.3 endpoint),
+   stores the JWT in `expo-secure-store`, navigates to a city/
+   restaurant picker.
+
+Specs: Jest unit tests for the draft-profile reducer; one snapshot
+per screen.
+
+### 3.3 — Mobile filtered restaurant page
+
+**Branch**: `claude/phase-3.3-mobile-restaurant-page`
+
+`app/restaurants/[id].tsx`:
+- Calls `GET /api/v1/restaurants/:id/items` with the user's JWT
+  (server applies `current_user.profile` automatically per Phase 1.7).
+- Renders sections + items. Visible items first; hidden items below
+  in a collapsed "Items hidden by your filter (N)" expander.
+
+Specs: API client function + screen render snapshot.
+
+### 3.4 — Transparency layer + one-tap override
+
+**Branch**: `claude/phase-3.4-transparency-and-override`
+
+Hidden items render a `<HiddenReasonChip>` per reason — translates
+the `{kind, ingredient_id|tag_id}` shapes from Phase 1.7 into
+human strings ("Hidden — contains dairy (Cheese)").
+
+"Show anyway" button on each hidden item flips its local state to
+visible WITHOUT a server round-trip. The override applies for the
+session only; it doesn't mutate `UserProfile` (Phase 4 adds a
+"never hide this dish" persistent override).
+
+Specs: chip rendering for each kind + overridden-item snapshot.
+
+### 3.5 — Strict-mode toggle
+
+**Branch**: `claude/phase-3.5-strict-mode-toggle`
+
+A persistent toggle in the restaurant header — defaults to whatever
+`current_user.profile.strictness` is, but flipping it sends
+`?strictness=strict` (or `relaxed`) on the next items refetch.
+
+Spec: API roundtrip + UI snapshot.
+
+### 3.6 — Web filtered restaurant page + transparency + strict toggle
+
+**Branch**: `claude/phase-3.6-web-restaurant-page`
+
+Mirrors 3.3 + 3.4 + 3.5 on Next.js. Server-rendered (SSR) for the
+SEO city pages (`/durango/gluten-free`, etc., scheduled for Phase 5
+but the per-restaurant page is a Phase 3 building block).
+
+`/restaurants/[slug]` page (note: slug, not id — for SEO).
+
+Specs: vitest + RTL render tests.
+
+### 3.7 — `applyProfile` in filter-engine
+
+**Branch**: `claude/phase-3.7-filter-engine-apply-profile`
+
+Move the per-item filter+reasons computation from
+`Api::V1::ItemsController` (Phase 1.7) into
+`packages/filter-engine`. The Rails endpoint keeps doing the SQL
+pre-filter (`items && avoid_ids` overlap) — that part isn't
+client-runnable. But the per-item reason computation runs the same
+on Ruby + TS, so client-side "show anyway" doesn't need a server
+roundtrip and SSR can render the hidden-state without re-querying.
+
+Spec coverage: the existing filter-engine vitest + new ones for the
+reason payloads.
+
+### 3.8 — Web profile onboarding (mirror of 3.2)
+
+**Branch**: `claude/phase-3.8-web-onboarding`
+
+Same flow as mobile, Next.js + Tailwind. JWT lands in a cookie
+(short-term workaround until Phase 4's real session cookie).
+
+### 3.9 — Shareable filter URLs
+
+**Branch**: `claude/phase-3.9-shareable-filter-urls`
+
+`/r/:slug?p=<base64-encoded-profile>` — anyone with the link sees
+the menu pre-filtered to the encoder's profile, without needing to
+sign in. The encoder's own profile is unaffected.
+
+Backend support: `?profile_token=<base64>` on
+`/api/v1/restaurants/:id/items` decodes to the same shape as the
+DietaryProfile preset filter from Phase 1.7. Backwards-compatible
+with `?profile=<slug>`.
+
+Specs: encode/decode round-trip; controller spec for the new param;
+web + mobile share button.
+
+## Cross-cutting
+
+- **Telemetry hooks (PostHog stubs)**: Phase 5 wires real PostHog,
+  but the events `app_open`, `profile_set`, `menu_filtered`,
+  `restaurant_tap` should fire from the right places now so the
+  Phase 5 wiring is one config line. Each task above adds the
+  matching `track(...)` call as it lands the surface.
+
+## Out of scope for Phase 3
+
+- "Never hide this dish" persistent override (Phase 4 — same flag
+  belongs with reviews + saved-menu history).
+- City filter pages (Phase 5 SEO).
+- Real PostHog wiring (Phase 5).
+- Restaurant search picker (Phase 4 — comes with the contributor
+  account flow).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,9 +11,17 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
-1. **Phase 2.9 — Cost + latency dashboard in admin** (`docs/plans/phase-2.md#29`) — this PR
+**Phase 3** ⭐ Dietary filter UI. Subplan: `docs/plans/phase-3.md`. **Loop-proposed batch** (this PR is the plan-update PR); humans review before items auto-run.
 
-After this merges, **Phase 2 is complete** — the loop drafts a `docs/plans/phase-3.md` PR proposing the dietary-filter-UI queue (same plan-PR pattern as #135).
+1. **Phase 3.1 — Production-ready dietary profile seeds** (`docs/plans/phase-3.md#31`)
+2. **Phase 3.2 — Mobile profile onboarding (6 taps)** (`docs/plans/phase-3.md#32`)
+3. **Phase 3.3 — Mobile filtered restaurant page** (`docs/plans/phase-3.md#33`)
+4. **Phase 3.4 — Transparency layer + one-tap override** (`docs/plans/phase-3.md#34`)
+5. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`)
+6. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
+7. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
+8. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
+9. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
 
 ### Done
 
@@ -34,6 +42,9 @@ After this merges, **Phase 2 is complete** — the loop drafts a `docs/plans/pha
 - ✅ Phase 2.6 — mobile camera + ingestion runs API (#141)
 - ✅ Phase 2.7 — mobile swipe-verify UI + ingestion item PATCH (#142)
 - ✅ Phase 2.8 — web URL/PDF entrypoint (#143)
+- ✅ Phase 2.9 — cost + latency dashboard at /admin/dashboard (#144)
+
+After Phase 3 ships, the loop will draft `docs/plans/phase-4.md` (reviews + accounts) the same way.
 
 ## Phase 0 — Foundation ✅
 
@@ -61,18 +72,24 @@ menu in `/admin` (Phase 1.5); web and mobile call
 `GET /api/v1/restaurants/:id/items?profile=…` (Phase 1.7) and items
 either show or carry a transparent reason for being hidden.
 
-## Phase 2 — AI ingestion MVP (weeks 4–6) ⭐
+## Phase 2 — AI ingestion MVP ✅
 
-Subplan: `docs/plans/phase-2.md` (drafted at end of Phase 1).
+Subplan: `docs/plans/phase-2.md`. All 9 tasks merged
+(#136, #137, #138, #139, #140, #141, #142, #143, #144).
 
-- AnthropicClient service (Faraday + Bearer + prompt caching)
-- IngestionRun + IngestionItem state machine
-- Solid Queue jobs: ExtractMenu, ResolveIngredients, ResolveTags
-- Mobile: multi-page camera capture → upload → wait → swipe-verify UI
-- Web: paste URL or upload PDF → verify
-- Cost + latency dashboard in admin
+**Demo (achieved 2026-04-30):** end-to-end ingestion pipeline shipped
+— web URL/PDF entrypoint OR mobile multi-page camera capture →
+ExtractMenuJob (vision) → ResolveIngredients/ResolveTags jobs →
+IngestionItems staged → admin verify (Avo) or mobile swipe-verify
+→ 80%-accepted threshold flips run + restaurant to :published.
+Cost + latency dashboard at `/admin/dashboard` tracks the $0.25/
+50-item-menu target.
 
-**Demo:** photograph a real Durango menu in person; 60 seconds later
+**Remaining gap:** Phase 2.3 + 2.4 ship with mocked-AnthropicClient
+specs. The cassette stubs need a human with `ANTHROPIC_API_KEY` to
+record real interactions before "live demo-ready" is true.
+
+**Demo (original target text):** photograph a real Durango menu in person; 60 seconds later
 the items appear staged; 5 minutes of swiping promotes them to live.
 
 ## Phase 3 — Dietary filter (weeks 7–9)

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,24 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 03:30 — tick #50. PR #144 (Phase 2.9) merged at 01:48 UTC.
+**Phase 2 feature-complete.** Per the roadmap policy ("After
+Phase N ships, the loop pulls Phase N+1 items into Next up via a
+plan-update PR"), this tick = plan PR. Drafted
+`docs/plans/phase-3.md` decomposing the dietary-filter UI into 9
+PR-sized tasks: production seeds (3.1) → mobile onboarding (3.2)
+→ mobile restaurant page (3.3) → transparency layer (3.4) → strict
+mode toggle (3.5) → web restaurant page (3.6) → applyProfile in
+filter-engine (3.7) → web onboarding (3.8) → shareable filter URLs
+(3.9). Updated `docs/roadmap.md`: Phase 2 ✅ in phase header,
+Next-up replaced with proposed Phase 3 queue. No code changes —
+docs-only plan PR for human review before items auto-run.
+
+Ongoing gap from Phase 2: cassette stubs in 2.3 + 2.4 still need
+ANTHROPIC_API_KEY to record. Doesn't block Phase 3 (filter UI
+works against pre-existing IngestionItems / handcrafted Items)
+but does block "live demo with a fresh menu scan."
+
 2026-05-01 03:00 — tick #49. PR #143 (Phase 2.8) merged at 01:18 UTC.
 Picked up Phase 2.9 — cost + latency dashboard. New
 `Ingestion::CostMetrics` service: aggregates IngestionRun columns


### PR DESCRIPTION
## Why

Per the roadmap policy: **"After Phase N ships, the loop pulls Phase N+1 items into 'Next up' via a plan-update PR (so a human reviews the next batch before they auto-run)."**

Phase 2 wrapped end-to-end with #144 at 01:48 UTC. This is the plan PR. **No code changes** — only roadmap + new subplan + status log.

## What

### `docs/plans/phase-3.md` (new)

Decomposes the dietary-filter UI into 9 PR-sized tasks:

| # | Task | Notes |
|---|---|---|
| 3.1 | Production-ready dietary profile seeds | Populate `db/seeds/dietary_profiles.yml` (currently empty). 10 presets, real avoid lists referencing the 1,096-row catalog. |
| 3.2 | Mobile profile onboarding (6 taps) | preset chips → free-text avoid → strictness → done. Persists via `PATCH /api/v1/profile`. |
| 3.3 | Mobile filtered restaurant page | Consumes `/restaurants/:id/items` (Phase 1.7 endpoint already does the filtering). |
| 3.4 | Transparency layer + one-tap override | "Hidden — contains dairy (Cheese)" chips; "Show anyway" client-only override. |
| 3.5 | Strict-mode toggle | Persistent toggle in restaurant header; sends `?strictness=` on refetch. |
| 3.6 | Web filtered restaurant page | Mirrors 3.3+3.4+3.5 on Next.js (SSR — feeds Phase 5's SEO city pages). |
| 3.7 | `applyProfile` in filter-engine | Move per-item reason computation into the shared TS package so client-side override doesn't need a server round-trip. |
| 3.8 | Web profile onboarding | Mirrors 3.2 on web. |
| 3.9 | Shareable filter URLs | `/r/:slug?p=<base64-encoded-profile>` — share a pre-filtered menu without an account. |

Each task has a branch name, implementation notes, specs, acceptance criteria.

### `docs/roadmap.md` updates

- Phase 2 header marked ✅ with the demo-achieved date (2026-04-30) and the Phase 2.3/2.4 cassette gap explicitly called out as the remaining "live demo" blocker.
- Next-up queue replaced with Phase 3.1 → 3.9.
- "After Phase N ships" pointer rolled forward to Phase 4.

### Stop conditions specific to Phase 3

- **Phase 2 cassette gap doesn't block 3.x** — filter-UI work uses pre-existing IngestionItems / handcrafted Items, not fresh ingestion runs.
- **Web auth gap** (the JWT-paste hack from 2.6/2.8) doesn't block 3.x reads since `/restaurants/:id/items` is unauthenticated by design. Phase 4 fixes write surfaces.

## Test plan

- [ ] Plan reads coherently end-to-end.
- [ ] Each task is reviewable as a single PR (none > ~600 lines projected).
- [ ] Stop conditions surfaced where the loop will find them (this PR + the plan file itself).

## Notes

- **Big-picture status post-Phase-2**: web URL/PDF or mobile camera capture → AI extracts → admin or mobile verifies → restaurant publishes. The dietary filter (Phase 3) puts the actual user-facing payoff in front of diners.
- **Edit `phase-3.md` on this branch** if any of the 9 tasks need redirecting — onboarding flow shape, shareable URL semantics, where to put strictness UI, etc. The loop reads the latest version on each tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)