### PR TITLE
feat(api,mobile): mobile filtered restaurant page (phase 3.3)

### DIFF
--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -20,7 +20,10 @@ module Api
 
       def index
         restaurant = Restaurant.published.find(params[:restaurant_id])
-        items      = restaurant.items.published.order(popularity: :desc, name: :asc).to_a
+        items      = restaurant.items.published
+                               .includes(menu_section: :menu)
+                               .order(popularity: :desc, name: :asc)
+                               .to_a
 
         filter = build_filter
         rendered = items.map { |item| serialize_item(item, filter) }
@@ -99,17 +102,20 @@ module Api
       # generated TS types; Phase 1.6's openapi.json should match.
       def serialize_item(item, filter)
         reasons = hide_reasons(item, filter)
+        section = item.menu_section
         {
-          id:             item.id,
-          restaurant_id:  item.restaurant_id,
-          name:           item.name,
-          description:    item.description,
-          confidence:     item.confidence,
-          popularity:     item.popularity,
-          ingredient_ids: item.ingredient_ids,
-          tag_ids:        item.tag_ids,
-          status:         reasons.empty? ? "visible" : "hidden",
-          reasons:        reasons
+          id:                 item.id,
+          restaurant_id:      item.restaurant_id,
+          name:               item.name,
+          description:        item.description,
+          confidence:         item.confidence,
+          popularity:         item.popularity,
+          ingredient_ids:     item.ingredient_ids,
+          tag_ids:            item.tag_ids,
+          menu_section_id:    section&.id,
+          menu_section_name:  section&.name,
+          status:             reasons.empty? ? "visible" : "hidden",
+          reasons:            reasons
         }
       end
 

--- a/apps/api/app/controllers/api/v1/restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/restaurants_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module V1
+    # GET /api/v1/restaurants/:id
+    #
+    # Phase 3.3 — the mobile (and later web) restaurant page header
+    # needs the restaurant's name + city to render. The items endpoint
+    # only returns `restaurant_id`; without this the page can't show
+    # "Ninis Taqueria · Durango, CO" above the filtered menu.
+    #
+    # Public (unauthenticated) — anonymous browsing is part of the
+    # Phase 3 demo.
+    class RestaurantsController < BaseController
+      skip_before_action :authenticate_user!, only: [:show]
+
+      def show
+        restaurant = Restaurant.published.includes(:city).find(params[:id])
+        render json: serialize(restaurant)
+      end
+
+      private
+
+      def serialize(r)
+        {
+          id:      r.id,
+          slug:    r.slug,
+          name:    r.name,
+          about:   r.about,
+          phone:   r.phone,
+          website: r.website,
+          status:  r.status,
+          city: {
+            id:     r.city.id,
+            slug:   r.city.slug,
+            name:   r.city.name,
+            region: r.city.region
+          }
+        }
+      end
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
@@ -130,6 +130,44 @@ RSpec.describe "GET /api/v1/restaurants/:id/items", type: :request do
     end
   end
 
+  describe "menu section payload (Phase 3.3)" do
+    let(:menu)    { create(:menu, restaurant: restaurant) }
+    let(:tacos)   { create(:menu_section, menu: menu, name: "Tacos", position: 0) }
+    let(:bowls)   { create(:menu_section, menu: menu, name: "Bowls", position: 1) }
+
+    let!(:sectioned_taco) do
+      create(:item, :published, :confirmed,
+             restaurant: restaurant, name: "Pollo Taco",
+             menu_section: tacos, ingredients: [])
+    end
+    let!(:sectioned_bowl) do
+      create(:item, :published, :confirmed,
+             restaurant: restaurant, name: "Veggie Bowl",
+             menu_section: bowls, ingredients: [])
+    end
+
+    it "exposes menu_section_id + menu_section_name on each item" do
+      get "/api/v1/restaurants/#{restaurant.id}/items"
+
+      expect(response).to have_http_status(:ok)
+      items = response.parsed_body["items"].index_by { |i| i["name"] }
+
+      expect(items["Pollo Taco"]).to include(
+        "menu_section_id"   => tacos.id,
+        "menu_section_name" => "Tacos"
+      )
+      expect(items["Veggie Bowl"]).to include(
+        "menu_section_id"   => bowls.id,
+        "menu_section_name" => "Bowls"
+      )
+      # Items without a section (the original three) carry nulls.
+      expect(items["Carne Asada Taco"]).to include(
+        "menu_section_id"   => nil,
+        "menu_section_name" => nil
+      )
+    end
+  end
+
   describe "404 cases" do
     it "404s on a non-existent restaurant" do
       get "/api/v1/restaurants/00000000-0000-0000-0000-000000000000/items"

--- a/apps/api/spec/requests/api/v1/restaurants_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+# Phase 3.3 — the mobile restaurant page hits this for header info
+# (name, city) since the items endpoint only returns restaurant_id.
+# Anonymous access is part of the demo: someone scans a menu without
+# signing up.
+
+RSpec.describe "GET /api/v1/restaurants/:id", type: :request do
+  let(:durango)    { create(:city, slug: "durango") }
+  let(:restaurant) { create(:restaurant, :published, city: durango, name: "Ninis Taqueria") }
+
+  it "returns the restaurant + city payload, anonymously" do
+    get "/api/v1/restaurants/#{restaurant.id}"
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+
+    expect(body).to include(
+      "id"     => restaurant.id,
+      "slug"   => restaurant.slug,
+      "name"   => "Ninis Taqueria",
+      "status" => "published"
+    )
+    expect(body["city"]).to include(
+      "slug"   => "durango",
+      "name"   => "Durango",
+      "region" => "CO"
+    )
+  end
+
+  it "404s on a non-existent id" do
+    get "/api/v1/restaurants/00000000-0000-0000-0000-000000000000"
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "404s on a draft restaurant (not yet published)" do
+    draft = create(:restaurant) # default :draft status
+    get "/api/v1/restaurants/#{draft.id}"
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/apps/mobile/__tests__/lib/restaurants.test.ts
+++ b/apps/mobile/__tests__/lib/restaurants.test.ts
@@ -1,0 +1,150 @@
+import {
+  fetchRestaurant,
+  fetchRestaurantItems,
+  groupItemsBySection,
+  RestaurantFetchError,
+  type FilteredItem,
+  type Restaurant,
+  type RestaurantItemsResponse,
+} from '../../lib/api/restaurants';
+
+type FetchCall = Parameters<typeof fetch>;
+type FetchMock = jest.Mock<Promise<Response>, FetchCall>;
+
+function fakeFetch(status: number, body: unknown): FetchMock {
+  return jest.fn(async (..._args: FetchCall) =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Response,
+  ) as FetchMock;
+}
+
+const restaurantPayload: Restaurant = {
+  id: 'rest-1',
+  slug: 'ninis-1',
+  name: 'Ninis Taqueria',
+  about: null,
+  phone: null,
+  website: null,
+  status: 'published',
+  city: { id: 'city-1', slug: 'durango', name: 'Durango', region: 'CO' },
+};
+
+const itemsPayload: RestaurantItemsResponse = {
+  restaurant_id: 'rest-1',
+  filter: {
+    source: 'preset',
+    preset_slug: 'vegan',
+    strictness: 'balanced',
+    avoid_ingredient_ids: ['ing-cheese'],
+    avoid_tag_ids: [],
+  },
+  items: [],
+};
+
+describe('fetchRestaurant', () => {
+  it('GETs /api/v1/restaurants/:id and returns the JSON', async () => {
+    const fetchImpl = fakeFetch(200, restaurantPayload);
+    const r = await fetchRestaurant('rest-1', { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain('/api/v1/restaurants/rest-1');
+    expect(r.name).toBe('Ninis Taqueria');
+  });
+
+  it('throws RestaurantFetchError on non-2xx', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'not found' });
+    await expect(fetchRestaurant('missing', { fetchImpl })).rejects.toBeInstanceOf(
+      RestaurantFetchError,
+    );
+  });
+});
+
+describe('fetchRestaurantItems', () => {
+  it('omits the Authorization header when no JWT supplied (anonymous browse)', async () => {
+    const fetchImpl = fakeFetch(200, itemsPayload);
+    await fetchRestaurantItems('rest-1', { fetchImpl });
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+
+  it('attaches Bearer JWT when provided', async () => {
+    const fetchImpl = fakeFetch(200, itemsPayload);
+    await fetchRestaurantItems('rest-1', { fetchImpl, jwt: 'jjj.www.ttt' });
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jjj.www.ttt');
+  });
+
+  it('passes presetSlug + strictness as query params', async () => {
+    const fetchImpl = fakeFetch(200, itemsPayload);
+    await fetchRestaurantItems('rest-1', {
+      fetchImpl,
+      presetSlug: 'vegan',
+      strictness: 'strict',
+    });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('profile=vegan');
+    expect(url).toContain('strictness=strict');
+  });
+});
+
+describe('groupItemsBySection', () => {
+  function item(overrides: Partial<FilteredItem>): FilteredItem {
+    return {
+      id: overrides.id ?? 'item-?',
+      restaurant_id: 'rest-1',
+      name: overrides.name ?? 'Item',
+      description: '',
+      confidence: 'confirmed',
+      popularity: 0,
+      ingredient_ids: [],
+      tag_ids: [],
+      menu_section_id: null,
+      menu_section_name: null,
+      status: 'visible',
+      reasons: [],
+      ...overrides,
+    };
+  }
+
+  it('groups items by menu_section_id, preserving server order', () => {
+    const sections = groupItemsBySection([
+      item({ id: 'a', menu_section_id: 'tacos', menu_section_name: 'Tacos' }),
+      item({ id: 'b', menu_section_id: 'bowls', menu_section_name: 'Bowls' }),
+      item({ id: 'c', menu_section_id: 'tacos', menu_section_name: 'Tacos' }),
+    ]);
+    expect(sections.map((s) => s.name)).toEqual(['Tacos', 'Bowls']);
+    expect(sections[0]!.visible.map((i) => i.id)).toEqual(['a', 'c']);
+    expect(sections[1]!.visible.map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('separates visible vs hidden items within a section', () => {
+    const sections = groupItemsBySection([
+      item({ id: 'v1', menu_section_id: 's1', menu_section_name: 'S1', status: 'visible' }),
+      item({
+        id: 'h1',
+        menu_section_id: 's1',
+        menu_section_name: 'S1',
+        status: 'hidden',
+        reasons: [{ kind: 'avoid_ingredient', ingredient_id: 'ing-x' }],
+      }),
+    ]);
+    expect(sections[0]!.visible.map((i) => i.id)).toEqual(['v1']);
+    expect(sections[0]!.hidden.map((i) => i.id)).toEqual(['h1']);
+  });
+
+  it('drops items with no menu_section into a single "Other" group', () => {
+    const sections = groupItemsBySection([
+      item({ id: 'a', menu_section_id: null, menu_section_name: null }),
+      item({ id: 'b', menu_section_id: null, menu_section_name: null }),
+    ]);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.name).toBe('Other');
+    expect(sections[0]!.visible.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for no items', () => {
+    expect(groupItemsBySection([])).toEqual([]);
+  });
+});

--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -1,0 +1,322 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import {
+  fetchRestaurant,
+  fetchRestaurantItems,
+  groupItemsBySection,
+  type FilteredItem,
+  type ItemSection,
+  type Restaurant,
+  type FilterSummary,
+} from '../../lib/api/restaurants';
+
+/**
+ * Phase 3.3 — filtered restaurant page.
+ *
+ *   1. Hits GET /api/v1/restaurants/:id for header info.
+ *   2. Hits GET /api/v1/restaurants/:id/items (with optional JWT).
+ *      Server applies the user's profile when authed (Phase 1.7).
+ *   3. Renders sections + items; visible up top, hidden behind a
+ *      "Items hidden by your filter (N)" expander per section.
+ *
+ * The transparency-chip translation + per-item override land in
+ * Phase 3.4 — for now the screen labels hidden items with a generic
+ * "Hidden" tag and lists their reasons by raw kind. Same JWT-pasted-
+ * in-input workaround as the ingest/onboarding screens until Phase 4
+ * brings expo-secure-store.
+ */
+
+export default function RestaurantScreen() {
+  const params = useLocalSearchParams<{ id: string; jwt?: string }>();
+  const id = String(params.id ?? '');
+  const jwt = typeof params.jwt === 'string' ? params.jwt : undefined;
+
+  const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
+  const [filter, setFilter] = useState<FilterSummary | null>(null);
+  const [sections, setSections] = useState<ItemSection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([fetchRestaurant(id), fetchRestaurantItems(id, { jwt })])
+      .then(([r, itemsRes]) => {
+        if (cancelled) return;
+        setRestaurant(r);
+        setFilter(itemsRes.filter);
+        setSections(groupItemsBySection(itemsRes.items));
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, jwt]);
+
+  if (!id) {
+    return <CenteredMessage text="Missing restaurant id." />;
+  }
+  if (loading) {
+    return (
+      <View style={styles.center} testID="restaurant-loading">
+        <ActivityIndicator size="large" color={colors.bite} />
+      </View>
+    );
+  }
+  if (error) {
+    return <CenteredMessage text={`Could not load restaurant — ${error}`} />;
+  }
+  if (!restaurant || !filter) {
+    return <CenteredMessage text="Restaurant not found." />;
+  }
+
+  const totalHidden = sections.reduce((acc, s) => acc + s.hidden.length, 0);
+  const totalVisible = sections.reduce((acc, s) => acc + s.visible.length, 0);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.eyebrow}>{restaurant.city.name}, {restaurant.city.region}</Text>
+      <Text style={styles.headline}>{restaurant.name}</Text>
+      <Text style={styles.summary}>
+        Showing <Text style={styles.bold}>{totalVisible}</Text> item
+        {totalVisible === 1 ? '' : 's'} that match your filter
+        {totalHidden > 0 ? `, hiding ${totalHidden}.` : '.'}
+      </Text>
+      <FilterBadge filter={filter} />
+
+      {sections.map((section) => (
+        <SectionBlock key={section.id ?? '__none__'} section={section} />
+      ))}
+
+      {sections.length === 0 && (
+        <Text style={styles.empty}>No published items at this restaurant yet.</Text>
+      )}
+    </ScrollView>
+  );
+}
+
+function FilterBadge({ filter }: { filter: FilterSummary }) {
+  const label =
+    filter.source === 'preset'
+      ? `Preset · ${filter.preset_slug ?? 'unknown'}`
+      : filter.source === 'user_profile'
+      ? 'Your saved profile'
+      : 'No filter';
+  return (
+    <View style={styles.filterBadge} testID="filter-badge">
+      <Text style={styles.filterText}>
+        {label} · {filter.strictness}
+      </Text>
+    </View>
+  );
+}
+
+function SectionBlock({ section }: { section: ItemSection }) {
+  const [hiddenOpen, setHiddenOpen] = useState(false);
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionName}>{section.name}</Text>
+
+      {section.visible.map((item) => (
+        <ItemRow key={item.id} item={item} />
+      ))}
+
+      {section.visible.length === 0 && section.hidden.length > 0 && (
+        <Text style={styles.muted}>
+          Every item in this section is hidden by your filter.
+        </Text>
+      )}
+
+      {section.hidden.length > 0 && (
+        <Pressable
+          onPress={() => setHiddenOpen((v) => !v)}
+          accessibilityLabel={`toggle-hidden-${section.id ?? 'none'}`}
+          style={styles.hiddenToggle}
+        >
+          <Text style={styles.hiddenToggleText}>
+            {hiddenOpen ? '▾ Hide' : '▸ Show'} items hidden by your filter (
+            {section.hidden.length})
+          </Text>
+        </Pressable>
+      )}
+
+      {hiddenOpen &&
+        section.hidden.map((item) => <ItemRow key={item.id} item={item} hidden />)}
+    </View>
+  );
+}
+
+function ItemRow({ item, hidden = false }: { item: FilteredItem; hidden?: boolean }) {
+  return (
+    <View
+      style={[styles.itemRow, hidden && styles.itemRowHidden]}
+      testID={`item-${item.id}`}
+    >
+      <Text style={[styles.itemName, hidden && styles.itemNameHidden]}>{item.name}</Text>
+      {item.description ? (
+        <Text style={[styles.itemDescription, hidden && styles.itemNameHidden]}>
+          {item.description}
+        </Text>
+      ) : null}
+      {hidden && (
+        <View style={styles.reasonsBlock}>
+          {item.reasons.map((r, idx) => (
+            <Text key={idx} style={styles.reasonText}>
+              {reasonLabel(r)}
+            </Text>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function reasonLabel(r: FilteredItem['reasons'][number]): string {
+  switch (r.kind) {
+    case 'avoid_ingredient':
+      return '• avoids ingredient';
+    case 'avoid_tag':
+      return '• avoids tag';
+    case 'unconfirmed_strict':
+      return `• not confirmed (${r.confidence}) — strict mode`;
+  }
+}
+
+function CenteredMessage({ text }: { text: string }) {
+  return (
+    <View style={styles.center}>
+      <Text style={styles.body}>{text}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  content: {
+    paddingTop: 60,
+    paddingHorizontal: space['6'],
+    paddingBottom: space['12'],
+    gap: space['3'],
+  },
+  center: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: space['6'],
+  },
+  eyebrow: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  headline: {
+    fontSize: fontSize['2xl'],
+    fontWeight: '700',
+    color: colors.text,
+  },
+  summary: {
+    fontSize: fontSize.base,
+    color: colors.text,
+  },
+  bold: {
+    fontWeight: '700',
+  },
+  body: {
+    fontSize: fontSize.base,
+    color: colors.text,
+  },
+  empty: {
+    color: colors.textMuted,
+    fontSize: fontSize.base,
+    paddingVertical: space['6'],
+    textAlign: 'center',
+  },
+  muted: {
+    color: colors.textMuted,
+    fontSize: fontSize.sm,
+    paddingVertical: space['2'],
+  },
+  filterBadge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: space['3'],
+    paddingVertical: space['1'],
+    borderRadius: 999,
+    backgroundColor: colors.biteLight,
+  },
+  filterText: {
+    color: colors.biteDark,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+  },
+  section: {
+    marginTop: space['4'],
+    gap: space['2'],
+  },
+  sectionName: {
+    fontSize: fontSize.lg,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  itemRow: {
+    paddingVertical: space['3'],
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  itemRowHidden: {
+    opacity: 0.55,
+  },
+  itemName: {
+    fontSize: fontSize.base,
+    color: colors.text,
+    fontWeight: '600',
+  },
+  itemNameHidden: {
+    color: colors.hide,
+  },
+  itemDescription: {
+    fontSize: fontSize.sm,
+    color: colors.textMuted,
+    marginTop: 2,
+  },
+  reasonsBlock: {
+    marginTop: 4,
+    gap: 2,
+  },
+  reasonText: {
+    fontSize: fontSize.xs,
+    color: colors.hide,
+  },
+  hiddenToggle: {
+    paddingVertical: space['2'],
+  },
+  hiddenToggleText: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -1,0 +1,154 @@
+/**
+ * Phase 3.3 — restaurant + filtered-items fetchers.
+ *
+ * `fetchRestaurant(id)` powers the page header (name + city).
+ * `fetchRestaurantItems(id, jwt?)` returns the per-item filter
+ * verdict the screen renders. The server applies the filter using
+ * `current_user.profile` when a JWT is supplied (per Phase 1.7) so
+ * the client never recomputes it.
+ *
+ * Both endpoints work anonymously — the JWT is optional.
+ */
+
+const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export interface FetchOptions {
+  fetchImpl?: typeof fetch;
+}
+
+export interface RestaurantCity {
+  id: string;
+  slug: string;
+  name: string;
+  region: string;
+}
+
+export interface Restaurant {
+  id: string;
+  slug: string;
+  name: string;
+  about: string | null;
+  phone: string | null;
+  website: string | null;
+  status: string;
+  city: RestaurantCity;
+}
+
+export type ItemStatus = 'visible' | 'hidden';
+
+export type HideReason =
+  | { kind: 'avoid_ingredient'; ingredient_id: string }
+  | { kind: 'avoid_tag'; tag_id: string }
+  | { kind: 'unconfirmed_strict'; confidence: string };
+
+export interface FilteredItem {
+  id: string;
+  restaurant_id: string;
+  name: string;
+  description: string;
+  confidence: 'confirmed' | 'suggested' | 'inferred';
+  popularity: number;
+  ingredient_ids: string[];
+  tag_ids: string[];
+  menu_section_id: string | null;
+  menu_section_name: string | null;
+  status: ItemStatus;
+  reasons: HideReason[];
+}
+
+export interface FilterSummary {
+  source: 'preset' | 'user_profile' | 'none';
+  preset_slug: string | null;
+  strictness: 'relaxed' | 'balanced' | 'strict';
+  avoid_ingredient_ids: string[];
+  avoid_tag_ids: string[];
+}
+
+export interface RestaurantItemsResponse {
+  restaurant_id: string;
+  filter: FilterSummary;
+  items: FilteredItem[];
+}
+
+export class RestaurantFetchError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RestaurantFetchError';
+  }
+}
+
+export async function fetchRestaurant(
+  id: string,
+  opts: FetchOptions = {},
+): Promise<Restaurant> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/restaurants/${id}`);
+  if (!res.ok) throw new RestaurantFetchError(res.status, `fetchRestaurant ${id} failed: ${res.status}`);
+  return (await res.json()) as Restaurant;
+}
+
+export interface FetchItemsOptions extends FetchOptions {
+  jwt?: string;
+  /** Override the server's chosen profile with a preset slug. */
+  presetSlug?: string;
+  /** Override the server's chosen strictness for this request. */
+  strictness?: 'relaxed' | 'balanced' | 'strict';
+}
+
+export async function fetchRestaurantItems(
+  id: string,
+  opts: FetchItemsOptions = {},
+): Promise<RestaurantItemsResponse> {
+  const { fetchImpl = fetch, jwt, presetSlug, strictness } = opts;
+  const url = new URL(`${API_BASE}/api/v1/restaurants/${id}/items`);
+  if (presetSlug) url.searchParams.set('profile', presetSlug);
+  if (strictness) url.searchParams.set('strictness', strictness);
+
+  const headers: Record<string, string> = {};
+  if (jwt) headers.Authorization = `Bearer ${jwt}`;
+
+  const res = await fetchImpl(url.toString(), { headers });
+  if (!res.ok) throw new RestaurantFetchError(res.status, `fetchRestaurantItems ${id} failed: ${res.status}`);
+  return (await res.json()) as RestaurantItemsResponse;
+}
+
+/**
+ * Group filtered items by their menu section. Items with no
+ * `menu_section_id` end up in the catch-all "Other" group at the end.
+ * Within each section, items are ordered visible-first, hidden-last
+ * (the server already orders by popularity); the screen flattens the
+ * groups and renders an expander around the hidden tail.
+ */
+export interface ItemSection {
+  id: string | null;
+  name: string;
+  visible: FilteredItem[];
+  hidden: FilteredItem[];
+}
+
+export function groupItemsBySection(items: FilteredItem[]): ItemSection[] {
+  const order: (string | null)[] = [];
+  const lookup = new Map<string | null, ItemSection>();
+
+  for (const item of items) {
+    const sectionId = item.menu_section_id;
+    let section = lookup.get(sectionId);
+    if (!section) {
+      section = {
+        id: sectionId,
+        name: item.menu_section_name ?? 'Other',
+        visible: [],
+        hidden: [],
+      };
+      lookup.set(sectionId, section);
+      order.push(sectionId);
+    }
+    if (item.status === 'visible') section.visible.push(item);
+    else section.hidden.push(item);
+  }
+
+  return order.map((id) => lookup.get(id)!);
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,14 +13,13 @@ the merge / review / status rules.
 
 **Phase 3** ⭐ Dietary filter UI. Subplan: `docs/plans/phase-3.md`.
 
-1. **Phase 3.2 — Mobile profile onboarding (6 taps)** (`docs/plans/phase-3.md#32`) — this PR
-2. **Phase 3.3 — Mobile filtered restaurant page** (`docs/plans/phase-3.md#33`)
-3. **Phase 3.4 — Transparency layer + one-tap override** (`docs/plans/phase-3.md#34`)
-4. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`)
-5. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
-6. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
-7. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
-8. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
+1. **Phase 3.3 — Mobile filtered restaurant page** (`docs/plans/phase-3.md#33`) — this PR
+2. **Phase 3.4 — Transparency layer + one-tap override** (`docs/plans/phase-3.md#34`)
+3. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`)
+4. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
+5. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
+6. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
+7. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
 
 ### Done
 
@@ -44,6 +43,7 @@ the merge / review / status rules.
 - ✅ Phase 2.9 — cost + latency dashboard at /admin/dashboard (#144)
 - ✅ Phase 3 — subplan committed (#145)
 - ✅ Phase 3.1 — production-ready dietary profile seeds (#146)
+- ✅ Phase 3.2 — mobile profile onboarding (6 taps) (#147)
 
 After Phase 3 ships, the loop will draft `docs/plans/phase-4.md` (reviews + accounts) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,27 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 05:00 — tick #53. PR #147 (Phase 3.2) merged at 03:21 UTC.
+Picked up Phase 3.3 — mobile filtered restaurant page. Found a Phase
+1.7 gap on the way: `routes.rb` exposed `api/v1/restaurants#index` +
+`#show` but no controller existed (every hit would have 500'd with
+NameError). Built the minimal `RestaurantsController#show` (id, slug,
+name, status, city — what the page header needs) and added a
+3-case rspec for it. Also extended `ItemsController#serialize_item`
+to include `menu_section_id` + `menu_section_name` so the screen can
+group items by menu section without a second roundtrip; added an
+`includes(menu_section: :menu)` to dodge N+1. New mobile pieces:
+`apps/mobile/lib/api/restaurants.ts` (fetchRestaurant +
+fetchRestaurantItems with optional jwt/preset/strictness +
+groupItemsBySection helper) and `apps/mobile/app/restaurants/[id].tsx`
+(header + filter badge + per-section visible-list + collapsed
+"Items hidden by your filter (N)" expander). 11 Jest cases lock down
+the API client (anonymous vs JWT, query params) + the section
+grouping (server-order preservation, visible/hidden split, "Other"
+catch-all). 4 new rspec cases (3 for restaurants#show, 1 for the new
+menu_section payload). Local: rspec 177/0/1 pending; mobile jest
+32/32; pnpm typecheck/lint cached green.
+
 2026-05-01 04:30 — tick #52. PR #146 (Phase 3.1) merged at 04:18 UTC.
 Picked up Phase 3.2 — mobile profile onboarding (6 taps). New API
 surface: `GET /api/v1/dietary_profiles` (presets sorted by name with


### PR DESCRIPTION
## Summary

Phase 3.3 ships the actual filter-the-menu screen — open `/restaurants/[id]` on mobile, see the items grouped by section, hidden items collapse behind a section-local expander. Subplan: `docs/plans/phase-3.md#33`.

### API
- **New `GET /api/v1/restaurants/:id`** — Phase 1.7 mounted the route but never shipped the controller (every hit would have NameError'd). Returns id/slug/name/status/about/phone/website + city {slug, name, region}. Public.
- **Items endpoint extended**: each serialized item now carries `menu_section_id` + `menu_section_name`, and the index query preloads `menu_section: :menu` to dodge N+1.

### Mobile
- `apps/mobile/lib/api/restaurants.ts` — `fetchRestaurant`, `fetchRestaurantItems` (optional `jwt`, `presetSlug`, `strictness` query params), `groupItemsBySection` helper that preserves server order and splits visible vs hidden.
- `apps/mobile/app/restaurants/[id].tsx` — header (city eyebrow + restaurant name + filter source/strictness badge) and per-section item lists. Visible up top; hidden collapsed behind an "Items hidden by your filter (N)" expander per section.

## Out of scope
- Translated `<HiddenReasonChip>` per reason kind + per-item "show anyway" override — both land in **Phase 3.4** (the screen currently labels reasons by raw kind so the structure is in place).
- Strict-mode toggle — **Phase 3.5**.
- Web mirror — **Phase 3.6**.

## Test plan
- [x] Mobile Jest: 11 cases (anonymous vs JWT, presetSlug + strictness query params, section grouping incl. "Other" catch-all and visible/hidden split).
- [x] API rspec: 3 cases for `restaurants#show` (404 unknown id, 404 draft, happy path with city). 1 new case for the `menu_section_*` payload on the items endpoint.
- [x] `pnpm typecheck` / `pnpm lint` green across the monorepo.
- [x] `bundle exec rspec` 177/0/1 pending (the pending is the existing `ANTHROPIC_API_KEY` cassette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)