### PR TITLE
feat(api,mobile): transparency chips + show-anyway override (phase 3.4)

### DIFF
--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -26,7 +26,8 @@ module Api
                                .to_a
 
         filter = build_filter
-        rendered = items.map { |item| serialize_item(item, filter) }
+        labels = build_label_lookup(items, filter)
+        rendered = items.map { |item| serialize_item(item, filter, labels) }
 
         render json: {
           restaurant_id: restaurant.id,
@@ -37,7 +38,8 @@ module Api
 
       def show
         item = Restaurant.published.find(params[:restaurant_id]).items.published.find(params[:id])
-        render json: serialize_item(item, build_filter)
+        filter = build_filter
+        render json: serialize_item(item, filter, build_label_lookup([item], filter))
       end
 
       private
@@ -81,15 +83,30 @@ module Api
       end
 
       # Compute reasons WHY an item would be hidden under this filter.
-      # An empty reasons array means the item passes the filter.
-      def hide_reasons(item, filter)
+      # An empty reasons array means the item passes the filter. Each
+      # reason is enriched with display strings (`*_name`, `*_family`)
+      # so the mobile/web HiddenReasonChip is a pure render — no
+      # second roundtrip to look up names.
+      def hide_reasons(item, filter, labels)
         reasons = []
 
         (item.ingredient_ids & filter.avoid_ingredient_ids).each do |ing_id|
-          reasons << { kind: "avoid_ingredient", ingredient_id: ing_id }
+          ing = labels[:ingredients][ing_id]
+          reasons << {
+            kind:              "avoid_ingredient",
+            ingredient_id:     ing_id,
+            ingredient_name:   ing&.dig(:name),
+            ingredient_family: ing&.dig(:family)
+          }
         end
         (item.tag_ids & filter.avoid_tag_ids).each do |tag_id|
-          reasons << { kind: "avoid_tag", tag_id: tag_id }
+          tag = labels[:tags][tag_id]
+          reasons << {
+            kind:       "avoid_tag",
+            tag_id:     tag_id,
+            tag_name:   tag&.dig(:name),
+            tag_family: tag&.dig(:family)
+          }
         end
         if filter.strictness == "strict" && item.confidence != "confirmed"
           reasons << { kind: "unconfirmed_strict", confidence: item.confidence }
@@ -98,10 +115,30 @@ module Api
         reasons
       end
 
+      # Bulk-load names + family strings for every ingredient/tag id
+      # the filter could possibly cite. Keyed by id so `hide_reasons`
+      # is a hash lookup. Family for ingredients = first ltree segment
+      # (e.g. `dairy.cheddar` -> `dairy`); for tags it's the model
+      # column.
+      def build_label_lookup(items, filter)
+        cited_ingredient_ids = items.flat_map(&:ingredient_ids).uniq & filter.avoid_ingredient_ids
+        cited_tag_ids        = items.flat_map(&:tag_ids).uniq        & filter.avoid_tag_ids
+
+        ingredient_labels = Ingredient.where(id: cited_ingredient_ids)
+                                      .pluck(:id, :name, :path)
+                                      .to_h { |id, name, path| [id, { name: name, family: path.to_s.split(".").first }] }
+
+        tag_labels = Tag.where(id: cited_tag_ids)
+                        .pluck(:id, :name, :family)
+                        .to_h { |id, name, family| [id, { name: name, family: family }] }
+
+        { ingredients: ingredient_labels, tags: tag_labels }
+      end
+
       # Try to keep this stable — mobile + web bind to these keys via
       # generated TS types; Phase 1.6's openapi.json should match.
-      def serialize_item(item, filter)
-        reasons = hide_reasons(item, filter)
+      def serialize_item(item, filter, labels)
+        reasons = hide_reasons(item, filter, labels)
         section = item.menu_section
         {
           id:                 item.id,

--- a/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
@@ -79,6 +79,27 @@ RSpec.describe "GET /api/v1/restaurants/:id/items", type: :request do
       )
     end
 
+    it "enriches reasons with the human name + family for the chip (Phase 3.4)" do
+      # The factory's `dairy-cheese` slug maps to name=Cheese, path=dairy.cheese.
+      # The `allergen-contains-dairy` tag has family=allergen.
+      get "/api/v1/restaurants/#{restaurant.id}/items?profile=vegan"
+
+      reasons = response.parsed_body["items"]
+                        .find { |i| i["name"] == "Cheese Quesadilla" }["reasons"]
+                        .index_by { |r| r["kind"] }
+
+      expect(reasons["avoid_ingredient"]).to include(
+        "ingredient_id"     => cheese.id,
+        "ingredient_name"   => "Cheese",
+        "ingredient_family" => "dairy"
+      )
+      expect(reasons["avoid_tag"]).to include(
+        "tag_id"     => contains_dairy_tag.id,
+        "tag_name"   => "Contains Dairy",
+        "tag_family" => "allergen"
+      )
+    end
+
     it "404s on an unknown profile slug" do
       get "/api/v1/restaurants/#{restaurant.id}/items?profile=no-such-thing"
       expect(response).to have_http_status(:not_found)

--- a/apps/mobile/__tests__/lib/hidden-reason.test.ts
+++ b/apps/mobile/__tests__/lib/hidden-reason.test.ts
@@ -1,0 +1,82 @@
+import { hiddenReasonHeadline, hiddenReasonLabel } from '../../lib/hidden-reason';
+import type { HideReason } from '../../lib/api/restaurants';
+
+const dairyCheese: HideReason = {
+  kind: 'avoid_ingredient',
+  ingredient_id: 'ing-cheese',
+  ingredient_name: 'Cheese',
+  ingredient_family: 'dairy',
+};
+
+const treeNutAlmond: HideReason = {
+  kind: 'avoid_ingredient',
+  ingredient_id: 'ing-almond',
+  ingredient_name: 'Almond',
+  ingredient_family: 'tree_nut',
+};
+
+const containsDairyTag: HideReason = {
+  kind: 'avoid_tag',
+  tag_id: 'tag-cd',
+  tag_name: 'Contains Dairy',
+  tag_family: 'allergen',
+};
+
+const strict: HideReason = {
+  kind: 'unconfirmed_strict',
+  confidence: 'suggested',
+};
+
+describe('hiddenReasonLabel', () => {
+  it('formats avoid_ingredient as "Contains <family> (<name>)"', () => {
+    expect(hiddenReasonLabel(dairyCheese)).toBe('Contains dairy (Cheese)');
+  });
+
+  it('humanizes snake_case families (tree_nut → tree nut)', () => {
+    expect(hiddenReasonLabel(treeNutAlmond)).toBe('Contains tree nut (Almond)');
+  });
+
+  it('formats avoid_tag as "Tagged <family>: <name>"', () => {
+    expect(hiddenReasonLabel(containsDairyTag)).toBe('Tagged allergen: Contains Dairy');
+  });
+
+  it('formats unconfirmed_strict with the AI confidence + strict-mode note', () => {
+    expect(hiddenReasonLabel(strict)).toBe('AI confidence: suggested (strict mode)');
+  });
+
+  it('falls back gracefully when family is missing', () => {
+    const noFamily: HideReason = {
+      kind: 'avoid_ingredient',
+      ingredient_id: 'ing-x',
+      ingredient_name: 'Mystery',
+      ingredient_family: null,
+    };
+    expect(hiddenReasonLabel(noFamily)).toBe('Contains restricted (Mystery)');
+  });
+
+  it('falls back gracefully when name is missing (ingredient deleted server-side)', () => {
+    const noName: HideReason = {
+      kind: 'avoid_ingredient',
+      ingredient_id: 'ing-gone',
+      ingredient_name: null,
+      ingredient_family: 'dairy',
+    };
+    expect(hiddenReasonLabel(noName)).toBe('Contains dairy (ingredient)');
+  });
+});
+
+describe('hiddenReasonHeadline', () => {
+  it('returns empty string for no reasons', () => {
+    expect(hiddenReasonHeadline([])).toBe('');
+  });
+
+  it('shows the first reason for a single reason', () => {
+    expect(hiddenReasonHeadline([dairyCheese])).toBe('Hidden — Contains dairy (Cheese)');
+  });
+
+  it('appends "(+N more)" for multi-reason items', () => {
+    expect(hiddenReasonHeadline([dairyCheese, containsDairyTag, strict])).toBe(
+      'Hidden — Contains dairy (Cheese) (+2 more)',
+    );
+  });
+});

--- a/apps/mobile/__tests__/lib/restaurant-overrides.test.ts
+++ b/apps/mobile/__tests__/lib/restaurant-overrides.test.ts
@@ -1,0 +1,83 @@
+import { applyOverrides } from '../../lib/restaurant-overrides';
+import type { FilteredItem, ItemSection } from '../../lib/api/restaurants';
+
+function item(overrides: Partial<FilteredItem>): FilteredItem {
+  return {
+    id: overrides.id ?? 'item-?',
+    restaurant_id: 'rest-1',
+    name: overrides.name ?? 'Item',
+    description: '',
+    confidence: 'confirmed',
+    popularity: 0,
+    ingredient_ids: [],
+    tag_ids: [],
+    menu_section_id: null,
+    menu_section_name: null,
+    status: 'visible',
+    reasons: [],
+    ...overrides,
+  };
+}
+
+function section(visible: FilteredItem[], hidden: FilteredItem[]): ItemSection {
+  return {
+    id: 'tacos',
+    name: 'Tacos',
+    visible,
+    hidden,
+  };
+}
+
+describe('applyOverrides', () => {
+  const visible = item({ id: 'v1', status: 'visible' });
+  const hiddenA = item({
+    id: 'h1',
+    status: 'hidden',
+    reasons: [
+      {
+        kind: 'avoid_ingredient',
+        ingredient_id: 'ing-x',
+        ingredient_name: 'Cheese',
+        ingredient_family: 'dairy',
+      },
+    ],
+  });
+  const hiddenB = item({
+    id: 'h2',
+    status: 'hidden',
+    reasons: [
+      {
+        kind: 'avoid_tag',
+        tag_id: 'tag-y',
+        tag_name: 'Contains Dairy',
+        tag_family: 'allergen',
+      },
+    ],
+  });
+
+  it('returns the input unchanged when no overrides are active', () => {
+    const sections = [section([visible], [hiddenA, hiddenB])];
+    expect(applyOverrides(sections, new Set())).toBe(sections);
+  });
+
+  it('promotes overridden items into the visible bucket of their section', () => {
+    const sections = [section([visible], [hiddenA, hiddenB])];
+    const result = applyOverrides(sections, new Set(['h1']));
+    expect(result[0]!.visible.map((i) => i.id)).toEqual(['v1', 'h1']);
+    expect(result[0]!.hidden.map((i) => i.id)).toEqual(['h2']);
+  });
+
+  it('leaves other sections untouched (referential equality preserved)', () => {
+    const tacos = section([visible], [hiddenA]);
+    const bowls: ItemSection = { id: 'bowls', name: 'Bowls', visible: [], hidden: [] };
+    const result = applyOverrides([tacos, bowls], new Set(['h1']));
+    expect(result[1]).toBe(bowls); // untouched section keeps identity
+  });
+
+  it('promotes multiple items across one section in one pass', () => {
+    const sections = [section([visible], [hiddenA, hiddenB])];
+    const result = applyOverrides(sections, new Set(['h1', 'h2']));
+    expect(result[0]!.visible.map((i) => i.id)).toEqual(['v1', 'h1', 'h2']);
+    expect(result[0]!.hidden).toEqual([]);
+  });
+});

--- a/apps/mobile/__tests__/lib/restaurants.test.ts
+++ b/apps/mobile/__tests__/lib/restaurants.test.ts
@@ -127,7 +127,14 @@ describe('groupItemsBySection', () => {
         menu_section_id: 's1',
         menu_section_name: 'S1',
         status: 'hidden',
-        reasons: [{ kind: 'avoid_ingredient', ingredient_id: 'ing-x' }],
+        reasons: [
+          {
+            kind: 'avoid_ingredient',
+            ingredient_id: 'ing-x',
+            ingredient_name: 'Cheese',
+            ingredient_family: 'dairy',
+          },
+        ],
       }),
     ]);
     expect(sections[0]!.visible.map((i) => i.id)).toEqual(['v1']);

--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -14,25 +14,24 @@ import {
   fetchRestaurantItems,
   groupItemsBySection,
   type FilteredItem,
+  type HideReason,
   type ItemSection,
   type Restaurant,
   type FilterSummary,
 } from '../../lib/api/restaurants';
+import { hiddenReasonLabel } from '../../lib/hidden-reason';
+import { applyOverrides } from '../../lib/restaurant-overrides';
 
 /**
- * Phase 3.3 — filtered restaurant page.
+ * Phase 3.3 + 3.4 — filtered restaurant page with transparency chips
+ * and a session-only override.
  *
- *   1. Hits GET /api/v1/restaurants/:id for header info.
- *   2. Hits GET /api/v1/restaurants/:id/items (with optional JWT).
- *      Server applies the user's profile when authed (Phase 1.7).
- *   3. Renders sections + items; visible up top, hidden behind a
- *      "Items hidden by your filter (N)" expander per section.
- *
- * The transparency-chip translation + per-item override land in
- * Phase 3.4 — for now the screen labels hidden items with a generic
- * "Hidden" tag and lists their reasons by raw kind. Same JWT-pasted-
- * in-input workaround as the ingest/onboarding screens until Phase 4
- * brings expo-secure-store.
+ * Each hidden item now renders one <HiddenReasonChip> per reason
+ * (e.g. "Contains dairy (Cheese)"), and a "Show anyway" pressable
+ * that flips the item to visible **client-side only** — no server
+ * roundtrip, no profile mutation. The override resets when the
+ * screen unmounts; Phase 4 introduces a persisted "never hide this
+ * dish" override on UserProfile.
  */
 
 export default function RestaurantScreen() {
@@ -45,12 +44,14 @@ export default function RestaurantScreen() {
   const [sections, setSections] = useState<ItemSection[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [shownAnyway, setShownAnyway] = useState<Set<string>>(() => new Set());
 
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setShownAnyway(new Set());
 
     Promise.all([fetchRestaurant(id), fetchRestaurantItems(id, { jwt })])
       .then(([r, itemsRes]) => {
@@ -72,6 +73,20 @@ export default function RestaurantScreen() {
     };
   }, [id, jwt]);
 
+  const toggleOverride = (itemId: string) => {
+    setShownAnyway((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  };
+
+  const overriddenSections = useMemo(
+    () => applyOverrides(sections, shownAnyway),
+    [sections, shownAnyway],
+  );
+
   if (!id) {
     return <CenteredMessage text="Missing restaurant id." />;
   }
@@ -89,8 +104,8 @@ export default function RestaurantScreen() {
     return <CenteredMessage text="Restaurant not found." />;
   }
 
-  const totalHidden = sections.reduce((acc, s) => acc + s.hidden.length, 0);
-  const totalVisible = sections.reduce((acc, s) => acc + s.visible.length, 0);
+  const totalHidden = overriddenSections.reduce((acc, s) => acc + s.hidden.length, 0);
+  const totalVisible = overriddenSections.reduce((acc, s) => acc + s.visible.length, 0);
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -103,11 +118,16 @@ export default function RestaurantScreen() {
       </Text>
       <FilterBadge filter={filter} />
 
-      {sections.map((section) => (
-        <SectionBlock key={section.id ?? '__none__'} section={section} />
+      {overriddenSections.map((section) => (
+        <SectionBlock
+          key={section.id ?? '__none__'}
+          section={section}
+          shownAnyway={shownAnyway}
+          onToggleOverride={toggleOverride}
+        />
       ))}
 
-      {sections.length === 0 && (
+      {overriddenSections.length === 0 && (
         <Text style={styles.empty}>No published items at this restaurant yet.</Text>
       )}
     </ScrollView>
@@ -130,14 +150,27 @@ function FilterBadge({ filter }: { filter: FilterSummary }) {
   );
 }
 
-function SectionBlock({ section }: { section: ItemSection }) {
+function SectionBlock({
+  section,
+  shownAnyway,
+  onToggleOverride,
+}: {
+  section: ItemSection;
+  shownAnyway: Set<string>;
+  onToggleOverride: (itemId: string) => void;
+}) {
   const [hiddenOpen, setHiddenOpen] = useState(false);
   return (
     <View style={styles.section}>
       <Text style={styles.sectionName}>{section.name}</Text>
 
       {section.visible.map((item) => (
-        <ItemRow key={item.id} item={item} />
+        <ItemRow
+          key={item.id}
+          item={item}
+          overridden={shownAnyway.has(item.id)}
+          onToggleOverride={onToggleOverride}
+        />
       ))}
 
       {section.visible.length === 0 && section.hidden.length > 0 && (
@@ -160,12 +193,33 @@ function SectionBlock({ section }: { section: ItemSection }) {
       )}
 
       {hiddenOpen &&
-        section.hidden.map((item) => <ItemRow key={item.id} item={item} hidden />)}
+        section.hidden.map((item) => (
+          <ItemRow
+            key={item.id}
+            item={item}
+            hidden
+            overridden={false}
+            onToggleOverride={onToggleOverride}
+          />
+        ))}
     </View>
   );
 }
 
-function ItemRow({ item, hidden = false }: { item: FilteredItem; hidden?: boolean }) {
+function ItemRow({
+  item,
+  hidden = false,
+  overridden,
+  onToggleOverride,
+}: {
+  item: FilteredItem;
+  hidden?: boolean;
+  overridden: boolean;
+  onToggleOverride: (itemId: string) => void;
+}) {
+  // An item with reasons but rendered in the visible column means the
+  // user tapped "show anyway" — keep the chips visible as a cue.
+  const showChips = hidden || overridden;
   return (
     <View
       style={[styles.itemRow, hidden && styles.itemRowHidden]}
@@ -177,28 +231,36 @@ function ItemRow({ item, hidden = false }: { item: FilteredItem; hidden?: boolea
           {item.description}
         </Text>
       ) : null}
-      {hidden && (
-        <View style={styles.reasonsBlock}>
+
+      {showChips && item.reasons.length > 0 && (
+        <View style={styles.chipRow}>
           {item.reasons.map((r, idx) => (
-            <Text key={idx} style={styles.reasonText}>
-              {reasonLabel(r)}
-            </Text>
+            <HiddenReasonChip key={idx} reason={r} />
           ))}
         </View>
+      )}
+
+      {item.reasons.length > 0 && (
+        <Pressable
+          accessibilityLabel={`toggle-override-${item.id}`}
+          onPress={() => onToggleOverride(item.id)}
+          style={styles.overrideButton}
+        >
+          <Text style={styles.overrideText}>
+            {overridden ? 'Hide again' : 'Show anyway'}
+          </Text>
+        </Pressable>
       )}
     </View>
   );
 }
 
-function reasonLabel(r: FilteredItem['reasons'][number]): string {
-  switch (r.kind) {
-    case 'avoid_ingredient':
-      return '• avoids ingredient';
-    case 'avoid_tag':
-      return '• avoids tag';
-    case 'unconfirmed_strict':
-      return `• not confirmed (${r.confidence}) — strict mode`;
-  }
+export function HiddenReasonChip({ reason }: { reason: HideReason }) {
+  return (
+    <View style={styles.chip} testID={`chip-${reason.kind}`}>
+      <Text style={styles.chipText}>{hiddenReasonLabel(reason)}</Text>
+    </View>
+  );
 }
 
 function CenteredMessage({ text }: { text: string }) {
@@ -303,13 +365,34 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     marginTop: 2,
   },
-  reasonsBlock: {
-    marginTop: 4,
-    gap: 2,
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: space['1'],
+    marginTop: space['2'],
   },
-  reasonText: {
+  chip: {
+    paddingHorizontal: space['2'],
+    paddingVertical: space['0_5'],
+    borderRadius: 999,
+    backgroundColor: colors.bgAlt,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  chipText: {
     fontSize: fontSize.xs,
     color: colors.hide,
+    fontWeight: '600',
+  },
+  overrideButton: {
+    marginTop: space['2'],
+    paddingVertical: space['1'],
+    alignSelf: 'flex-start',
+  },
+  overrideText: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
   },
   hiddenToggle: {
     paddingVertical: space['2'],

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -37,8 +37,18 @@ export interface Restaurant {
 export type ItemStatus = 'visible' | 'hidden';
 
 export type HideReason =
-  | { kind: 'avoid_ingredient'; ingredient_id: string }
-  | { kind: 'avoid_tag'; tag_id: string }
+  | {
+      kind: 'avoid_ingredient';
+      ingredient_id: string;
+      ingredient_name: string | null;
+      ingredient_family: string | null;
+    }
+  | {
+      kind: 'avoid_tag';
+      tag_id: string;
+      tag_name: string | null;
+      tag_family: string | null;
+    }
   | { kind: 'unconfirmed_strict'; confidence: string };
 
 export interface FilteredItem {

--- a/apps/mobile/lib/hidden-reason.ts
+++ b/apps/mobile/lib/hidden-reason.ts
@@ -1,0 +1,41 @@
+/**
+ * Phase 3.4 — translate the {kind, *_id, *_name, *_family} reason
+ * shape from the items endpoint into a human chip label.
+ *
+ * Pure function so tests can lock the strings down without mounting
+ * React. The screen wraps the result in a styled chip; the web app
+ * (Phase 3.6) will reuse this same helper.
+ */
+import type { HideReason } from './api/restaurants';
+
+/** Family slugs use snake_case (e.g. `tree_nut`). Display in regular words. */
+function humanizeFamily(family: string | null | undefined): string {
+  if (!family) return 'restricted';
+  return family.replace(/_/g, ' ');
+}
+
+export function hiddenReasonLabel(reason: HideReason): string {
+  switch (reason.kind) {
+    case 'avoid_ingredient': {
+      const family = humanizeFamily(reason.ingredient_family);
+      const name = reason.ingredient_name ?? 'ingredient';
+      return `Contains ${family} (${name})`;
+    }
+    case 'avoid_tag': {
+      const family = humanizeFamily(reason.tag_family);
+      const name = reason.tag_name ?? 'tag';
+      return `Tagged ${family}: ${name}`;
+    }
+    case 'unconfirmed_strict':
+      return `AI confidence: ${reason.confidence} (strict mode)`;
+  }
+}
+
+/** A short headline for the row when there's no room for the full chip list. */
+export function hiddenReasonHeadline(reasons: HideReason[]): string {
+  if (reasons.length === 0) return '';
+  const first = reasons[0]!;
+  const more = reasons.length - 1;
+  const suffix = more > 0 ? ` (+${more} more)` : '';
+  return `Hidden — ${hiddenReasonLabel(first)}${suffix}`;
+}

--- a/apps/mobile/lib/restaurant-overrides.ts
+++ b/apps/mobile/lib/restaurant-overrides.ts
@@ -1,0 +1,32 @@
+/**
+ * Phase 3.4 — apply session-only "show anyway" overrides to grouped
+ * restaurant items. Pure helper so the screen stays small and the
+ * test suite doesn't need to mount React Native.
+ *
+ * Items in `shownAnyway` are moved from each section's `hidden`
+ * bucket into its `visible` bucket. The underlying item still
+ * carries `status: "hidden"` and its reasons[]; the chip UI keeps
+ * showing them so the override is transparent to the user.
+ */
+import type { FilteredItem, ItemSection } from './api/restaurants';
+
+export function applyOverrides(
+  sections: ItemSection[],
+  shownAnyway: Set<string>,
+): ItemSection[] {
+  if (shownAnyway.size === 0) return sections;
+  return sections.map((section) => {
+    const stillHidden: FilteredItem[] = [];
+    const promoted: FilteredItem[] = [];
+    for (const item of section.hidden) {
+      if (shownAnyway.has(item.id)) promoted.push(item);
+      else stillHidden.push(item);
+    }
+    if (promoted.length === 0) return section;
+    return {
+      ...section,
+      visible: [...section.visible, ...promoted],
+      hidden: stillHidden,
+    };
+  });
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,13 +13,12 @@ the merge / review / status rules.
 
 **Phase 3** ⭐ Dietary filter UI. Subplan: `docs/plans/phase-3.md`.
 
-1. **Phase 3.3 — Mobile filtered restaurant page** (`docs/plans/phase-3.md#33`) — this PR
-2. **Phase 3.4 — Transparency layer + one-tap override** (`docs/plans/phase-3.md#34`)
-3. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`)
-4. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
-5. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
-6. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
-7. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
+1. **Phase 3.4 — Transparency layer + one-tap override** (`docs/plans/phase-3.md#34`) — this PR
+2. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`)
+3. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
+4. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
+5. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
+6. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
 
 ### Done
 
@@ -44,6 +43,7 @@ the merge / review / status rules.
 - ✅ Phase 3 — subplan committed (#145)
 - ✅ Phase 3.1 — production-ready dietary profile seeds (#146)
 - ✅ Phase 3.2 — mobile profile onboarding (6 taps) (#147)
+- ✅ Phase 3.3 — mobile filtered restaurant page (#148)
 
 After Phase 3 ships, the loop will draft `docs/plans/phase-4.md` (reviews + accounts) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,32 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 05:30 — tick #54. PR #148 (Phase 3.3) merged at 04:22 UTC.
+Picked up Phase 3.4 — transparency chips + session-only "show
+anyway" override. Backend: `ItemsController#hide_reasons` now
+enriches each reason with the human display strings the chip needs
+(`ingredient_name` + `ingredient_family` from the ltree path's first
+segment; `tag_name` + `tag_family` from the Tag model's family
+column). One bulk pluck per kind in `build_label_lookup`, joined to
+the items the request already loaded — avoids N+1 even with dozens
+of items. The reason payload stays self-contained so the mobile +
+web chips never make a second roundtrip. Mobile: pure helper at
+`apps/mobile/lib/hidden-reason.ts` formats reasons as "Contains
+dairy (Cheese)" / "Tagged allergen: Contains Dairy" / "AI
+confidence: suggested (strict mode)" with snake_case → space
+humanization (`tree_nut` → `tree nut`) and graceful name/family
+fallbacks. Pure helper at `apps/mobile/lib/restaurant-overrides.ts`
+re-buckets visible vs hidden based on a `Set<string>` of overridden
+ids; preserves section identity for non-touched sections. The
+restaurant screen wires both helpers in: every item with reasons[]
+gets a Show anyway / Hide again pressable, and the chip row stays
+visible after a "show anyway" so the override remains transparent
+to the user. The override resets on screen unmount/remount —
+Phase 4 introduces the persistent `UserProfile` override. 12 new
+Jest cases (6 chip label + 3 headline + 4 override). 1 new rspec
+case for the enriched reason payload. Local: rspec 178/0/1 pending;
+mobile jest 45/45; pnpm typecheck/lint cached green.
+
 2026-05-01 05:00 — tick #53. PR #147 (Phase 3.2) merged at 03:21 UTC.
 Picked up Phase 3.3 — mobile filtered restaurant page. Found a Phase
 1.7 gap on the way: `routes.rb` exposed `api/v1/restaurants#index` +


### PR DESCRIPTION
## Summary

Phase 3.4 lands the **honest disclosure** half of BiteWorthy's filter promise: every hidden item now tells the user *why* it's hidden in plain language ("Contains dairy (Cheese)"), and a one-tap "Show anyway" promotes the item without touching the server or mutating the user's profile. Subplan: `docs/plans/phase-3.md#34`.

### API
- `ItemsController#hide_reasons` enriches each reason with the human-readable name + family the chip needs:
  - `avoid_ingredient` → adds `ingredient_name` and `ingredient_family` (derived from the ltree path's first segment, e.g. `dairy.cheese` → `dairy`).
  - `avoid_tag` → adds `tag_name` and `tag_family` (the Tag model already carries `family`).
  - `unconfirmed_strict` → unchanged (the existing `confidence` is enough).
- One bulk `pluck` per kind in `build_label_lookup`, scoped to the ids the request actually loaded — no N+1.

### Mobile
- `apps/mobile/lib/hidden-reason.ts` — pure formatter. Snake_case families humanize to spaces (`tree_nut` → `tree nut`); name/family fallbacks keep the chip readable even if a record was deleted server-side.
- `apps/mobile/lib/restaurant-overrides.ts` — pure helper that re-buckets items based on a `Set<string>` of "shown anyway" ids. Preserves section identity for non-touched sections.
- `apps/mobile/app/restaurants/[id].tsx` — every item with reasons gets a `Show anyway` / `Hide again` pressable; the chip row stays visible after override so the user keeps seeing why the item was hidden.

## Out of scope
- Persistent "never hide this dish" override on `UserProfile` — Phase 4.
- Strict-mode toggle in the header — Phase 3.5.
- Web mirror — Phase 3.6.

## Test plan
- [x] Mobile Jest: 12 new cases (6 chip-label permutations incl. snake_case + null fallbacks; 3 headline; 4 override re-bucketing incl. referential identity preservation).
- [x] API rspec: 1 new case asserting the enriched `reasons[].ingredient_name|family` + `tag_name|family` shape.
- [x] `pnpm typecheck` / `pnpm lint` green across the monorepo.
- [x] `bundle exec rspec` 178/0/1 pending (the pending is the existing `ANTHROPIC_API_KEY` cassette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)