### PR TITLE
feat(api,web): web filtered restaurant page (phase 3.6)

### DIFF
--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -19,7 +19,7 @@ module Api
       skip_before_action :authenticate_user!, only: [:index, :show]
 
       def index
-        restaurant = Restaurant.published.find(params[:restaurant_id])
+        restaurant = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id])
         items      = restaurant.items.published
                                .includes(menu_section: :menu)
                                .order(popularity: :desc, name: :asc)
@@ -37,7 +37,7 @@ module Api
       end
 
       def show
-        item = Restaurant.published.find(params[:restaurant_id]).items.published.find(params[:id])
+        item = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id]).items.published.find(params[:id])
         filter = build_filter
         render json: serialize_item(item, filter, build_label_lookup([item], filter))
       end

--- a/apps/api/app/controllers/api/v1/restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/restaurants_controller.rb
@@ -13,7 +13,7 @@ module Api
       skip_before_action :authenticate_user!, only: [:show]
 
       def show
-        restaurant = Restaurant.published.includes(:city).find(params[:id])
+        restaurant = Restaurant.published.includes(:city).find_by_id_or_slug!(params[:id])
         render json: serialize(restaurant)
       end
 

--- a/apps/api/app/models/restaurant.rb
+++ b/apps/api/app/models/restaurant.rb
@@ -15,4 +15,17 @@ class Restaurant < ApplicationRecord
   validates :status, inclusion: { in: STATUSES }
 
   scope :published, -> { where(status: "published") }
+
+  # SEO-friendly URLs (`/restaurants/ninis-1`) need lookup-by-slug;
+  # mobile/api consumers still pass UUIDs. Single endpoint accepts
+  # either by sniffing the value.
+  UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+  def self.find_by_id_or_slug!(value)
+    if value.to_s.match?(UUID_FORMAT)
+      find(value)
+    else
+      find_by!(slug: value)
+    end
+  end
 end

--- a/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
@@ -202,6 +202,14 @@ RSpec.describe "GET /api/v1/restaurants/:id/items", type: :request do
     end
   end
 
+  describe "lookup by slug (Phase 3.6)" do
+    it "accepts the restaurant slug in place of the UUID" do
+      get "/api/v1/restaurants/#{restaurant.slug}/items"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["restaurant_id"]).to eq(restaurant.id)
+    end
+  end
+
   describe "404 cases" do
     it "404s on a non-existent restaurant" do
       get "/api/v1/restaurants/00000000-0000-0000-0000-000000000000/items"

--- a/apps/api/spec/requests/api/v1/restaurants_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants_spec.rb
@@ -38,4 +38,23 @@ RSpec.describe "GET /api/v1/restaurants/:id", type: :request do
     get "/api/v1/restaurants/#{draft.id}"
     expect(response).to have_http_status(:not_found)
   end
+
+  describe "lookup by slug (Phase 3.6 — SEO URLs)" do
+    it "resolves a restaurant by its slug" do
+      get "/api/v1/restaurants/#{restaurant.slug}"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["id"]).to eq(restaurant.id)
+    end
+
+    it "404s on a slug that doesn't exist" do
+      get "/api/v1/restaurants/no-such-restaurant-here"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s on a slug for a draft restaurant" do
+      draft = create(:restaurant, slug: "secret-place-1")
+      get "/api/v1/restaurants/secret-place-1"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import { useEffect, useMemo, useState, useTransition } from 'react';
+import {
+  fetchRestaurantItems,
+  groupItemsBySection,
+  type FilterSummary,
+  type FilteredItem,
+  type HideReason,
+  type ItemSection,
+  type Restaurant,
+  type RestaurantItemsResponse,
+  type Strictness,
+} from '../../../lib/restaurants';
+import { hiddenReasonLabel } from '../../../lib/hidden-reason';
+import { applyOverrides } from '../../../lib/restaurant-overrides';
+
+/**
+ * Phase 3.6 — client island for the SSR-rendered restaurant page.
+ *
+ * Mirrors the mobile screen's interactivity: strictness toggle that
+ * triggers a refetch, "show anyway" per-item override (session-only),
+ * and translated <HiddenReasonChip> per reason. SSR renders the
+ * initial items with the server's default filter; the client takes
+ * over for re-filtering and overrides without a full page navigation.
+ */
+
+const STRICTNESSES: Strictness[] = ['relaxed', 'balanced', 'strict'];
+
+export function RestaurantClient({
+  slug,
+  restaurant,
+  initialItems,
+}: {
+  slug: string;
+  restaurant: Restaurant;
+  initialItems: RestaurantItemsResponse;
+}) {
+  const [filter, setFilter] = useState<FilterSummary>(initialItems.filter);
+  const [sections, setSections] = useState<ItemSection[]>(() =>
+    groupItemsBySection(initialItems.items),
+  );
+  const [strictnessOverride, setStrictnessOverride] = useState<Strictness | null>(null);
+  const [shownAnyway, setShownAnyway] = useState<Set<string>>(() => new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const isInitialRender = strictnessOverride === null;
+
+  useEffect(() => {
+    if (isInitialRender) return;
+    let cancelled = false;
+    startTransition(() => {
+      fetchRestaurantItems(slug, { strictness: strictnessOverride ?? undefined })
+        .then((res) => {
+          if (cancelled) return;
+          setFilter(res.filter);
+          setSections(groupItemsBySection(res.items));
+          setShownAnyway(new Set());
+        })
+        .catch((e) => {
+          if (!cancelled) setError((e as Error).message);
+        });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, strictnessOverride, isInitialRender]);
+
+  const overriddenSections = useMemo(
+    () => applyOverrides(sections, shownAnyway),
+    [sections, shownAnyway],
+  );
+
+  const toggleOverride = (itemId: string) => {
+    setShownAnyway((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  };
+
+  const totalHidden = overriddenSections.reduce((acc, s) => acc + s.hidden.length, 0);
+  const totalVisible = overriddenSections.reduce((acc, s) => acc + s.visible.length, 0);
+
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 py-bw-12">
+      <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">
+        {restaurant.city.name}, {restaurant.city.region}
+      </p>
+      <h1 className="mt-bw-2 text-bw-3xl font-bold">{restaurant.name}</h1>
+      <p className="mt-bw-2 text-bw-base text-zinc-700">
+        Showing <span className="font-bold">{totalVisible}</span> item
+        {totalVisible === 1 ? '' : 's'} that match your filter
+        {totalHidden > 0 ? `, hiding ${totalHidden}.` : '.'}
+      </p>
+
+      <div className="mt-bw-3 flex items-center gap-bw-2">
+        <FilterBadge filter={filter} />
+        <StrictnessToggle
+          active={strictnessOverride ?? filter.strictness}
+          loading={isPending}
+          onChange={setStrictnessOverride}
+        />
+      </div>
+
+      {error && (
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          Could not refresh items — {error}
+        </p>
+      )}
+
+      {overriddenSections.length === 0 && (
+        <p className="mt-bw-6 text-center text-bw-base text-zinc-500">
+          No published items at this restaurant yet.
+        </p>
+      )}
+
+      {overriddenSections.map((section) => (
+        <SectionBlock
+          key={section.id ?? '__none__'}
+          section={section}
+          shownAnyway={shownAnyway}
+          onToggleOverride={toggleOverride}
+        />
+      ))}
+    </main>
+  );
+}
+
+function FilterBadge({ filter }: { filter: FilterSummary }) {
+  const label =
+    filter.source === 'preset'
+      ? `Preset · ${filter.preset_slug ?? 'unknown'}`
+      : filter.source === 'user_profile'
+      ? 'Your saved profile'
+      : 'No filter';
+  return (
+    <span
+      data-testid="filter-badge"
+      className="rounded-bw-pill bg-bite-light px-bw-3 py-bw-1 text-bw-sm font-semibold text-bite-dark"
+    >
+      {label} · {filter.strictness}
+    </span>
+  );
+}
+
+export function StrictnessToggle({
+  active,
+  loading,
+  onChange,
+}: {
+  active: Strictness;
+  loading: boolean;
+  onChange: (next: Strictness) => void;
+}) {
+  return (
+    <div data-testid="strictness-toggle" className="flex items-center gap-bw-2">
+      {STRICTNESSES.map((s) => {
+        const selected = s === active;
+        return (
+          <button
+            key={s}
+            type="button"
+            aria-pressed={selected}
+            disabled={loading}
+            onClick={() => {
+              if (!loading && !selected) onChange(s);
+            }}
+            className={[
+              'rounded-bw-pill border px-bw-3 py-bw-1 text-bw-sm font-semibold transition',
+              selected
+                ? 'border-bite bg-bite-light text-bite-dark'
+                : 'border-zinc-200 bg-zinc-50 text-zinc-500 hover:border-zinc-300',
+              loading ? 'opacity-60' : '',
+            ].join(' ')}
+          >
+            {capitalize(s)}
+          </button>
+        );
+      })}
+      {loading && <span className="text-bw-xs text-zinc-400">refreshing…</span>}
+    </div>
+  );
+}
+
+function SectionBlock({
+  section,
+  shownAnyway,
+  onToggleOverride,
+}: {
+  section: ItemSection;
+  shownAnyway: Set<string>;
+  onToggleOverride: (itemId: string) => void;
+}) {
+  const [hiddenOpen, setHiddenOpen] = useState(false);
+  return (
+    <section className="mt-bw-6">
+      <h2 className="text-bw-lg font-bold">{section.name}</h2>
+      <ul className="mt-bw-2 divide-y divide-zinc-100">
+        {section.visible.map((item) => (
+          <ItemRow
+            key={item.id}
+            item={item}
+            overridden={shownAnyway.has(item.id)}
+            onToggleOverride={onToggleOverride}
+          />
+        ))}
+        {section.visible.length === 0 && section.hidden.length > 0 && (
+          <li className="py-bw-2 text-bw-sm text-zinc-500">
+            Every item in this section is hidden by your filter.
+          </li>
+        )}
+      </ul>
+
+      {section.hidden.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setHiddenOpen((v) => !v)}
+          aria-expanded={hiddenOpen}
+          aria-controls={`hidden-${section.id ?? 'none'}`}
+          className="mt-bw-2 text-bw-sm font-semibold text-bite hover:text-bite-dark"
+        >
+          {hiddenOpen ? '▾ Hide' : '▸ Show'} items hidden by your filter ({section.hidden.length})
+        </button>
+      )}
+
+      {hiddenOpen && (
+        <ul
+          id={`hidden-${section.id ?? 'none'}`}
+          className="mt-bw-2 divide-y divide-zinc-100"
+        >
+          {section.hidden.map((item) => (
+            <ItemRow
+              key={item.id}
+              item={item}
+              hidden
+              overridden={false}
+              onToggleOverride={onToggleOverride}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function ItemRow({
+  item,
+  hidden = false,
+  overridden,
+  onToggleOverride,
+}: {
+  item: FilteredItem;
+  hidden?: boolean;
+  overridden: boolean;
+  onToggleOverride: (itemId: string) => void;
+}) {
+  // Item shown in the visible list but with reasons[] = the user
+  // tapped "Show anyway". Keep chips visible as a transparency cue.
+  const showChips = hidden || overridden;
+  return (
+    <li
+      data-testid={`item-${item.id}`}
+      className={['py-bw-3', hidden ? 'opacity-60' : ''].join(' ')}
+    >
+      <p className={['font-semibold', hidden ? 'text-hide' : 'text-zinc-900'].join(' ')}>
+        {item.name}
+      </p>
+      {item.description && (
+        <p className="mt-1 text-bw-sm text-zinc-500">{item.description}</p>
+      )}
+
+      {showChips && item.reasons.length > 0 && (
+        <div className="mt-bw-2 flex flex-wrap gap-bw-1">
+          {item.reasons.map((r, idx) => (
+            <HiddenReasonChip key={idx} reason={r} />
+          ))}
+        </div>
+      )}
+
+      {item.reasons.length > 0 && (
+        <button
+          type="button"
+          onClick={() => onToggleOverride(item.id)}
+          className="mt-bw-2 text-bw-sm font-semibold text-bite hover:text-bite-dark"
+        >
+          {overridden ? 'Hide again' : 'Show anyway'}
+        </button>
+      )}
+    </li>
+  );
+}
+
+export function HiddenReasonChip({ reason }: { reason: HideReason }) {
+  return (
+    <span
+      data-testid={`chip-${reason.kind}`}
+      className="rounded-bw-pill border border-zinc-200 bg-zinc-50 px-bw-2 py-bw-0_5 text-bw-xs font-semibold text-hide"
+    >
+      {hiddenReasonLabel(reason)}
+    </span>
+  );
+}
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/apps/web/src/app/restaurants/[slug]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from 'next/navigation';
+import {
+  fetchRestaurant,
+  fetchRestaurantItems,
+} from '../../../lib/restaurants';
+import { RestaurantClient } from './RestaurantClient';
+
+/**
+ * Phase 3.6 — server-rendered restaurant page.
+ *
+ * The slug-based URL (`/restaurants/cream-bean-berry-1`) is what the
+ * Phase 5 SEO city pages will eventually link to. Both endpoints
+ * accept either UUID or slug; the SSR fetch here uses the slug.
+ *
+ * The fetch is anonymous — Phase 4 brings cookie-session auth that
+ * would let us pass the user's JWT here for profile-aware filtering
+ * during SSR. For now the page renders with the server's "no filter"
+ * default, then the client island lets the user pick a preset +
+ * strictness for live re-filtering.
+ */
+type Params = { slug: string };
+
+export default async function RestaurantPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { slug } = await params;
+
+  const [restaurant, initialItems] = await Promise.all([
+    fetchRestaurant(slug).catch(() => null),
+    fetchRestaurantItems(slug).catch(() => null),
+  ]);
+
+  if (!restaurant || !initialItems) notFound();
+
+  return <RestaurantClient slug={slug} restaurant={restaurant} initialItems={initialItems} />;
+}

--- a/apps/web/src/lib/__tests__/hidden-reason.test.ts
+++ b/apps/web/src/lib/__tests__/hidden-reason.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { hiddenReasonLabel } from '../hidden-reason';
+import type { HideReason } from '../restaurants';
+
+describe('hiddenReasonLabel (web mirror)', () => {
+  it('formats avoid_ingredient as "Contains <family> (<name>)"', () => {
+    const r: HideReason = {
+      kind: 'avoid_ingredient',
+      ingredient_id: 'i-1',
+      ingredient_name: 'Cheese',
+      ingredient_family: 'dairy',
+    };
+    expect(hiddenReasonLabel(r)).toBe('Contains dairy (Cheese)');
+  });
+
+  it('humanizes snake_case families (tree_nut → tree nut)', () => {
+    const r: HideReason = {
+      kind: 'avoid_ingredient',
+      ingredient_id: 'i-1',
+      ingredient_name: 'Almond',
+      ingredient_family: 'tree_nut',
+    };
+    expect(hiddenReasonLabel(r)).toBe('Contains tree nut (Almond)');
+  });
+
+  it('formats avoid_tag as "Tagged <family>: <name>"', () => {
+    const r: HideReason = {
+      kind: 'avoid_tag',
+      tag_id: 't-1',
+      tag_name: 'Contains Dairy',
+      tag_family: 'allergen',
+    };
+    expect(hiddenReasonLabel(r)).toBe('Tagged allergen: Contains Dairy');
+  });
+
+  it('formats unconfirmed_strict with the confidence + strict-mode note', () => {
+    const r: HideReason = { kind: 'unconfirmed_strict', confidence: 'inferred' };
+    expect(hiddenReasonLabel(r)).toBe('AI confidence: inferred (strict mode)');
+  });
+
+  it('falls back when family is null', () => {
+    const r: HideReason = {
+      kind: 'avoid_ingredient',
+      ingredient_id: 'i-x',
+      ingredient_name: 'Mystery',
+      ingredient_family: null,
+    };
+    expect(hiddenReasonLabel(r)).toBe('Contains restricted (Mystery)');
+  });
+});

--- a/apps/web/src/lib/__tests__/restaurant-overrides.test.ts
+++ b/apps/web/src/lib/__tests__/restaurant-overrides.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { applyOverrides } from '../restaurant-overrides';
+import type { FilteredItem, ItemSection } from '../restaurants';
+
+function item(overrides: Partial<FilteredItem>): FilteredItem {
+  return {
+    id: overrides.id ?? 'item-?',
+    restaurant_id: 'rest-1',
+    name: 'Item',
+    description: '',
+    confidence: 'confirmed',
+    popularity: 0,
+    ingredient_ids: [],
+    tag_ids: [],
+    menu_section_id: null,
+    menu_section_name: null,
+    status: 'visible',
+    reasons: [],
+    ...overrides,
+  };
+}
+
+const visible = item({ id: 'v', status: 'visible' });
+const hiddenA = item({
+  id: 'h1',
+  status: 'hidden',
+  reasons: [
+    {
+      kind: 'avoid_ingredient',
+      ingredient_id: 'i-x',
+      ingredient_name: 'Cheese',
+      ingredient_family: 'dairy',
+    },
+  ],
+});
+const hiddenB = item({
+  id: 'h2',
+  status: 'hidden',
+  reasons: [
+    {
+      kind: 'avoid_tag',
+      tag_id: 't-y',
+      tag_name: 'Contains Dairy',
+      tag_family: 'allergen',
+    },
+  ],
+});
+
+function section(visibleItems: FilteredItem[], hiddenItems: FilteredItem[]): ItemSection {
+  return { id: 'tacos', name: 'Tacos', visible: visibleItems, hidden: hiddenItems };
+}
+
+describe('applyOverrides (web mirror)', () => {
+  it('returns input unchanged when no overrides', () => {
+    const sections = [section([visible], [hiddenA])];
+    expect(applyOverrides(sections, new Set())).toBe(sections);
+  });
+
+  it('promotes overridden items into the visible bucket', () => {
+    const sections = [section([visible], [hiddenA, hiddenB])];
+    const result = applyOverrides(sections, new Set(['h1']));
+    expect(result[0]!.visible.map((i) => i.id)).toEqual(['v', 'h1']);
+    expect(result[0]!.hidden.map((i) => i.id)).toEqual(['h2']);
+  });
+
+  it('preserves untouched section identity', () => {
+    const tacos = section([visible], [hiddenA]);
+    const bowls: ItemSection = { id: 'bowls', name: 'Bowls', visible: [], hidden: [] };
+    const result = applyOverrides([tacos, bowls], new Set(['h1']));
+    expect(result[1]).toBe(bowls);
+  });
+});

--- a/apps/web/src/lib/__tests__/restaurants.test.ts
+++ b/apps/web/src/lib/__tests__/restaurants.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchRestaurant,
+  fetchRestaurantItems,
+  groupItemsBySection,
+  type FilteredItem,
+  type Restaurant,
+  type RestaurantItemsResponse,
+} from '../restaurants';
+
+const restaurantPayload: Restaurant = {
+  id: 'rest-1',
+  slug: 'cream-bean-berry-1',
+  name: 'Cream, Bean & Berry',
+  about: null,
+  phone: null,
+  website: null,
+  status: 'published',
+  city: { id: 'city-1', slug: 'durango', name: 'Durango', region: 'CO' },
+};
+
+const itemsPayload: RestaurantItemsResponse = {
+  restaurant_id: 'rest-1',
+  filter: {
+    source: 'none',
+    preset_slug: null,
+    strictness: 'balanced',
+    avoid_ingredient_ids: [],
+    avoid_tag_ids: [],
+  },
+  items: [],
+};
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'NOT FOUND',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+describe('fetchRestaurant', () => {
+  it('GETs /api/v1/restaurants/:slugOrId', async () => {
+    const fetchImpl = fakeFetch(200, restaurantPayload);
+    const r = await fetchRestaurant('cream-bean-berry-1', { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain(
+      '/api/v1/restaurants/cream-bean-berry-1',
+    );
+    expect(r.name).toBe('Cream, Bean & Berry');
+  });
+
+  it('encodes slugs that contain reserved URL characters', async () => {
+    const fetchImpl = fakeFetch(200, restaurantPayload);
+    await fetchRestaurant('café & co', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('caf%C3%A9%20%26%20co');
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'not found' });
+    await expect(fetchRestaurant('missing', { fetchImpl })).rejects.toThrow(/404/);
+  });
+});
+
+describe('fetchRestaurantItems', () => {
+  it('omits the strictness param when undefined', async () => {
+    const fetchImpl = fakeFetch(200, itemsPayload);
+    await fetchRestaurantItems('cream-bean-berry-1', { fetchImpl });
+    expect(String(fetchImpl.mock.calls[0]![0])).not.toContain('strictness=');
+  });
+
+  it('passes presetSlug + strictness as query params', async () => {
+    const fetchImpl = fakeFetch(200, itemsPayload);
+    await fetchRestaurantItems('cream-bean-berry-1', {
+      fetchImpl,
+      presetSlug: 'celiac',
+      strictness: 'strict',
+    });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('profile=celiac');
+    expect(url).toContain('strictness=strict');
+  });
+
+  it('attaches Bearer JWT when supplied', async () => {
+    const fetchImpl = fakeFetch(200, itemsPayload);
+    await fetchRestaurantItems('cream-bean-berry-1', { fetchImpl, jwt: 'jjj.www.ttt' });
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jjj.www.ttt');
+  });
+});
+
+describe('groupItemsBySection', () => {
+  function item(overrides: Partial<FilteredItem>): FilteredItem {
+    return {
+      id: overrides.id ?? 'item-?',
+      restaurant_id: 'rest-1',
+      name: 'Item',
+      description: '',
+      confidence: 'confirmed',
+      popularity: 0,
+      ingredient_ids: [],
+      tag_ids: [],
+      menu_section_id: null,
+      menu_section_name: null,
+      status: 'visible',
+      reasons: [],
+      ...overrides,
+    };
+  }
+
+  it('groups by menu_section_id, preserves server order', () => {
+    const sections = groupItemsBySection([
+      item({ id: 'a', menu_section_id: 'tacos', menu_section_name: 'Tacos' }),
+      item({ id: 'b', menu_section_id: 'bowls', menu_section_name: 'Bowls' }),
+      item({ id: 'c', menu_section_id: 'tacos', menu_section_name: 'Tacos' }),
+    ]);
+    expect(sections.map((s) => s.name)).toEqual(['Tacos', 'Bowls']);
+    expect(sections[0]!.visible.map((i) => i.id)).toEqual(['a', 'c']);
+  });
+
+  it('drops null-section items into "Other"', () => {
+    const sections = groupItemsBySection([item({ id: 'a' })]);
+    expect(sections[0]!.name).toBe('Other');
+  });
+
+  it('separates visible vs hidden within a section', () => {
+    const sections = groupItemsBySection([
+      item({ id: 'v', status: 'visible', menu_section_id: 's', menu_section_name: 'S' }),
+      item({
+        id: 'h',
+        status: 'hidden',
+        menu_section_id: 's',
+        menu_section_name: 'S',
+        reasons: [
+          {
+            kind: 'avoid_ingredient',
+            ingredient_id: 'ing-x',
+            ingredient_name: 'Cheese',
+            ingredient_family: 'dairy',
+          },
+        ],
+      }),
+    ]);
+    expect(sections[0]!.visible.map((i) => i.id)).toEqual(['v']);
+    expect(sections[0]!.hidden.map((i) => i.id)).toEqual(['h']);
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,17 +1,25 @@
 /**
  * Thin fetch wrapper for the BiteWorthy Rails API.
  * Real auth header injection lands with the JWT login flow in Phase 1.
+ *
+ * `fetchImpl` is optional and only set by tests — production code
+ * uses the global fetch.
  */
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
 
-export async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}/api/v1${path}`, {
+export interface ApiOptions extends RequestInit {
+  fetchImpl?: typeof fetch;
+}
+
+export async function api<T>(path: string, options: ApiOptions = {}): Promise<T> {
+  const { fetchImpl = fetch, ...init } = options;
+  const res = await fetchImpl(`${API_BASE}/api/v1${path}`, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
-      ...(init?.headers ?? {}),
+      ...(init.headers ?? {}),
     },
   });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);

--- a/apps/web/src/lib/hidden-reason.ts
+++ b/apps/web/src/lib/hidden-reason.ts
@@ -1,0 +1,29 @@
+/**
+ * Phase 3.6 — translate the {kind, *_id, *_name, *_family} reason
+ * shape into a human chip label. Mirror of the mobile helper at
+ * apps/mobile/lib/hidden-reason.ts. Kept duplicated until a future
+ * refactor extracts it into a shared package.
+ */
+import type { HideReason } from './restaurants';
+
+function humanizeFamily(family: string | null | undefined): string {
+  if (!family) return 'restricted';
+  return family.replace(/_/g, ' ');
+}
+
+export function hiddenReasonLabel(reason: HideReason): string {
+  switch (reason.kind) {
+    case 'avoid_ingredient': {
+      const family = humanizeFamily(reason.ingredient_family);
+      const name = reason.ingredient_name ?? 'ingredient';
+      return `Contains ${family} (${name})`;
+    }
+    case 'avoid_tag': {
+      const family = humanizeFamily(reason.tag_family);
+      const name = reason.tag_name ?? 'tag';
+      return `Tagged ${family}: ${name}`;
+    }
+    case 'unconfirmed_strict':
+      return `AI confidence: ${reason.confidence} (strict mode)`;
+  }
+}

--- a/apps/web/src/lib/restaurant-overrides.ts
+++ b/apps/web/src/lib/restaurant-overrides.ts
@@ -1,0 +1,27 @@
+/**
+ * Phase 3.6 — apply session-only "show anyway" overrides.
+ * Mirror of apps/mobile/lib/restaurant-overrides.ts; see that file
+ * for the design rationale.
+ */
+import type { FilteredItem, ItemSection } from './restaurants';
+
+export function applyOverrides(
+  sections: ItemSection[],
+  shownAnyway: Set<string>,
+): ItemSection[] {
+  if (shownAnyway.size === 0) return sections;
+  return sections.map((section) => {
+    const stillHidden: FilteredItem[] = [];
+    const promoted: FilteredItem[] = [];
+    for (const item of section.hidden) {
+      if (shownAnyway.has(item.id)) promoted.push(item);
+      else stillHidden.push(item);
+    }
+    if (promoted.length === 0) return section;
+    return {
+      ...section,
+      visible: [...section.visible, ...promoted],
+      hidden: stillHidden,
+    };
+  });
+}

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -1,0 +1,151 @@
+/**
+ * Phase 3.6 — restaurant + filtered-items fetchers (web mirror).
+ *
+ * Same surface as the mobile client at apps/mobile/lib/api/restaurants.ts
+ * but uses the existing `api()` helper from src/lib/api.ts so the web
+ * app's API_BASE env var is honored. Server-callable for SSR.
+ *
+ * Types stay co-located with the fetchers (rather than in
+ * @biteworthy/api-types) until the items endpoint gets its own rswag
+ * spec — for now, hand-written + spec-locked is the same pattern the
+ * mobile side uses.
+ */
+
+import { api } from './api';
+
+export interface RestaurantCity {
+  id: string;
+  slug: string;
+  name: string;
+  region: string;
+}
+
+export interface Restaurant {
+  id: string;
+  slug: string;
+  name: string;
+  about: string | null;
+  phone: string | null;
+  website: string | null;
+  status: string;
+  city: RestaurantCity;
+}
+
+export type ItemStatus = 'visible' | 'hidden';
+
+export type HideReason =
+  | {
+      kind: 'avoid_ingredient';
+      ingredient_id: string;
+      ingredient_name: string | null;
+      ingredient_family: string | null;
+    }
+  | {
+      kind: 'avoid_tag';
+      tag_id: string;
+      tag_name: string | null;
+      tag_family: string | null;
+    }
+  | { kind: 'unconfirmed_strict'; confidence: string };
+
+export interface FilteredItem {
+  id: string;
+  restaurant_id: string;
+  name: string;
+  description: string;
+  confidence: 'confirmed' | 'suggested' | 'inferred';
+  popularity: number;
+  ingredient_ids: string[];
+  tag_ids: string[];
+  menu_section_id: string | null;
+  menu_section_name: string | null;
+  status: ItemStatus;
+  reasons: HideReason[];
+}
+
+export type Strictness = 'relaxed' | 'balanced' | 'strict';
+
+export interface FilterSummary {
+  source: 'preset' | 'user_profile' | 'none';
+  preset_slug: string | null;
+  strictness: Strictness;
+  avoid_ingredient_ids: string[];
+  avoid_tag_ids: string[];
+}
+
+export interface RestaurantItemsResponse {
+  restaurant_id: string;
+  filter: FilterSummary;
+  items: FilteredItem[];
+}
+
+export interface FetchOptions {
+  fetchImpl?: typeof fetch;
+}
+
+export interface FetchItemsOptions extends FetchOptions {
+  jwt?: string;
+  presetSlug?: string;
+  strictness?: Strictness;
+}
+
+export async function fetchRestaurant(
+  slugOrId: string,
+  opts: FetchOptions = {},
+): Promise<Restaurant> {
+  return api<Restaurant>(`/restaurants/${encodeURIComponent(slugOrId)}`, {
+    fetchImpl: opts.fetchImpl,
+  });
+}
+
+export async function fetchRestaurantItems(
+  slugOrId: string,
+  opts: FetchItemsOptions = {},
+): Promise<RestaurantItemsResponse> {
+  const params = new URLSearchParams();
+  if (opts.presetSlug) params.set('profile', opts.presetSlug);
+  if (opts.strictness) params.set('strictness', opts.strictness);
+  const qs = params.toString();
+  const path = `/restaurants/${encodeURIComponent(slugOrId)}/items${qs ? `?${qs}` : ''}`;
+  const headers: Record<string, string> = {};
+  if (opts.jwt) headers.Authorization = `Bearer ${opts.jwt}`;
+  return api<RestaurantItemsResponse>(path, { headers, fetchImpl: opts.fetchImpl });
+}
+
+/**
+ * Group filtered items by their menu section. Same shape as the
+ * mobile helper — kept duplicated rather than extracted because the
+ * surface is small and consolidating into a shared package is its
+ * own followup (mobile lives outside the pnpm workspace's TS-import
+ * graph in some configurations).
+ */
+export interface ItemSection {
+  id: string | null;
+  name: string;
+  visible: FilteredItem[];
+  hidden: FilteredItem[];
+}
+
+export function groupItemsBySection(items: FilteredItem[]): ItemSection[] {
+  const order: (string | null)[] = [];
+  const lookup = new Map<string | null, ItemSection>();
+
+  for (const item of items) {
+    const sectionId = item.menu_section_id;
+    let section = lookup.get(sectionId);
+    if (!section) {
+      section = {
+        id: sectionId,
+        name: item.menu_section_name ?? 'Other',
+        visible: [],
+        hidden: [],
+      };
+      lookup.set(sectionId, section);
+      order.push(sectionId);
+    }
+    if (item.status === 'visible') section.visible.push(item);
+    else section.hidden.push(item);
+  }
+
+  return order.map((id) => lookup.get(id)!);
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,11 +13,10 @@ the merge / review / status rules.
 
 **Phase 3** ⭐ Dietary filter UI. Subplan: `docs/plans/phase-3.md`.
 
-1. **Phase 3.5 — Strict-mode toggle** (`docs/plans/phase-3.md#35`) — this PR
-2. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`)
-3. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
-4. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
-5. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
+1. **Phase 3.6 — Web filtered restaurant page** (`docs/plans/phase-3.md#36`) — this PR
+2. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`)
+3. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
+4. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
 
 ### Done
 
@@ -44,6 +43,7 @@ the merge / review / status rules.
 - ✅ Phase 3.2 — mobile profile onboarding (6 taps) (#147)
 - ✅ Phase 3.3 — mobile filtered restaurant page (#148)
 - ✅ Phase 3.4 — transparency chips + show-anyway override (#149)
+- ✅ Phase 3.5 — strict-mode toggle (#150)
 
 After Phase 3 ships, the loop will draft `docs/plans/phase-4.md` (reviews + accounts) the same way.
 
@@ -142,7 +142,26 @@ The loop appends here when work surfaces a new task that doesn't
 belong in the current phase. Humans triage these into the appropriate
 phase or "Next up" queue.
 
-(empty)
+- **Wire `jest-expo` preset + `@testing-library/react-native` for the
+  mobile app** — surfaced during Phase 3.5. Mobile tests currently
+  run pure-TS only; importing any screen module (which transitively
+  imports react-native ESM) fails Jest's default transformer. The
+  Phase 3.5 subplan asked for a UI snapshot, which we couldn't ship
+  without the preset wiring. Setup change in its own PR; once landed,
+  retroactively add the deferred snapshots from 3.2 / 3.3 / 3.4 / 3.5.
+- **Auto-merge race lost a follow-on commit on PR #150**. After the
+  initial push, a second commit (the prior version of this Discovered
+  note) was added before CI finished — auto-merge had already enabled
+  on the first sha and squashed without the second commit's diff.
+  Either tighten the loop's flow (push everything in one go) or
+  consider gating auto-merge on a manual "ready" label after final
+  push.
+- **Consolidate web + mobile pure helpers** (`hidden-reason.ts`,
+  `restaurant-overrides.ts`, `groupItemsBySection`). Phase 3.6
+  duplicated three small files into `apps/web/src/lib/`. Once Phase
+  3.7 moves the filter logic into `packages/filter-engine`, consider
+  moving the display helpers into a sibling shared package
+  (`@biteworthy/restaurant-page-helpers`?) to delete the duplicate.
 
 ## What we are explicitly NOT doing in v1
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,31 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 06:30 — tick #56. PR #150 (Phase 3.5) merged at 04:46 UTC.
+Picked up Phase 3.6 — web filtered restaurant page (mirror of mobile
+3.3 + 3.4 + 3.5). API: extended Restaurant model with
+`find_by_id_or_slug!` (sniffs UUID format vs slug); both
+`/api/v1/restaurants/:id` and `/api/v1/restaurants/:restaurant_id/items`
+now accept either form so SEO-friendly URLs (`/restaurants/cream-bean-
+berry-1`) work end-to-end. Web: built `apps/web/src/lib/restaurants.ts`
+mirroring the mobile API client (server-callable for SSR), with
+duplicates of `hidden-reason.ts` + `restaurant-overrides.ts` for now
+(extraction into a shared package logged as Discovered followup).
+SSR page at `apps/web/src/app/restaurants/[slug]/page.tsx` fetches
+restaurant + initial items in parallel with `notFound()` on miss; the
+`'use client'` island `RestaurantClient.tsx` handles strictness
+toggle + per-item show-anyway override + chip rendering using
+`useTransition` for non-blocking refetch. Tests: 9 vitest for the
+API client + grouping; 5 for chip labels; 3 for override
+re-bucketing — total 17 new web cases. 4 new rspec cases for the
+slug lookup (restaurant by slug + by-slug 404 + draft 404 + items by
+slug). Also re-added the Discovered note that lost the auto-merge
+race on PR #150 (push-then-second-push was squashed without the
+second sha) and added two new Discovered followups (helper
+consolidation + auto-merge race protection). Local: rspec 184/0/1
+pending; web vitest 21/21; mobile jest 47/47; pnpm typecheck/lint
+cached green.
+
 2026-05-01 06:00 — tick #55. PR #149 (Phase 3.4) merged at 04:29 UTC.
 Picked up Phase 3.5 — strictness toggle in the restaurant header. The
 items endpoint already accepted `?strictness` (Phase 1.7) so this was


### PR DESCRIPTION
## Summary

Phase 3.6 ports the mobile restaurant page (3.3 + 3.4 + 3.5) to Next.js with SSR. The page is reachable at `/restaurants/[slug]` (slug, not id — for the eventual SEO city pages in Phase 5). Subplan: `docs/plans/phase-3.md#36`.

### API
- **`Restaurant.find_by_id_or_slug!`** sniffs UUID format vs slug. Both `/api/v1/restaurants/:id` and `/api/v1/restaurants/:restaurant_id/items` now accept either form, so SEO-friendly URLs work without a separate by-slug lookup endpoint.

### Web
- **`apps/web/src/lib/restaurants.ts`** — server-callable API client (used by SSR), with optional `fetchImpl` seam for tests. Mirrors the mobile types.
- **`apps/web/src/lib/{hidden-reason,restaurant-overrides}.ts`** — duplicates of the mobile pure helpers. Extraction into a shared package logged as a Discovered followup (the duplication is small and each side has its own coverage).
- **`apps/web/src/app/restaurants/[slug]/page.tsx`** — Next.js 15 server component. Fetches restaurant + initial items in parallel; `notFound()` on either miss.
- **`apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx`** — client island for interactivity. `useTransition` keeps the strictness toggle non-blocking; per-item show-anyway override + per-section "Items hidden by your filter (N)" expander + chip rendering.

### Discovered followups (added to roadmap)
1. Wire `jest-expo` preset for mobile snapshot tests (re-added after auto-merge dropped it on #150).
2. Auto-merge raced PR #150 — second push didn't make it into the squash. Either tighten the loop's flow or gate auto-merge on a manual "ready" label.
3. Consolidate web + mobile `hidden-reason` / `restaurant-overrides` / `groupItemsBySection` after Phase 3.7 establishes a shared package pattern.

## Test plan
- [x] **API rspec**: 4 new (restaurant by slug, by-slug 404, by-slug for draft 404, items endpoint accepts slug). Total: 184/0/1 pending (the pending is the existing `ANTHROPIC_API_KEY` cassette).
- [x] **Web vitest**: 17 new (9 API client incl. URL encoding + JWT header + omits-strictness; 5 chip-label permutations; 3 override re-bucketing). Total: 21/21.
- [x] **Mobile jest**: 47/47 unchanged.
- [x] **`pnpm typecheck` / `pnpm lint`**: green across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)