### PR TITLE
feat(web,filter-engine): web profile onboarding (phase 3.8)

### DIFF
--- a/apps/mobile/app/onboarding/index.tsx
+++ b/apps/mobile/app/onboarding/index.tsx
@@ -13,12 +13,12 @@ import {
 import { router } from 'expo-router';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
-  reducer,
   initialDraft,
+  onboardingReducer,
   toProfilePayload,
-  type Strictness,
   type DietaryPreset,
-} from '../../lib/onboarding-reducer';
+  type Strictness,
+} from '@biteworthy/filter-engine';
 import {
   fetchDietaryProfiles,
   saveProfile,
@@ -42,7 +42,7 @@ type Step = 'presets' | 'ingredients' | 'strictness' | 'done';
 
 export default function OnboardingScreen() {
   const [step, setStep] = useState<Step>('presets');
-  const [draft, dispatch] = useReducer(reducer, initialDraft);
+  const [draft, dispatch] = useReducer(onboardingReducer, initialDraft);
   const [presets, setPresets] = useState<DietaryPreset[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');

--- a/apps/mobile/lib/api/onboarding.ts
+++ b/apps/mobile/lib/api/onboarding.ts
@@ -7,7 +7,7 @@
  * taps Done (Phase 1.3 endpoint, wholesale-replace semantics).
  */
 
-import type { DietaryPreset } from '../onboarding-reducer';
+import type { DietaryPreset } from '@biteworthy/filter-engine';
 
 const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
 

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,0 +1,435 @@
+'use client';
+
+import { useEffect, useReducer, useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  initialDraft,
+  onboardingReducer,
+  toProfilePayload,
+  type DietaryPreset,
+  type Strictness,
+} from '@biteworthy/filter-engine';
+import {
+  fetchDietaryProfiles,
+  saveProfile,
+  searchIngredients,
+  type IngredientSearchResult,
+} from '../../lib/onboarding';
+import { setJwtCookie } from '../../lib/jwt-cookie';
+
+/**
+ * Phase 3.8 — web mirror of the mobile 4-step onboarding flow.
+ *
+ *   1. Pick presets ("What can't you eat?")
+ *   2. Add specific ingredients ("Anything else?")
+ *   3. Set strictness ("How strict?")
+ *   4. Done → PATCH /api/v1/profile, save JWT to cookie, navigate home.
+ *
+ * The reducer + payload composition come from
+ * `@biteworthy/filter-engine` (Phase 3.7), so mobile + web stay
+ * in lockstep.
+ */
+type Step = 'presets' | 'ingredients' | 'strictness' | 'done';
+
+const STRICTNESSES: Strictness[] = ['relaxed', 'balanced', 'strict'];
+const STRICTNESS_BLURB: Record<Strictness, string> = {
+  relaxed: 'Show items even if some ingredients are inferred.',
+  balanced: 'Hide items where the avoid match is confident.',
+  strict: 'Also hide items the AI marked suggested or inferred.',
+};
+
+export default function OnboardingPage() {
+  const router = useRouter();
+
+  const [step, setStep] = useState<Step>('presets');
+  const [draft, dispatch] = useReducer(onboardingReducer, initialDraft);
+  const [presets, setPresets] = useState<DietaryPreset[]>([]);
+  const [presetsError, setPresetsError] = useState<string | null>(null);
+  const [loadingPresets, setLoadingPresets] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<IngredientSearchResult[]>([]);
+  const [jwt, setJwt] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchDietaryProfiles()
+      .then(setPresets)
+      .catch((e) => setPresetsError((e as Error).message))
+      .finally(() => setLoadingPresets(false));
+  }, []);
+
+  // Debounced ingredient search.
+  useEffect(() => {
+    if (step !== 'ingredients') return;
+    const handle = setTimeout(() => {
+      searchIngredients(searchQuery)
+        .then(setSearchResults)
+        .catch(() => {
+          // Search errors are non-fatal — silently no-op.
+        });
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [searchQuery, step]);
+
+  const finalize = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!jwt) {
+      setSaveError('Paste a JWT — Phase 4 will swap to a real session cookie.');
+      return;
+    }
+    try {
+      setSaving(true);
+      setSaveError(null);
+      await saveProfile(toProfilePayload(draft, presets), jwt);
+      setJwtCookie(jwt);
+      router.replace('/');
+    } catch (err) {
+      setSaveError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-2xl px-bw-6 py-bw-12">
+      {step === 'presets' && (
+        <PresetsStep
+          presets={presets}
+          loading={loadingPresets}
+          error={presetsError}
+          selectedSlugs={draft.selectedPresetSlugs}
+          onToggle={(slug) => dispatch({ type: 'TOGGLE_PRESET', slug })}
+          onNext={() => setStep('ingredients')}
+        />
+      )}
+
+      {step === 'ingredients' && (
+        <IngredientsStep
+          query={searchQuery}
+          results={searchResults}
+          addedIds={draft.manualIngredientIds}
+          onQueryChange={setSearchQuery}
+          onToggle={(id, added) =>
+            dispatch({
+              type: added ? 'REMOVE_MANUAL_INGREDIENT' : 'ADD_MANUAL_INGREDIENT',
+              ingredientId: id,
+            })
+          }
+          onNext={() => setStep('strictness')}
+        />
+      )}
+
+      {step === 'strictness' && (
+        <StrictnessStep
+          active={draft.strictness}
+          onPick={(s) => dispatch({ type: 'SET_STRICTNESS', strictness: s })}
+          onNext={() => setStep('done')}
+        />
+      )}
+
+      {step === 'done' && (
+        <ReviewStep
+          presetCount={draft.selectedPresetSlugs.length}
+          ingredientCount={draft.manualIngredientIds.length}
+          strictness={draft.strictness}
+          jwt={jwt}
+          onJwtChange={setJwt}
+          saving={saving}
+          error={saveError}
+          onSubmit={finalize}
+        />
+      )}
+    </main>
+  );
+}
+
+// ─── Step components ──────────────────────────────────────────────
+
+function StepHeader({
+  step,
+  title,
+  body,
+}: {
+  step: number;
+  title: string;
+  body: string;
+}) {
+  return (
+    <>
+      <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">
+        Step {step} of 4
+      </p>
+      <h1 className="mt-bw-2 text-bw-2xl font-bold">{title}</h1>
+      <p className="mt-bw-2 text-bw-base text-zinc-700">{body}</p>
+    </>
+  );
+}
+
+function NextButton({
+  label,
+  onClick,
+  testId,
+}: {
+  label: string;
+  onClick: () => void;
+  testId: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className="mt-bw-6 w-full rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white hover:bg-bite-dark"
+    >
+      {label}
+    </button>
+  );
+}
+
+function PresetsStep({
+  presets,
+  loading,
+  error,
+  selectedSlugs,
+  onToggle,
+  onNext,
+}: {
+  presets: DietaryPreset[];
+  loading: boolean;
+  error: string | null;
+  selectedSlugs: string[];
+  onToggle: (slug: string) => void;
+  onNext: () => void;
+}) {
+  return (
+    <>
+      <StepHeader step={1} title="What can't you eat?" body="Tap any presets that apply. You can multi-select." />
+      {error && (
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          Could not load presets — {error}
+        </p>
+      )}
+      {loading ? (
+        <p className="mt-bw-6 text-bw-sm text-zinc-500" data-testid="presets-loading">
+          Loading presets…
+        </p>
+      ) : (
+        <div className="mt-bw-4 grid grid-cols-1 gap-bw-2 sm:grid-cols-2">
+          {presets.map((p) => {
+            const selected = selectedSlugs.includes(p.slug);
+            return (
+              <button
+                key={p.slug}
+                type="button"
+                aria-pressed={selected}
+                data-testid={`preset-${p.slug}`}
+                onClick={() => onToggle(p.slug)}
+                className={[
+                  'rounded-bw-md border p-bw-3 text-left transition',
+                  selected
+                    ? 'border-bite bg-bite-light'
+                    : 'border-zinc-200 bg-white hover:border-zinc-300',
+                ].join(' ')}
+              >
+                <p className={['font-bold', selected ? 'text-bite-dark' : 'text-zinc-900'].join(' ')}>
+                  {p.name}
+                </p>
+                <p
+                  className={[
+                    'mt-1 text-bw-sm',
+                    selected ? 'text-bite-dark' : 'text-zinc-500',
+                  ].join(' ')}
+                >
+                  {p.description}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <NextButton label="Next →" onClick={onNext} testId="next-to-ingredients" />
+    </>
+  );
+}
+
+function IngredientsStep({
+  query,
+  results,
+  addedIds,
+  onQueryChange,
+  onToggle,
+  onNext,
+}: {
+  query: string;
+  results: IngredientSearchResult[];
+  addedIds: string[];
+  onQueryChange: (q: string) => void;
+  onToggle: (id: string, isAlreadyAdded: boolean) => void;
+  onNext: () => void;
+}) {
+  return (
+    <>
+      <StepHeader step={2} title="Anything else?" body="Search for specific ingredients to avoid." />
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="Search ingredients (e.g. 'cilantro')"
+        aria-label="ingredient-search"
+        className="mt-bw-4 w-full rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+      />
+      <ul className="mt-bw-3 divide-y divide-zinc-100">
+        {results.map((r) => {
+          const added = addedIds.includes(r.id);
+          return (
+            <li key={r.id}>
+              <button
+                type="button"
+                onClick={() => onToggle(r.id, added)}
+                data-testid={`add-${r.slug}`}
+                className={[
+                  'flex w-full items-center justify-between py-bw-3 text-left',
+                  added ? 'bg-bite-light px-bw-3' : '',
+                ].join(' ')}
+              >
+                <span>
+                  <span className="block text-bw-base text-zinc-900">{r.name}</span>
+                  {r.aliases.length > 0 && (
+                    <span className="block text-bw-xs text-zinc-500">
+                      aka {r.aliases.join(', ')}
+                    </span>
+                  )}
+                </span>
+                <span className={['font-semibold', added ? 'text-ok' : 'text-bite'].join(' ')}>
+                  {added ? '✓ added' : '+ add'}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+        {results.length === 0 && (
+          <li className="py-bw-6 text-center text-bw-sm text-zinc-500">
+            {query ? 'No matches — try a different word.' : 'Type to search the ingredient catalog.'}
+          </li>
+        )}
+      </ul>
+      <p className="mt-bw-3 text-bw-sm text-zinc-500">{addedIds.length} added manually</p>
+      <NextButton label="Next →" onClick={onNext} testId="next-to-strictness" />
+    </>
+  );
+}
+
+function StrictnessStep({
+  active,
+  onPick,
+  onNext,
+}: {
+  active: Strictness;
+  onPick: (s: Strictness) => void;
+  onNext: () => void;
+}) {
+  return (
+    <>
+      <StepHeader
+        step={3}
+        title="How strict?"
+        body="Strict mode also hides items the AI hasn't fully confirmed. Pick balanced if unsure."
+      />
+      <div className="mt-bw-4 flex flex-col gap-bw-2">
+        {STRICTNESSES.map((s) => {
+          const selected = active === s;
+          return (
+            <button
+              key={s}
+              type="button"
+              data-testid={`strictness-${s}`}
+              aria-pressed={selected}
+              onClick={() => onPick(s)}
+              className={[
+                'rounded-bw-md border p-bw-3 text-left transition',
+                selected ? 'border-bite bg-bite-light' : 'border-zinc-200 bg-white hover:border-zinc-300',
+              ].join(' ')}
+            >
+              <p className={['font-bold', selected ? 'text-bite-dark' : 'text-zinc-900'].join(' ')}>
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </p>
+              <p
+                className={['mt-1 text-bw-sm', selected ? 'text-bite-dark' : 'text-zinc-500'].join(' ')}
+              >
+                {STRICTNESS_BLURB[s]}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+      <NextButton label="Review →" onClick={onNext} testId="next-to-done" />
+    </>
+  );
+}
+
+function ReviewStep({
+  presetCount,
+  ingredientCount,
+  strictness,
+  jwt,
+  onJwtChange,
+  saving,
+  error,
+  onSubmit,
+}: {
+  presetCount: number;
+  ingredientCount: number;
+  strictness: Strictness;
+  jwt: string;
+  onJwtChange: (j: string) => void;
+  saving: boolean;
+  error: string | null;
+  onSubmit: (e: FormEvent) => void;
+}) {
+  return (
+    <form onSubmit={onSubmit}>
+      <StepHeader step={4} title="Ready?" body="Saving will replace any existing avoid lists on your profile." />
+
+      <p className="mt-bw-4 text-bw-base text-zinc-700">
+        Avoiding{' '}
+        <span className="font-bold">
+          {presetCount} preset{presetCount === 1 ? '' : 's'}
+        </span>{' '}
+        +{' '}
+        <span className="font-bold">
+          {ingredientCount} ingredient{ingredientCount === 1 ? '' : 's'}
+        </span>
+        , strictness <span className="font-bold">{strictness}</span>.
+      </p>
+
+      <input
+        type="password"
+        value={jwt}
+        onChange={(e) => onJwtChange(e.target.value)}
+        placeholder="JWT (paste from /api/v1/auth/login)"
+        autoComplete="off"
+        aria-label="jwt"
+        className="mt-bw-4 w-full rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+      />
+
+      {error && (
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={saving}
+        data-testid="finish"
+        className={[
+          'mt-bw-6 w-full rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
+          saving ? 'opacity-60' : 'hover:bg-bite-dark',
+        ].join(' ')}
+      >
+        {saving ? 'Saving…' : 'Save profile'}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/lib/__tests__/jwt-cookie.test.ts
+++ b/apps/web/src/lib/__tests__/jwt-cookie.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearJwtCookie, getJwtCookie, setJwtCookie } from '../jwt-cookie';
+
+// vitest defaults to node env — stub the DOM bits the helper touches.
+let cookieJar = '';
+
+beforeEach(() => {
+  cookieJar = '';
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {
+      get cookie() {
+        return cookieJar;
+      },
+      set cookie(value: string) {
+        // Document.cookie semantics: each set adds (or overwrites by name).
+        // Crude but enough for these tests — split off the name=value head.
+        const head = value.split(';')[0]!;
+        const [name] = head.split('=');
+        const parts = cookieJar
+          ? cookieJar.split('; ').filter((p) => !p.startsWith(`${name}=`))
+          : [];
+
+        // Detect Max-Age=0 (deletion) by sniffing the rest of the value.
+        if (/Max-Age=0\b/.test(value)) {
+          cookieJar = parts.join('; ');
+          return;
+        }
+        parts.push(head);
+        cookieJar = parts.join('; ');
+      },
+    },
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { protocol: 'http:' } },
+  });
+});
+
+afterEach(() => {
+  // @ts-expect-error — cleanup the stubbed globals
+  delete globalThis.document;
+  // @ts-expect-error — cleanup the stubbed globals
+  delete globalThis.window;
+});
+
+describe('jwt-cookie helpers', () => {
+  it('round-trips a JWT through set + get', () => {
+    setJwtCookie('header.payload.sig');
+    expect(getJwtCookie()).toBe('header.payload.sig');
+  });
+
+  it('returns null when no cookie is set', () => {
+    expect(getJwtCookie()).toBeNull();
+  });
+
+  it('clears the cookie', () => {
+    setJwtCookie('jjj');
+    clearJwtCookie();
+    expect(getJwtCookie()).toBeNull();
+  });
+
+  it('encodes/decodes values that contain reserved characters', () => {
+    const tricky = 'header.payload.with spaces & =equals=';
+    setJwtCookie(tricky);
+    expect(getJwtCookie()).toBe(tricky);
+  });
+
+  it('returns null safely in a non-DOM environment', () => {
+    // @ts-expect-error — simulate SSR / node environment
+    delete globalThis.document;
+    expect(getJwtCookie()).toBeNull();
+  });
+});

--- a/apps/web/src/lib/__tests__/onboarding.test.ts
+++ b/apps/web/src/lib/__tests__/onboarding.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchDietaryProfiles,
+  saveProfile,
+  searchIngredients,
+  type SaveProfilePayload,
+} from '../onboarding';
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'NOT FOUND',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+describe('fetchDietaryProfiles', () => {
+  it('GETs /api/v1/dietary_profiles and unwraps the array', async () => {
+    const fetchImpl = fakeFetch(200, {
+      dietary_profiles: [
+        {
+          id: 'p1',
+          slug: 'vegan',
+          name: 'Vegan',
+          description: 'No animal products.',
+          avoid_ingredient_ids: ['ing-dairy'],
+          avoid_tag_ids: ['tag-cd'],
+        },
+      ],
+    });
+    const presets = await fetchDietaryProfiles({ fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain('/api/v1/dietary_profiles');
+    expect(presets).toHaveLength(1);
+    expect(presets[0]!.slug).toBe('vegan');
+  });
+});
+
+describe('searchIngredients', () => {
+  it('passes ?q= when the query is non-empty', async () => {
+    const fetchImpl = fakeFetch(200, { ingredients: [] });
+    await searchIngredients('cilantro', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('q=cilantro');
+    expect(url).toContain('limit=20');
+  });
+
+  it('omits ?q= for empty / whitespace queries', async () => {
+    const fetchImpl = fakeFetch(200, { ingredients: [] });
+    await searchIngredients('   ', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).not.toContain('q=');
+    expect(url).toContain('limit=20');
+  });
+
+  it('returns the unwrapped array', async () => {
+    const fetchImpl = fakeFetch(200, {
+      ingredients: [
+        { id: 'i1', slug: 'cilantro', name: 'Cilantro', path: 'herb.cilantro', aliases: [], allergen: false },
+      ],
+    });
+    const out = await searchIngredients('cilantro', { fetchImpl });
+    expect(out[0]!.name).toBe('Cilantro');
+  });
+});
+
+describe('saveProfile', () => {
+  const payload: SaveProfilePayload = {
+    avoid_ingredient_ids: ['ing-dairy'],
+    avoid_tag_ids: ['tag-cd'],
+    prefer_tag_ids: [],
+    strictness: 'balanced',
+  };
+
+  it('PATCHes /api/v1/profile with the payload + Bearer auth', async () => {
+    const fetchImpl = fakeFetch(200, {});
+    await saveProfile(payload, 'jjj.www.ttt', { fetchImpl });
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe('PATCH');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jjj.www.ttt');
+    expect(JSON.parse(init.body as string)).toEqual(payload);
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = fakeFetch(422, { error: 'invalid' });
+    await expect(saveProfile(payload, 'jwt', { fetchImpl })).rejects.toThrow(/422/);
+  });
+});

--- a/apps/web/src/lib/jwt-cookie.ts
+++ b/apps/web/src/lib/jwt-cookie.ts
@@ -1,0 +1,42 @@
+/**
+ * Phase 3.8 — temporary JWT cookie store.
+ *
+ * Phase 4 will land proper session cookies (HttpOnly, Secure, SameSite,
+ * server-managed). For now the onboarding flow stores the JWT in a
+ * client-side cookie so the next request to a profile-aware endpoint
+ * (e.g. `/restaurants/[slug]?with_jwt=true`) can read it back.
+ *
+ * This is intentionally NOT secure for production — the cookie has
+ * no HttpOnly flag and is JS-readable. The same plaintext-input
+ * workaround the ingest/restaurant screens use today.
+ */
+
+const COOKIE_NAME = 'bw_jwt';
+const ONE_WEEK = 60 * 60 * 24 * 7;
+
+export function setJwtCookie(jwt: string): void {
+  if (typeof document === 'undefined') return;
+  const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `${COOKIE_NAME}=${encodeURIComponent(jwt)}; Path=/; Max-Age=${ONE_WEEK}; SameSite=Lax${secure}`;
+}
+
+export function getJwtCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  for (const part of document.cookie.split('; ')) {
+    const [k, ...vparts] = part.split('=');
+    if (k === COOKIE_NAME) {
+      const v = vparts.join('=');
+      try {
+        return decodeURIComponent(v);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+export function clearJwtCookie(): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`;
+}

--- a/apps/web/src/lib/onboarding.ts
+++ b/apps/web/src/lib/onboarding.ts
@@ -1,0 +1,66 @@
+/**
+ * Phase 3.8 — read-side helpers for the web onboarding flow.
+ *
+ * Mirrors apps/mobile/lib/api/onboarding.ts. Both apps drive the
+ * same `onboardingReducer` from `@biteworthy/filter-engine`, so the
+ * fetcher shapes have to line up too.
+ */
+
+import type { DietaryPreset } from '@biteworthy/filter-engine';
+import { api, type ApiOptions } from './api';
+
+export interface IngredientSearchResult {
+  id: string;
+  slug: string;
+  name: string;
+  path: string;
+  aliases: string[];
+  allergen: boolean;
+}
+
+export interface SaveProfilePayload {
+  avoid_ingredient_ids: string[];
+  avoid_tag_ids: string[];
+  prefer_tag_ids: string[];
+  strictness: 'relaxed' | 'balanced' | 'strict';
+}
+
+export async function fetchDietaryProfiles(opts: ApiOptions = {}): Promise<DietaryPreset[]> {
+  const json = await api<{ dietary_profiles: DietaryPreset[] }>('/dietary_profiles', opts);
+  return json.dietary_profiles;
+}
+
+export async function searchIngredients(
+  q: string,
+  opts: ApiOptions = {},
+): Promise<IngredientSearchResult[]> {
+  const params = new URLSearchParams();
+  if (q.trim().length > 0) params.set('q', q);
+  params.set('limit', '20');
+  const json = await api<{ ingredients: IngredientSearchResult[] }>(
+    `/ingredients?${params.toString()}`,
+    opts,
+  );
+  return json.ingredients;
+}
+
+/**
+ * PATCH /api/v1/profile (Phase 1.3) with the assembled draft. The
+ * endpoint replaces the whole avoid list — the reducer's
+ * `toProfilePayload` returns the wholesale-replacement payload.
+ */
+export async function saveProfile(
+  payload: SaveProfilePayload,
+  jwt: string,
+  opts: ApiOptions = {},
+): Promise<void> {
+  await api<unknown>('/profile', {
+    ...opts,
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      ...(opts.headers ?? {}),
+    },
+    body: JSON.stringify(payload),
+  });
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,9 +13,8 @@ the merge / review / status rules.
 
 **Phase 3** ⭐ Dietary filter UI. Subplan: `docs/plans/phase-3.md`.
 
-1. **Phase 3.7 — `applyProfile` in filter-engine** (`docs/plans/phase-3.md#37`) — this PR
-2. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`)
-3. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
+1. **Phase 3.8 — Web profile onboarding** (`docs/plans/phase-3.md#38`) — this PR
+2. **Phase 3.9 — Shareable filter URLs** (`docs/plans/phase-3.md#39`)
 
 ### Done
 
@@ -44,6 +43,7 @@ the merge / review / status rules.
 - ✅ Phase 3.4 — transparency chips + show-anyway override (#149)
 - ✅ Phase 3.5 — strict-mode toggle (#150)
 - ✅ Phase 3.6 — web filtered restaurant page (#151)
+- ✅ Phase 3.7 — applyProfile + display helpers consolidated in filter-engine (#152)
 
 After Phase 3 ships, the loop will draft `docs/plans/phase-4.md` (reviews + accounts) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,27 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 07:30 — tick #58. PR #152 (Phase 3.7) merged at 07:07 UTC.
+Picked up Phase 3.8 — web profile onboarding (mirror of mobile 3.2).
+First move: promoted the mobile onboarding reducer into
+`@biteworthy/filter-engine` as `onboardingReducer` + `toProfilePayload`
++ `DraftProfile` + `DietaryPreset` + `OnboardingAction`. Mobile reducer
+file deleted, mobile screen + API client now import from filter-engine
+(rename `reducer` → `onboardingReducer`). 14 reducer tests moved from
+mobile jest into filter-engine vitest — mobile jest count drops from
+34 to 20, filter-engine grows from 31 to 45. Web pieces: new
+`apps/web/src/lib/onboarding.ts` (fetchDietaryProfiles +
+searchIngredients + saveProfile, accepts injected fetchImpl);
+`apps/web/src/lib/jwt-cookie.ts` (set/get/clear bw_jwt cookie —
+plaintext + JS-readable, same workaround the ingest screen uses; Phase
+4 swaps for HttpOnly server-managed sessions); 4-step page at
+`apps/web/src/app/onboarding/page.tsx` ('use client' for the reducer
++ search + cookie writes). 11 new vitest cases (6 onboarding API
+client + 5 cookie helper), no UI snapshot test for the page itself
+(same blocker as Phase 3.5 — needs `@testing-library/react` setup).
+Local: filter-engine vitest 45/45; web vitest 21/21; mobile jest
+20/20; rspec 184/0/1 pending; pnpm typecheck/lint cached green.
+
 2026-05-01 07:00 — tick #57. PR #151 (Phase 3.6) merged at 06:00 UTC.
 Picked up Phase 3.7 — consolidated the per-item filter computation
 into `@biteworthy/filter-engine`. The package was previously a

--- a/packages/filter-engine/src/index.ts
+++ b/packages/filter-engine/src/index.ts
@@ -258,3 +258,14 @@ export function applyOverrides<T extends FilteredItem>(
     };
   });
 }
+
+// ─── Onboarding draft profile (Phase 3.2 + 3.8) ────────────────────
+
+export {
+  initialDraft,
+  onboardingReducer,
+  toProfilePayload,
+  type DietaryPreset,
+  type DraftProfile,
+  type OnboardingAction,
+} from './onboarding-reducer';

--- a/packages/filter-engine/src/onboarding-reducer.test.ts
+++ b/packages/filter-engine/src/onboarding-reducer.test.ts
@@ -1,10 +1,11 @@
+import { describe, expect, it } from 'vitest';
 import {
-  reducer,
   initialDraft,
+  onboardingReducer,
   toProfilePayload,
   type DietaryPreset,
   type DraftProfile,
-} from '../../lib/onboarding-reducer';
+} from './onboarding-reducer';
 
 const vegan: DietaryPreset = {
   id: 'p-vegan',
@@ -33,16 +34,16 @@ const dairyFree: DietaryPreset = {
   avoid_tag_ids: ['tag-contains-dairy'],
 };
 
-describe('onboarding reducer', () => {
+describe('onboardingReducer', () => {
   describe('TOGGLE_PRESET', () => {
     it('adds a preset slug when not selected', () => {
-      const next = reducer(initialDraft, { type: 'TOGGLE_PRESET', slug: 'vegan' });
+      const next = onboardingReducer(initialDraft, { type: 'TOGGLE_PRESET', slug: 'vegan' });
       expect(next.selectedPresetSlugs).toEqual(['vegan']);
     });
 
     it('removes a preset slug when already selected', () => {
       const seeded: DraftProfile = { ...initialDraft, selectedPresetSlugs: ['vegan', 'celiac'] };
-      const next = reducer(seeded, { type: 'TOGGLE_PRESET', slug: 'vegan' });
+      const next = onboardingReducer(seeded, { type: 'TOGGLE_PRESET', slug: 'vegan' });
       expect(next.selectedPresetSlugs).toEqual(['celiac']);
     });
 
@@ -52,7 +53,7 @@ describe('onboarding reducer', () => {
         manualIngredientIds: ['ing-cilantro'],
         strictness: 'strict',
       };
-      const next = reducer(seeded, { type: 'TOGGLE_PRESET', slug: 'vegan' });
+      const next = onboardingReducer(seeded, { type: 'TOGGLE_PRESET', slug: 'vegan' });
       expect(next.manualIngredientIds).toEqual(['ing-cilantro']);
       expect(next.strictness).toBe('strict');
     });
@@ -60,7 +61,7 @@ describe('onboarding reducer', () => {
 
   describe('ADD_MANUAL_INGREDIENT', () => {
     it('appends a new id', () => {
-      const next = reducer(initialDraft, {
+      const next = onboardingReducer(initialDraft, {
         type: 'ADD_MANUAL_INGREDIENT',
         ingredientId: 'ing-cilantro',
       });
@@ -68,11 +69,11 @@ describe('onboarding reducer', () => {
     });
 
     it('is idempotent — adding the same id twice keeps one entry', () => {
-      const once = reducer(initialDraft, {
+      const once = onboardingReducer(initialDraft, {
         type: 'ADD_MANUAL_INGREDIENT',
         ingredientId: 'ing-cilantro',
       });
-      const twice = reducer(once, {
+      const twice = onboardingReducer(once, {
         type: 'ADD_MANUAL_INGREDIENT',
         ingredientId: 'ing-cilantro',
       });
@@ -87,7 +88,7 @@ describe('onboarding reducer', () => {
         ...initialDraft,
         manualIngredientIds: ['ing-a', 'ing-b', 'ing-c'],
       };
-      const next = reducer(seeded, {
+      const next = onboardingReducer(seeded, {
         type: 'REMOVE_MANUAL_INGREDIENT',
         ingredientId: 'ing-b',
       });
@@ -99,7 +100,7 @@ describe('onboarding reducer', () => {
         ...initialDraft,
         manualIngredientIds: ['ing-a'],
       };
-      const next = reducer(seeded, {
+      const next = onboardingReducer(seeded, {
         type: 'REMOVE_MANUAL_INGREDIENT',
         ingredientId: 'ing-zzz',
       });
@@ -109,7 +110,7 @@ describe('onboarding reducer', () => {
 
   describe('SET_STRICTNESS', () => {
     it('updates strictness', () => {
-      const next = reducer(initialDraft, { type: 'SET_STRICTNESS', strictness: 'strict' });
+      const next = onboardingReducer(initialDraft, { type: 'SET_STRICTNESS', strictness: 'strict' });
       expect(next.strictness).toBe('strict');
     });
   });
@@ -121,7 +122,7 @@ describe('onboarding reducer', () => {
         manualIngredientIds: ['ing-x'],
         strictness: 'strict',
       };
-      expect(reducer(seeded, { type: 'RESET' })).toEqual(initialDraft);
+      expect(onboardingReducer(seeded, { type: 'RESET' })).toEqual(initialDraft);
     });
   });
 });
@@ -154,7 +155,7 @@ describe('toProfilePayload', () => {
 
   it('dedupes ids that appear in multiple selected presets', () => {
     const draft: DraftProfile = {
-      selectedPresetSlugs: ['vegan', 'dairy-free'], // both include ing-dairy + tag-contains-dairy
+      selectedPresetSlugs: ['vegan', 'dairy-free'],
       manualIngredientIds: [],
       strictness: 'balanced',
     };
@@ -171,14 +172,7 @@ describe('toProfilePayload', () => {
     };
     const payload = toProfilePayload(draft, catalog);
     expect(payload.avoid_ingredient_ids.sort()).toEqual(
-      [
-        'ing-almond',
-        'ing-cashew',
-        'ing-cilantro',
-        'ing-dairy',
-        'ing-egg',
-        'ing-meat',
-      ].sort(),
+      ['ing-almond', 'ing-cashew', 'ing-cilantro', 'ing-dairy', 'ing-egg', 'ing-meat'].sort(),
     );
     expect(payload.avoid_tag_ids.sort()).toEqual(
       ['tag-contains-dairy', 'tag-contains-tree-nut'].sort(),

--- a/packages/filter-engine/src/onboarding-reducer.ts
+++ b/packages/filter-engine/src/onboarding-reducer.ts
@@ -1,17 +1,18 @@
 /**
- * Phase 3.2 — pure reducer for the onboarding draft profile.
+ * Phase 3.2 + 3.8 — pure reducer for the onboarding draft profile.
  *
- * The screen drives this; the reducer is pure so the spec can verify
- * every transition without mounting React. The eventual `PATCH
- * /api/v1/profile` payload is the `toProfilePayload(state)` output.
+ * Drives the 4-step onboarding flow on both mobile (Phase 3.2) and
+ * web (Phase 3.8). The reducer is pure so the spec verifies every
+ * transition without mounting React, and the eventual
+ * `PATCH /api/v1/profile` payload is the `toProfilePayload(state)`
+ * output.
  *
  * Picking a preset (Vegan etc.) is **additive**: it unions the
- * preset's avoid_*_ids onto whatever's already in the draft.
- * Un-picking removes only the ids that ONLY came from that preset,
- * not ids the user added manually or via another preset.
+ * preset's avoid_*_ids onto whatever's already in the draft. The
+ * union+dedupe is what `toProfilePayload` does — the reducer just
+ * remembers which slugs the user tapped on.
  */
-
-export type Strictness = 'relaxed' | 'balanced' | 'strict';
+import type { Strictness } from './index';
 
 export interface DietaryPreset {
   id: string;
@@ -37,14 +38,14 @@ export const initialDraft: DraftProfile = {
   strictness: 'balanced',
 };
 
-export type Action =
+export type OnboardingAction =
   | { type: 'TOGGLE_PRESET'; slug: string }
   | { type: 'ADD_MANUAL_INGREDIENT'; ingredientId: string }
   | { type: 'REMOVE_MANUAL_INGREDIENT'; ingredientId: string }
   | { type: 'SET_STRICTNESS'; strictness: Strictness }
   | { type: 'RESET' };
 
-export function reducer(state: DraftProfile, action: Action): DraftProfile {
+export function onboardingReducer(state: DraftProfile, action: OnboardingAction): DraftProfile {
   switch (action.type) {
     case 'TOGGLE_PRESET': {
       const has = state.selectedPresetSlugs.includes(action.slug);


### PR DESCRIPTION
## Summary

Phase 3.8 brings the 4-step onboarding flow to the web — same flow as the mobile screen from Phase 3.2, driven by the same reducer code (now living in `@biteworthy/filter-engine`). Subplan: `docs/plans/phase-3.md#38`.

### filter-engine
- Promoted the mobile onboarding reducer into the package as `onboardingReducer`, `toProfilePayload`, `DraftProfile`, `DietaryPreset`, `OnboardingAction`. Renamed `reducer` → `onboardingReducer` for clarity at the package boundary.
- Mobile reducer file deleted; mobile screen + API client now import from filter-engine.
- 14 reducer tests moved from mobile jest to filter-engine vitest.

### Web
- **`apps/web/src/lib/onboarding.ts`** — `fetchDietaryProfiles`, `searchIngredients` (`?q=` omitted on whitespace), `saveProfile` (PATCH `/api/v1/profile` with Bearer auth). Accepts injected `fetchImpl` for tests.
- **`apps/web/src/lib/jwt-cookie.ts`** — `set/get/clear` for the `bw_jwt` cookie. Plaintext + JS-readable, matches the same workaround the ingest screen uses today; Phase 4 swaps it for HttpOnly server-managed sessions. Path=/, Max-Age 1 week, SameSite=Lax, `Secure` flag on https.
- **`apps/web/src/app/onboarding/page.tsx`** — `'use client'` 4-step flow driving `onboardingReducer`. Steps: presets → ingredients (debounced 250ms search) → strictness → review (paste JWT, save). On success: writes the JWT cookie and `router.replace('/')`.

## Out of scope
- Real session cookies (HttpOnly, server-managed) — **Phase 4**.
- UI snapshot test for the page itself — same blocker as Phase 3.5 (needs `@testing-library/react` setup; see Discovered followup).

## Test plan
- [x] **filter-engine vitest**: 45/45 (14 onboarding + 31 prior).
- [x] **Web vitest**: 21/21 (4 ingestion + 6 restaurants + 6 onboarding + 5 cookie).
- [x] **Mobile jest**: 20/20 (was 34, lost the 14 reducer tests that moved into filter-engine).
- [x] **Rspec**: 184/0/1 pending (the pending is the existing `ANTHROPIC_API_KEY` cassette).
- [x] `pnpm typecheck` / `pnpm lint`: green across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)