### PR TITLE
feat(mobile): strictness toggle in restaurant header (phase 3.5)

### DIFF
--- a/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
@@ -124,9 +124,22 @@ RSpec.describe "GET /api/v1/restaurants/:id/items", type: :request do
 
       expect(items["Carne Asada Taco"]["status"]).to    eq("visible") # confirmed
       expect(items["AI-Inferred Quinoa Bowl"]["status"]).to eq("hidden")
+      expect(body["filter"]["strictness"]).to eq("strict")
 
       reasons = items["AI-Inferred Quinoa Bowl"]["reasons"].map { |r| r["kind"] }
       expect(reasons).to include("unconfirmed_strict")
+    end
+
+    it "echoes 'relaxed' on filter.strictness when ?strictness=relaxed (Phase 3.5 toggle)" do
+      get "/api/v1/restaurants/#{restaurant.id}/items?strictness=relaxed"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["filter"]["strictness"]).to eq("relaxed")
+    end
+
+    it "ignores garbage values and falls back to balanced (defense-in-depth for the toggle)" do
+      get "/api/v1/restaurants/#{restaurant.id}/items?strictness=zomg-not-a-mode"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["filter"]["strictness"]).to eq("balanced")
     end
   end
 

--- a/apps/mobile/__tests__/lib/restaurants.test.ts
+++ b/apps/mobile/__tests__/lib/restaurants.test.ts
@@ -87,6 +87,22 @@ describe('fetchRestaurantItems', () => {
     expect(url).toContain('profile=vegan');
     expect(url).toContain('strictness=strict');
   });
+
+  it('omits the strictness param when undefined (server keeps profile default)', async () => {
+    const fetchImpl = fakeFetch(200, itemsPayload);
+    await fetchRestaurantItems('rest-1', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).not.toContain('strictness=');
+  });
+
+  it('passes each strictness value verbatim (relaxed | balanced | strict)', async () => {
+    for (const s of ['relaxed', 'balanced', 'strict'] as const) {
+      const fetchImpl = fakeFetch(200, itemsPayload);
+      await fetchRestaurantItems('rest-1', { fetchImpl, strictness: s });
+      const url = String(fetchImpl.mock.calls[0]![0]);
+      expect(url).toContain(`strictness=${s}`);
+    }
+  });
 });
 
 describe('groupItemsBySection', () => {

--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -23,16 +23,21 @@ import { hiddenReasonLabel } from '../../lib/hidden-reason';
 import { applyOverrides } from '../../lib/restaurant-overrides';
 
 /**
- * Phase 3.3 + 3.4 — filtered restaurant page with transparency chips
- * and a session-only override.
+ * Phase 3.3 + 3.4 + 3.5 — filtered restaurant page with transparency
+ * chips, a session-only override, and a strictness toggle.
  *
- * Each hidden item now renders one <HiddenReasonChip> per reason
- * (e.g. "Contains dairy (Cheese)"), and a "Show anyway" pressable
- * that flips the item to visible **client-side only** — no server
- * roundtrip, no profile mutation. The override resets when the
- * screen unmounts; Phase 4 introduces a persisted "never hide this
- * dish" override on UserProfile.
+ * Each hidden item renders one <HiddenReasonChip> per reason
+ * (e.g. "Contains dairy (Cheese)") and a "Show anyway" pressable that
+ * flips it to visible client-side only.
+ *
+ * The strictness toggle in the header sends `?strictness=…` on the
+ * next items refetch — the underlying user profile is unchanged. The
+ * override applies for this session only, the same way "show anyway"
+ * does. Phase 4 introduces a persistent profile-level toggle.
  */
+
+type Strictness = 'relaxed' | 'balanced' | 'strict';
+const STRICTNESSES: Strictness[] = ['relaxed', 'balanced', 'strict'];
 
 export default function RestaurantScreen() {
   const params = useLocalSearchParams<{ id: string; jwt?: string }>();
@@ -42,36 +47,62 @@ export default function RestaurantScreen() {
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
   const [filter, setFilter] = useState<FilterSummary | null>(null);
   const [sections, setSections] = useState<ItemSection[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingRestaurant, setLoadingRestaurant] = useState(true);
+  const [loadingItems, setLoadingItems] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [shownAnyway, setShownAnyway] = useState<Set<string>>(() => new Set());
+  // null = let the server pick (user profile or 'balanced'). Set by
+  // the toggle when the user wants to override for this session.
+  const [strictnessOverride, setStrictnessOverride] = useState<Strictness | null>(null);
 
+  // Load the restaurant header once per id. Toggling strictness later
+  // shouldn't re-fetch this — the header doesn't depend on it.
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
-    setLoading(true);
-    setError(null);
-    setShownAnyway(new Set());
-
-    Promise.all([fetchRestaurant(id), fetchRestaurantItems(id, { jwt })])
-      .then(([r, itemsRes]) => {
-        if (cancelled) return;
-        setRestaurant(r);
-        setFilter(itemsRes.filter);
-        setSections(groupItemsBySection(itemsRes.items));
+    setLoadingRestaurant(true);
+    fetchRestaurant(id)
+      .then((r) => {
+        if (!cancelled) setRestaurant(r);
       })
       .catch((e) => {
-        if (cancelled) return;
-        setError((e as Error).message);
+        if (!cancelled) setError((e as Error).message);
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setLoadingRestaurant(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  // Refetch items whenever id, jwt, or the strictness override change.
+  // Reset the per-item "show anyway" set so refetching clears stale
+  // overrides too (otherwise a swapped-out item id could still appear
+  // visible when the new payload says it isn't there).
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoadingItems(true);
+    setShownAnyway(new Set());
+
+    fetchRestaurantItems(id, { jwt, strictness: strictnessOverride ?? undefined })
+      .then((res) => {
+        if (cancelled) return;
+        setFilter(res.filter);
+        setSections(groupItemsBySection(res.items));
+      })
+      .catch((e) => {
+        if (!cancelled) setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingItems(false);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [id, jwt]);
+  }, [id, jwt, strictnessOverride]);
 
   const toggleOverride = (itemId: string) => {
     setShownAnyway((prev) => {
@@ -90,7 +121,8 @@ export default function RestaurantScreen() {
   if (!id) {
     return <CenteredMessage text="Missing restaurant id." />;
   }
-  if (loading) {
+  // First-time load: wait for both before showing the page.
+  if ((loadingRestaurant || loadingItems) && (!restaurant || !filter)) {
     return (
       <View style={styles.center} testID="restaurant-loading">
         <ActivityIndicator size="large" color={colors.bite} />
@@ -117,6 +149,11 @@ export default function RestaurantScreen() {
         {totalHidden > 0 ? `, hiding ${totalHidden}.` : '.'}
       </Text>
       <FilterBadge filter={filter} />
+      <StrictnessToggle
+        active={strictnessOverride ?? filter.strictness}
+        loading={loadingItems}
+        onChange={setStrictnessOverride}
+      />
 
       {overriddenSections.map((section) => (
         <SectionBlock
@@ -148,6 +185,56 @@ function FilterBadge({ filter }: { filter: FilterSummary }) {
       </Text>
     </View>
   );
+}
+
+export function StrictnessToggle({
+  active,
+  loading,
+  onChange,
+}: {
+  active: Strictness;
+  loading: boolean;
+  onChange: (next: Strictness) => void;
+}) {
+  return (
+    <View style={styles.strictnessRow} testID="strictness-toggle">
+      {STRICTNESSES.map((s) => {
+        const selected = s === active;
+        return (
+          <Pressable
+            key={s}
+            accessibilityLabel={`strictness-${s}`}
+            accessibilityState={{ selected, disabled: loading }}
+            onPress={() => {
+              if (!loading && !selected) onChange(s);
+            }}
+            style={[styles.strictnessChip, selected && styles.strictnessChipSelected]}
+          >
+            <Text
+              style={[
+                styles.strictnessText,
+                selected && styles.strictnessTextSelected,
+              ]}
+            >
+              {capitalize(s)}
+            </Text>
+          </Pressable>
+        );
+      })}
+      {loading && (
+        <ActivityIndicator
+          size="small"
+          color={colors.bite}
+          style={styles.strictnessSpinner}
+          testID="strictness-spinner"
+        />
+      )}
+    </View>
+  );
+}
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 function SectionBlock({
@@ -334,6 +421,35 @@ const styles = StyleSheet.create({
     color: colors.biteDark,
     fontSize: fontSize.sm,
     fontWeight: '600',
+  },
+  strictnessRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space['2'],
+    marginTop: space['1'],
+  },
+  strictnessChip: {
+    paddingHorizontal: space['3'],
+    paddingVertical: space['1'],
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bgAlt,
+  },
+  strictnessChipSelected: {
+    borderColor: colors.bite,
+    backgroundColor: colors.biteLight,
+  },
+  strictnessText: {
+    color: colors.textMuted,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+  },
+  strictnessTextSelected: {
+    color: colors.biteDark,
+  },
+  strictnessSpinner: {
+    marginLeft: space['1'],
   },
   section: {
     marginTop: space['4'],

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,12 +13,11 @@ the merge / review / status rules.
 
 **Phase 3** ⭐ Dietary filter UI. Subplan: `docs/plans/phase-3.md`.
 
-1. **Phase 3.4 — Transparency layer + one-tap override** (`docs/plans/phase-3.md#34`) — this PR
-2. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`)
-3. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
-4. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
-5. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
-6. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
+1. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`) — this PR
+2. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
+3. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
+4. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
+5. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
 
 ### Done
 
@@ -44,6 +43,7 @@ the merge / review / status rules.
 - ✅ Phase 3.1 — production-ready dietary profile seeds (#146)
 - ✅ Phase 3.2 — mobile profile onboarding (6 taps) (#147)
 - ✅ Phase 3.3 — mobile filtered restaurant page (#148)
+- ✅ Phase 3.4 — transparency chips + show-anyway override (#149)
 
 After Phase 3 ships, the loop will draft `docs/plans/phase-4.md` (reviews + accounts) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,26 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 06:00 — tick #55. PR #149 (Phase 3.4) merged at 04:29 UTC.
+Picked up Phase 3.5 — strictness toggle in the restaurant header. The
+items endpoint already accepted `?strictness` (Phase 1.7) so this was
+mostly a mobile change. Split the screen's effects: restaurant
+header loads once per id, items reload whenever id/jwt/strictness
+override change. The `<StrictnessToggle>` component renders three
+chips (Relaxed / Balanced / Strict); the active chip defaults to
+`filter.strictness` (which itself comes from the user profile or the
+`?profile=` preset). Tapping a different chip flips
+`strictnessOverride` state, which the items effect picks up and
+refetches with the new param. Inline ActivityIndicator next to the
+chips during refetch; chips are no-ops while loading. The override
+clears the per-item "show anyway" set on every refetch — otherwise a
+stale id could leak into the visible bucket. Tests: 2 new Jest cases
+on the API client (omits param when undefined; passes each strictness
+verbatim); 2 new rspec cases on the items endpoint (echoes 'relaxed'
+in filter.strictness; ignores garbage values, defense-in-depth for
+the toggle). Local: rspec 180/0/1 pending; mobile jest 47/47; pnpm
+typecheck/lint cached green.
+
 2026-05-01 05:30 — tick #54. PR #148 (Phase 3.3) merged at 04:22 UTC.
 Picked up Phase 3.4 — transparency chips + session-only "show
 anyway" override. Backend: `ItemsController#hide_reasons` now


### PR DESCRIPTION
## Summary

Phase 3.5 ships the third of the three header controls on the restaurant page. The items endpoint already accepted `?strictness=relaxed|balanced|strict` (Phase 1.7); this PR exposes it as a session-only chip in the header that refetches items when the user picks a different value. The user's stored profile is unchanged. Subplan: `docs/plans/phase-3.md#35`.

### Mobile
- **Split effects** in `app/restaurants/[id].tsx`. Previously a single effect loaded both restaurant + items keyed on `[id, jwt]`. Now: one effect for the restaurant header (depends on `id`), one for the items grid (depends on `id`, `jwt`, `strictnessOverride`). Toggling strictness no longer re-fetches the header.
- **New `<StrictnessToggle>` component** (relaxed | balanced | strict). Active chip defaults to `filter.strictness` (which itself comes from the user profile or the `?profile=` preset). Tap a different chip → `setStrictnessOverride(s)` → items refetch with `?strictness=s`.
- **Inline ActivityIndicator** next to the chips during refetch; chips are no-ops while loading. The per-item "show anyway" set resets on every items refetch so a stale id can't leak into the visible bucket.

## Out of scope
- A persistent toggle that saves the picked strictness back to the user profile — that belongs with the rest of the profile-edit flow in Phase 4.
- Web mirror — Phase 3.6.

## Test plan
- [x] Mobile Jest: 2 new (API client omits `strictness` when undefined; passes each of `relaxed|balanced|strict` verbatim).
- [x] API rspec: 2 new (`filter.strictness` echoes `relaxed` on `?strictness=relaxed`; garbage values fall back to `balanced` — defense-in-depth for the toggle).
- [x] `pnpm typecheck` / `pnpm lint` cached green across the monorepo.
- [x] `bundle exec rspec` 180/0/1 pending (the pending is the existing `ANTHROPIC_API_KEY` cassette).

### Note on UI snapshot testing
The phase subplan asks for a UI snapshot. The mobile test config runs Jest without the `jest-expo` preset, so importing the screen module fails (it transitively pulls in react-native ESM that bare Jest can't parse). All existing tests are pure-TS for that reason. Adding `jest-expo` + `@testing-library/react-native` is its own setup change; tracked as a discovered followup rather than expanded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)