### PR TITLE
feat(api,web,mobile): real session cookies + login/signup (phase 4.1)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -49,4 +49,4 @@ ANTHROPIC_API_KEY=
 # --- Mailer ------------------------------------------------------------------
 # Used by Devise for password-reset emails. The mailer itself isn't
 # wired in until Phase 4; this is documented now so .env stays canonical.
-DEVISE_MAILER_FROM=no-reply@biteworthy.app
+DEVISE_MAILER_FROM=info@bite-worthy.com

--- a/apps/api/spec/requests/admin/dashboard_spec.rb
+++ b/apps/api/spec/requests/admin/dashboard_spec.rb
@@ -1,6 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Dashboard", type: :request do
+  # Insulate the spec from whatever credentials live in the local
+  # .env / CI secrets — same reason as spec/requests/admin_spec.rb.
+  around do |example|
+    original_user = ENV["ADMIN_USERNAME"]
+    original_password = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_USERNAME"] = "admin"
+    ENV["ADMIN_PASSWORD"] = "admin"
+    example.run
+  ensure
+    ENV["ADMIN_USERNAME"] = original_user
+    ENV["ADMIN_PASSWORD"] = original_password
+  end
+
   let(:restaurant) { create(:restaurant, :published) }
   let(:basic_auth) do
     creds = ActionController::HttpAuthentication::Basic.encode_credentials("admin", "admin")

--- a/apps/api/spec/requests/admin_spec.rb
+++ b/apps/api/spec/requests/admin_spec.rb
@@ -7,6 +7,20 @@ require "rails_helper"
 # Phase 4 once we have policy-based per-action authorization.
 
 RSpec.describe "/admin (Avo) auth gate", type: :request do
+  # Insulate the spec from whatever credentials live in the local
+  # .env / CI secrets — the spec asserts the *gate*, not specific
+  # values. Restore on teardown so other specs aren't surprised.
+  around do |example|
+    original_user = ENV["ADMIN_USERNAME"]
+    original_password = ENV["ADMIN_PASSWORD"]
+    ENV["ADMIN_USERNAME"] = "admin"
+    ENV["ADMIN_PASSWORD"] = "admin"
+    example.run
+  ensure
+    ENV["ADMIN_USERNAME"] = original_user
+    ENV["ADMIN_PASSWORD"] = original_password
+  end
+
   let(:basic_auth) do
     creds = ActionController::HttpAuthentication::Basic.encode_credentials("admin", "admin")
     { "Authorization" => creds }

--- a/apps/mobile/__tests__/lib/auth.test.ts
+++ b/apps/mobile/__tests__/lib/auth.test.ts
@@ -1,0 +1,142 @@
+// Mock expo-secure-store with an in-memory store before importing
+// the SUT, so the wrapper exercises real persistence semantics.
+jest.mock('expo-secure-store', () => {
+  const store = new Map<string, string>();
+  return {
+    __memstore: store,
+    getItemAsync: jest.fn(async (key: string) => store.get(key) ?? null),
+    setItemAsync: jest.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    deleteItemAsync: jest.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+});
+
+import { AuthError, clearJwt, getJwt, login, logout, setJwt, signup } from '../../lib/auth';
+
+const SecureStore = jest.requireMock('expo-secure-store') as {
+  __memstore: Map<string, string>;
+  getItemAsync: jest.Mock;
+  setItemAsync: jest.Mock;
+  deleteItemAsync: jest.Mock;
+};
+
+beforeEach(() => {
+  SecureStore.__memstore.clear();
+  SecureStore.getItemAsync.mockClear();
+  SecureStore.setItemAsync.mockClear();
+  SecureStore.deleteItemAsync.mockClear();
+});
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown, headers: Record<string, string> = {}) {
+  return jest.fn(async (..._args: FetchArgs) =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      headers: {
+        get: (name: string) => headers[name] ?? null,
+      },
+      json: async () => body,
+    }) as unknown as Response,
+  );
+}
+
+describe('getJwt / setJwt / clearJwt', () => {
+  it('round-trips a token through SecureStore', async () => {
+    await setJwt('header.payload.sig');
+    expect(await getJwt()).toBe('header.payload.sig');
+  });
+
+  it('returns null when nothing is stored', async () => {
+    expect(await getJwt()).toBeNull();
+  });
+
+  it('clears the stored token', async () => {
+    await setJwt('jjj');
+    await clearJwt();
+    expect(await getJwt()).toBeNull();
+  });
+
+  it('returns null when SecureStore throws (e.g. simulator without keychain)', async () => {
+    SecureStore.getItemAsync.mockRejectedValueOnce(new Error('no keychain'));
+    expect(await getJwt()).toBeNull();
+  });
+});
+
+describe('login', () => {
+  const userPayload = { user: { id: 'u1', email: 'a@b.com', handle: null, display_name: null } };
+
+  it('POSTs credentials, persists the token from the Authorization header, returns the user', async () => {
+    const fetchImpl = fakeFetch(200, userPayload, { Authorization: 'Bearer header.body.sig' });
+    const user = await login('a@b.com', 'sekret123', { fetchImpl });
+
+    expect(user.email).toBe('a@b.com');
+    expect(await getJwt()).toBe('header.body.sig');
+
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({
+      user: { email: 'a@b.com', password: 'sekret123' },
+    });
+  });
+
+  it('throws AuthError on bad credentials and does not persist anything', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'invalid' });
+    await expect(login('a@b.com', 'wrong', { fetchImpl })).rejects.toMatchObject({
+      name: 'AuthError',
+      status: 401,
+    });
+    expect(await getJwt()).toBeNull();
+  });
+
+  it('throws when the upstream forgets to send the Authorization header', async () => {
+    const fetchImpl = fakeFetch(200, userPayload, {}); // no Authorization
+    await expect(login('a@b.com', 'sekret123', { fetchImpl })).rejects.toBeInstanceOf(AuthError);
+    expect(await getJwt()).toBeNull();
+  });
+});
+
+describe('signup', () => {
+  it('POSTs to /api/v1/auth/signup', async () => {
+    const fetchImpl = fakeFetch(
+      200,
+      { user: { id: 'u2', email: 'b@c.com', handle: null, display_name: null } },
+      { Authorization: 'Bearer fresh.token.here' },
+    );
+    await signup('b@c.com', 'longerpw1', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('/api/v1/auth/signup');
+    expect(await getJwt()).toBe('fresh.token.here');
+  });
+});
+
+describe('logout', () => {
+  it('clears the stored token even when the upstream call fails', async () => {
+    await setJwt('persisted.jwt');
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('network down');
+    });
+    await logout({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(await getJwt()).toBeNull();
+  });
+
+  it('best-effort calls the API logout when a token is present', async () => {
+    await setJwt('persisted.jwt');
+    const fetchImpl = fakeFetch(204, {});
+    await logout({ fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toContain('/api/v1/auth/logout');
+    expect(init.method).toBe('DELETE');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer persisted.jwt');
+  });
+
+  it('skips the API call when no token is stored', async () => {
+    const fetchImpl = jest.fn();
+    await logout({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/app/ingest/index.tsx
+++ b/apps/mobile/app/ingest/index.tsx
@@ -9,12 +9,14 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { router } from 'expo-router';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
   uploadIngestionRun,
   type CapturedPage,
 } from '../../lib/api/ingestion-runs';
+import { getJwt } from '../../lib/auth';
 
 /**
  * Phase 2.6 — multi-page menu capture.
@@ -31,7 +33,6 @@ import {
  */
 export default function IngestScreen() {
   const [restaurantId, setRestaurantId] = useState('');
-  const [jwt, setJwt] = useState(''); // Phase 4 will pull from secure-store
   const [pages, setPages] = useState<CapturedPage[]>([]);
   const [cameraOpen, setCameraOpen] = useState(false);
   const [permission, requestPermission] = useCameraPermissions();
@@ -47,8 +48,13 @@ export default function IngestScreen() {
   };
 
   const onUpload = async () => {
-    if (!restaurantId || pages.length === 0 || !jwt) {
-      Alert.alert('Missing info', 'Restaurant id, JWT, and at least one page are required.');
+    if (!restaurantId || pages.length === 0) {
+      Alert.alert('Missing info', 'Restaurant id and at least one page are required.');
+      return;
+    }
+    const jwt = await getJwt();
+    if (!jwt) {
+      router.replace('/login?next=%2Fingest');
       return;
     }
     try {
@@ -57,7 +63,12 @@ export default function IngestScreen() {
       Alert.alert('Uploaded', `Run ${run.id.slice(0, 8)}… is now ${run.status}.`);
       setPages([]);
     } catch (e) {
-      Alert.alert('Upload failed', (e as Error).message);
+      const message = (e as Error).message;
+      if (message.includes('401')) {
+        router.replace('/login?next=%2Fingest');
+        return;
+      }
+      Alert.alert('Upload failed', message);
     } finally {
       setUploading(false);
     }
@@ -107,15 +118,6 @@ export default function IngestScreen() {
         value={restaurantId}
         onChangeText={setRestaurantId}
         autoCapitalize="none"
-        style={styles.input}
-      />
-      <TextInput
-        accessibilityLabel="jwt"
-        placeholder="JWT (paste from /api/v1/auth/login)"
-        value={jwt}
-        onChangeText={setJwt}
-        autoCapitalize="none"
-        secureTextEntry
         style={styles.input}
       />
 

--- a/apps/mobile/app/ingest/verify.tsx
+++ b/apps/mobile/app/ingest/verify.tsx
@@ -9,8 +9,9 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import { getJwt } from '../../lib/auth';
 import {
   decideIngestionItem,
   getIngestionRun,
@@ -22,22 +23,36 @@ import {
 const POLL_INTERVAL_MS = 2_000;
 
 /**
- * Phase 2.7 — swipe-verify deck.
+ * Phase 2.7 + 4.1 — swipe-verify deck.
  *
- * Routed at `/ingest/verify?runId=...&jwt=...`. While the run is in
+ * Routed at `/ingest/verify?runId=...`. JWT comes from the keychain
+ * (Phase 4.1 — `getJwt()` from lib/auth). While the run is in
  * `:queued / :extracting / :resolving`, polls every 2s. Once status
  * hits `:staged`, fetches the items and shows a one-at-a-time card
  * with Accept / Reject / Edit buttons.
  *
- * Phase 2.7 ships the tap-to-decide flow + the polling. The
+ * Phase 2.7 shipped the tap-to-decide flow + the polling. The
  * Tinder-style swipe gestures (react-native-gesture-handler +
  * reanimated worklets) come in a follow-up after the on-device
  * testing pass — the data wiring is what matters for end-to-end.
  */
 export default function VerifyScreen() {
-  const params = useLocalSearchParams<{ runId?: string; jwt?: string }>();
+  const params = useLocalSearchParams<{ runId?: string }>();
   const runId = params.runId ?? '';
-  const jwt = params.jwt ?? '';
+  const [jwt, setJwtState] = useState<string | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getJwt().then((t) => {
+      if (cancelled) return;
+      setJwtState(t);
+      setAuthChecked(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const [run, setRun] = useState<IngestionRunPayload | null>(null);
   const [items, setItems] = useState<IngestionItemPayload[]>([]);
@@ -81,7 +96,7 @@ export default function VerifyScreen() {
 
   const decide = useCallback(
     async (decision: 'accepted' | 'rejected' | 'edited') => {
-      if (!current) return;
+      if (!current || !jwt) return;
       try {
         const edits =
           decision === 'edited' || decision === 'accepted'
@@ -105,10 +120,22 @@ export default function VerifyScreen() {
     [current, runId, jwt, editName, editDescription],
   );
 
-  if (!runId || !jwt) {
+  if (!runId) {
     return (
       <View style={styles.container}>
-        <Text style={styles.body}>Missing runId or jwt query params.</Text>
+        <Text style={styles.body}>Missing runId query param.</Text>
+      </View>
+    );
+  }
+
+  if (authChecked && !jwt) {
+    router.replace('/login?next=' + encodeURIComponent(`/ingest/verify?runId=${runId}`));
+    return null;
+  }
+  if (!authChecked) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={colors.bite} />
       </View>
     );
   }

--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Link, router, useLocalSearchParams } from 'expo-router';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import { AuthError, login } from '../lib/auth';
+
+/**
+ * Phase 4.1 — mobile login screen. Pulls the JWT from the response
+ * Authorization header and persists it in expo-secure-store. After
+ * success the user lands on `?next=…` (defaults to /).
+ */
+export default function LoginScreen() {
+  const params = useLocalSearchParams<{ next?: string }>();
+  const next = typeof params.next === 'string' && params.next.length > 0 ? params.next : '/';
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async () => {
+    if (!email || !password) {
+      Alert.alert('Missing info', 'Email and password required.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await login(email, password);
+      router.replace(next);
+    } catch (err) {
+      const status = err instanceof AuthError ? err.status : 0;
+      const message = status === 401 ? 'Wrong email or password.' : (err as Error).message;
+      Alert.alert('Sign-in failed', message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.eyebrow}>BiteWorthy</Text>
+      <Text style={styles.headline}>Sign in</Text>
+
+      <TextInput
+        accessibilityLabel="email"
+        placeholder="Email"
+        autoCapitalize="none"
+        autoComplete="email"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        accessibilityLabel="password"
+        placeholder="Password"
+        autoCapitalize="none"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+
+      <Pressable
+        accessibilityLabel="login-submit"
+        onPress={onSubmit}
+        disabled={submitting}
+        style={[styles.primary, submitting && { opacity: 0.5 }]}
+      >
+        {submitting ? (
+          <ActivityIndicator color={colors.bg} />
+        ) : (
+          <Text style={styles.primaryText}>Sign in</Text>
+        )}
+      </Pressable>
+
+      <Link href={`/signup?next=${encodeURIComponent(next)}`} style={styles.link}>
+        <Text style={styles.linkText}>Create an account</Text>
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 80,
+    paddingHorizontal: space['6'],
+    backgroundColor: colors.bg,
+    gap: space['3'],
+  },
+  eyebrow: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  headline: {
+    fontSize: fontSize['2xl'],
+    fontWeight: '700',
+    color: colors.text,
+    marginBottom: space['3'],
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: space['3'],
+    fontSize: fontSize.base,
+    color: colors.text,
+  },
+  primary: {
+    backgroundColor: colors.bite,
+    paddingVertical: space['4'],
+    borderRadius: 12,
+    alignItems: 'center',
+    marginTop: space['3'],
+  },
+  primaryText: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.base,
+  },
+  link: {
+    marginTop: space['4'],
+    alignSelf: 'center',
+  },
+  linkText: {
+    color: colors.bite,
+    fontWeight: '600',
+    fontSize: fontSize.sm,
+  },
+});

--- a/apps/mobile/app/onboarding/index.tsx
+++ b/apps/mobile/app/onboarding/index.tsx
@@ -25,6 +25,7 @@ import {
   searchIngredients,
   type IngredientSearchResult,
 } from '../../lib/api/onboarding';
+import { getJwt } from '../../lib/auth';
 
 /**
  * Phase 3.2 — 6-tap onboarding to a working dietary filter.
@@ -32,11 +33,11 @@ import {
  *   1. Pick presets ("What can't you eat?")
  *   2. Add specific ingredients ("Anything else?")
  *   3. Set strictness ("How strict?")
- *   4. Done → PATCH /api/v1/profile, navigate to ingest/restaurant
- *      picker (out of scope for 3.2 — for now just shows success).
+ *   4. Done → PATCH /api/v1/profile, navigate to /.
  *
- * The JWT is taken as a query param until Phase 4 wires
- * `expo-secure-store`. Same pattern as ingest/verify screens.
+ * Phase 4.1 dropped the paste-the-JWT field; auth comes from the
+ * keychain-backed token stored by /login. A 401 means the session
+ * expired — the user is bounced to /login?next=/onboarding.
  */
 type Step = 'presets' | 'ingredients' | 'strictness' | 'done';
 
@@ -48,7 +49,6 @@ export default function OnboardingScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<IngredientSearchResult[]>([]);
   const [searchedIngredients, setSearchedIngredients] = useState<Map<string, IngredientSearchResult>>(new Map());
-  const [jwt, setJwt] = useState('');
   const [saving, setSaving] = useState(false);
 
   // Load presets once.
@@ -80,8 +80,9 @@ export default function OnboardingScreen() {
   }, [searchQuery, step]);
 
   const finalize = async () => {
+    const jwt = await getJwt();
     if (!jwt) {
-      Alert.alert('JWT required', 'Paste a JWT — Phase 4 will swap to secure-store.');
+      router.replace('/login?next=%2Fonboarding');
       return;
     }
     try {
@@ -90,7 +91,12 @@ export default function OnboardingScreen() {
       Alert.alert('Profile saved', 'Your dietary filter is ready.');
       router.replace('/');
     } catch (e) {
-      Alert.alert('Save failed', (e as Error).message);
+      const message = (e as Error).message;
+      if (message.includes('401')) {
+        router.replace('/login?next=%2Fonboarding');
+        return;
+      }
+      Alert.alert('Save failed', message);
     } finally {
       setSaving(false);
     }
@@ -240,16 +246,6 @@ export default function OnboardingScreen() {
           {draft.manualIngredientIds.length} ingredient{draft.manualIngredientIds.length === 1 ? '' : 's'}
         </Text>, strictness <Text style={{ fontWeight: '700' }}>{draft.strictness}</Text>.
       </Text>
-
-      <TextInput
-        accessibilityLabel="jwt"
-        placeholder="JWT (paste from /api/v1/auth/login)"
-        value={jwt}
-        onChangeText={setJwt}
-        autoCapitalize="none"
-        secureTextEntry
-        style={styles.input}
-      />
 
       <Pressable
         accessibilityLabel="finish"

--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -18,6 +18,7 @@ import {
   type ItemSection,
 } from '@biteworthy/filter-engine';
 import { buildShareUrl } from '../../lib/share-url';
+import { getJwt } from '../../lib/auth';
 import {
   fetchRestaurant,
   fetchRestaurantItems,
@@ -44,9 +45,21 @@ type Strictness = 'relaxed' | 'balanced' | 'strict';
 const STRICTNESSES: Strictness[] = ['relaxed', 'balanced', 'strict'];
 
 export default function RestaurantScreen() {
-  const params = useLocalSearchParams<{ id: string; jwt?: string }>();
+  const params = useLocalSearchParams<{ id: string }>();
   const id = String(params.id ?? '');
-  const jwt = typeof params.jwt === 'string' ? params.jwt : undefined;
+  // Phase 4.1: pull the JWT from the keychain on mount; if absent
+  // the page still loads (anonymous browse), but personalized filter
+  // results require a sign-in.
+  const [jwt, setJwt] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    getJwt().then((t) => {
+      if (!cancelled) setJwt(t ?? undefined);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const [restaurant, setRestaurant] = useState<Restaurant | null>(null);
   const [filter, setFilter] = useState<FilterSummary | null>(null);

--- a/apps/mobile/app/signup.tsx
+++ b/apps/mobile/app/signup.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Link, router, useLocalSearchParams } from 'expo-router';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import { AuthError, signup } from '../lib/auth';
+
+/**
+ * Phase 4.1 — mobile signup screen. Mirrors the web signup; defaults
+ * the post-signup destination to /onboarding so a fresh account
+ * lands on the dietary-filter setup.
+ */
+export default function SignupScreen() {
+  const params = useLocalSearchParams<{ next?: string }>();
+  const next = typeof params.next === 'string' && params.next.length > 0 ? params.next : '/onboarding';
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async () => {
+    if (!email || !password) {
+      Alert.alert('Missing info', 'Email and password required.');
+      return;
+    }
+    if (password.length < 8) {
+      Alert.alert('Password too short', 'Use 8 or more characters.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await signup(email, password);
+      router.replace(next);
+    } catch (err) {
+      const status = err instanceof AuthError ? err.status : 0;
+      const message = status === 422 ? 'That email is already in use.' : (err as Error).message;
+      Alert.alert('Sign-up failed', message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.eyebrow}>BiteWorthy</Text>
+      <Text style={styles.headline}>Create account</Text>
+      <Text style={styles.body}>Free. We'll save your dietary filter for next time.</Text>
+
+      <TextInput
+        accessibilityLabel="email"
+        placeholder="Email"
+        autoCapitalize="none"
+        autoComplete="email"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        accessibilityLabel="password"
+        placeholder="Password (8+ chars)"
+        autoCapitalize="none"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+
+      <Pressable
+        accessibilityLabel="signup-submit"
+        onPress={onSubmit}
+        disabled={submitting}
+        style={[styles.primary, submitting && { opacity: 0.5 }]}
+      >
+        {submitting ? (
+          <ActivityIndicator color={colors.bg} />
+        ) : (
+          <Text style={styles.primaryText}>Create account</Text>
+        )}
+      </Pressable>
+
+      <Link href={`/login?next=${encodeURIComponent(next)}`} style={styles.link}>
+        <Text style={styles.linkText}>Already have an account? Sign in</Text>
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 80,
+    paddingHorizontal: space['6'],
+    backgroundColor: colors.bg,
+    gap: space['3'],
+  },
+  eyebrow: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  headline: {
+    fontSize: fontSize['2xl'],
+    fontWeight: '700',
+    color: colors.text,
+  },
+  body: {
+    fontSize: fontSize.base,
+    color: colors.textMuted,
+    marginBottom: space['3'],
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: space['3'],
+    fontSize: fontSize.base,
+    color: colors.text,
+  },
+  primary: {
+    backgroundColor: colors.bite,
+    paddingVertical: space['4'],
+    borderRadius: 12,
+    alignItems: 'center',
+    marginTop: space['3'],
+  },
+  primaryText: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.base,
+  },
+  link: {
+    marginTop: space['4'],
+    alignSelf: 'center',
+  },
+  linkText: {
+    color: colors.bite,
+    fontWeight: '600',
+    fontSize: fontSize.sm,
+  },
+});

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -1,0 +1,122 @@
+/**
+ * Phase 4.1 — mobile auth helpers.
+ *
+ * `getJwt` / `setJwt` / `clearJwt` wrap `expo-secure-store` so the
+ * JWT lives in the OS keychain (iOS) / Keystore (Android) instead of
+ * a paste-the-token URL param the way Phases 1–3 deferred it.
+ *
+ * `login` / `signup` POST to Rails directly (mobile doesn't go
+ * through a Next proxy), pull the JWT off the response's
+ * `Authorization` header, and persist it. `logout` clears the token
+ * locally and best-effort calls Rails to rotate the user's jti.
+ *
+ * The store is mocked module-level in tests so this stays jest-pure.
+ */
+import * as SecureStore from 'expo-secure-store';
+
+const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+const TOKEN_KEY = 'bw_jwt';
+
+export interface UserPayload {
+  id: string;
+  email: string;
+  handle: string | null;
+  display_name: string | null;
+}
+
+export class AuthError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+export async function getJwt(): Promise<string | null> {
+  try {
+    return (await SecureStore.getItemAsync(TOKEN_KEY)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setJwt(token: string): Promise<void> {
+  await SecureStore.setItemAsync(TOKEN_KEY, token);
+}
+
+export async function clearJwt(): Promise<void> {
+  await SecureStore.deleteItemAsync(TOKEN_KEY);
+}
+
+export interface AuthOptions {
+  fetchImpl?: typeof fetch;
+}
+
+export async function login(
+  email: string,
+  password: string,
+  opts: AuthOptions = {},
+): Promise<UserPayload> {
+  return await postCredentials('/api/v1/auth/login', email, password, opts);
+}
+
+export async function signup(
+  email: string,
+  password: string,
+  opts: AuthOptions = {},
+): Promise<UserPayload> {
+  return await postCredentials('/api/v1/auth/signup', email, password, opts);
+}
+
+export async function logout(opts: AuthOptions = {}): Promise<void> {
+  const { fetchImpl = fetch } = opts;
+  const token = await getJwt();
+  if (token) {
+    // Best-effort jti rotation — swallow errors so a disconnected
+    // user can still log out locally.
+    await fetchImpl(`${API_BASE}/api/v1/auth/logout`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    }).catch(() => {});
+  }
+  await clearJwt();
+}
+
+async function postCredentials(
+  path: string,
+  email: string,
+  password: string,
+  opts: AuthOptions,
+): Promise<UserPayload> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ user: { email, password } }),
+  });
+  if (!res.ok) {
+    let detail: string | null = null;
+    try {
+      const parsed = (await res.json()) as { error?: string };
+      detail = parsed?.error ?? null;
+    } catch {
+      // ignore
+    }
+    throw new AuthError(res.status, detail ?? `${path} failed: ${res.status}`);
+  }
+  const token = extractBearer(res.headers.get('Authorization'));
+  if (!token) {
+    throw new AuthError(502, 'Auth response missing Authorization header');
+  }
+  await setJwt(token);
+  const body = (await res.json()) as { user: UserPayload };
+  return body.user;
+}
+
+function extractBearer(header: string | null): string | null {
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1]!.trim() : null;
+}

--- a/apps/web/src/app/api/auth/[action]/route.ts
+++ b/apps/web/src/app/api/auth/[action]/route.ts
@@ -1,0 +1,116 @@
+/**
+ * Phase 4.1 — auth proxy.
+ *
+ * `POST /api/auth/{login,signup,logout}` proxies to the Rails
+ * `/api/v1/auth/{login,signup,logout}` endpoint, extracts the JWT
+ * from the upstream `Authorization` response header on success, and
+ * sets/clears the HttpOnly `bw_session` cookie. The browser never
+ * touches the JWT directly — only Rails (over the cookie-forwarded
+ * Bearer header) does.
+ *
+ * The Rails contract is unchanged: it still expects
+ * `{ user: { email, password } }` body shape on login/signup and a
+ * Bearer header on logout.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { SESSION_COOKIE } from '../../../../lib/server-auth';
+import { getServerJwt } from '../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+const ACTIONS = new Set(['login', 'signup', 'logout']);
+
+interface CredentialsBody {
+  email?: string;
+  password?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ action: string }> },
+) {
+  const { action } = await context.params;
+  if (!ACTIONS.has(action)) {
+    return NextResponse.json({ error: 'Unknown auth action' }, { status: 404 });
+  }
+
+  if (action === 'logout') {
+    return await handleLogout();
+  }
+
+  const body = (await request.json().catch(() => ({}))) as CredentialsBody;
+  return await handleLoginOrSignup(action, body);
+}
+
+async function handleLoginOrSignup(action: string, body: CredentialsBody) {
+  if (!body.email || !body.password) {
+    return NextResponse.json({ error: 'Email and password required' }, { status: 400 });
+  }
+
+  const path = action === 'login' ? '/api/v1/auth/login' : '/api/v1/auth/signup';
+  const upstream = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ user: { email: body.email, password: body.password } }),
+  });
+
+  if (!upstream.ok) {
+    const detail = await upstream.text().catch(() => '');
+    return NextResponse.json(
+      { error: `Auth failed: ${upstream.status}`, upstream: detail },
+      { status: upstream.status },
+    );
+  }
+
+  const token = extractBearer(upstream.headers.get('Authorization'));
+  if (!token) {
+    return NextResponse.json(
+      { error: 'Auth response missing Authorization header' },
+      { status: 502 },
+    );
+  }
+
+  const userPayload = await upstream.json().catch(() => ({}));
+  const response = NextResponse.json(userPayload, { status: 200 });
+  response.cookies.set({
+    name: SESSION_COOKIE,
+    value: token,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: COOKIE_MAX_AGE,
+  });
+  return response;
+}
+
+async function handleLogout() {
+  const token = await getServerJwt();
+  if (token) {
+    // Best-effort: rotate the user's jti on the API side. We
+    // continue even if this fails — the local cookie's gone either
+    // way and an attacker without it can't replay.
+    await fetch(`${API_BASE}/api/v1/auth/logout`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    }).catch(() => {});
+  }
+  const response = NextResponse.json({ ok: true }, { status: 200 });
+  response.cookies.set({
+    name: SESSION_COOKIE,
+    value: '',
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  return response;
+}
+
+function extractBearer(header: string | null): string | null {
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1]!.trim() : null;
+}

--- a/apps/web/src/app/api/ingestion_runs/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/route.ts
@@ -1,0 +1,44 @@
+/**
+ * Phase 4.1 — `POST /api/ingestion_runs` proxies multipart + JSON
+ * upload bodies to Rails with the JWT from the HttpOnly cookie.
+ * Lets the `/ingest` page kick off a run without the user pasting a
+ * Bearer token.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function POST(request: NextRequest) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+
+  const contentType = request.headers.get('Content-Type') ?? 'application/octet-stream';
+  const isMultipart = contentType.startsWith('multipart/form-data');
+
+  const headers: Record<string, string> = { Authorization: `Bearer ${jwt}` };
+  // For multipart we have to forward the original boundary verbatim,
+  // and the body has to stay a stream. JSON requests are simple text.
+  let body: BodyInit;
+  if (isMultipart) {
+    headers['Content-Type'] = contentType;
+    body = await request.arrayBuffer();
+  } else {
+    headers['Content-Type'] = 'application/json';
+    headers['Accept'] = 'application/json';
+    body = await request.text();
+  }
+
+  const upstream = await fetch(`${API_BASE}/api/v1/ingestion_runs`, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -1,0 +1,31 @@
+/**
+ * Phase 4.1 — `PATCH /api/profile` proxies to Rails with the JWT
+ * from the HttpOnly `bw_session` cookie. Lets the onboarding page
+ * call `saveProfile` without ever touching the JWT in JS.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function PATCH(request: NextRequest) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+  const body = await request.text();
+  const upstream = await fetch(`${API_BASE}/api/v1/profile`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body,
+  });
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/ingest/page.tsx
+++ b/apps/web/src/app/ingest/page.tsx
@@ -1,27 +1,30 @@
 'use client';
 
 import { useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   ingestFromFile,
   ingestFromUrl,
+  IngestionRequestError,
   type IngestionRunPayload,
 } from '../../lib/ingestion';
 
 /**
- * Phase 2.8 — admin entrypoint for AI ingestion via web.
+ * Phase 2.8 + 4.1 — admin entrypoint for AI ingestion via web.
  *
  * Two parallel ways to start a run:
  *   1. Paste a restaurant menu URL (HTML or PDF). Server-side
  *      `UrlFetcher` downloads it and attaches the body.
  *   2. Drop a PDF file. Same backend pipeline from the multipart side.
  *
- * Either way, the response carries the IngestionRun id; admin then
- * polls `/admin` (Avo) or, eventually, a follow-up web verify view
- * that mirrors the mobile swipe deck (out of scope for 2.8).
+ * Phase 4.1 dropped the JWT-paste field; auth comes from the
+ * `bw_session` cookie set by `/login`. A 401 from the proxy bounces
+ * the user to /login?next=/ingest.
  */
 export default function IngestPage() {
+  const router = useRouter();
+
   const [restaurantId, setRestaurantId] = useState('');
-  const [jwt, setJwt] = useState('');
   const [sourceUrl, setSourceUrl] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -31,8 +34,8 @@ export default function IngestPage() {
   const submit = async (mode: 'url' | 'file') => {
     setError(null);
     setResult(null);
-    if (!restaurantId || !jwt) {
-      setError('Restaurant id + JWT are required.');
+    if (!restaurantId) {
+      setError('Restaurant id is required.');
       return;
     }
     if (mode === 'url' && !sourceUrl) {
@@ -48,10 +51,14 @@ export default function IngestPage() {
       setSubmitting(true);
       const run =
         mode === 'url'
-          ? await ingestFromUrl({ restaurantId, sourceUrl, jwt })
-          : await ingestFromFile({ restaurantId, file: file!, jwt });
+          ? await ingestFromUrl({ restaurantId, sourceUrl })
+          : await ingestFromFile({ restaurantId, file: file! });
       setResult(run);
     } catch (e) {
+      if (e instanceof IngestionRequestError && e.status === 401) {
+        router.replace(`/login?next=${encodeURIComponent('/ingest')}`);
+        return;
+      }
       setError((e as Error).message);
     } finally {
       setSubmitting(false);
@@ -80,16 +87,6 @@ export default function IngestPage() {
             onChange={(e) => setRestaurantId(e.target.value)}
             className="mt-1 w-full rounded border border-zinc-300 px-3 py-2 font-mono text-sm"
             placeholder="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-          />
-        </label>
-        <label className="block">
-          <span className="text-sm font-medium text-zinc-700">JWT</span>
-          <input
-            type="password"
-            value={jwt}
-            onChange={(e) => setJwt(e.target.value)}
-            className="mt-1 w-full rounded border border-zinc-300 px-3 py-2 font-mono text-sm"
-            placeholder="paste the bearer token from /api/v1/auth/login"
           />
         </label>
       </section>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { login, AuthError } from '../../lib/auth';
+
+/**
+ * Phase 4.1 — web login page.
+ *
+ * Posts to the Next API route at `/api/auth/login` which proxies to
+ * Rails and sets the HttpOnly `bw_session` cookie. After success the
+ * user is bounced to `?next=…` (or the home page) — no JWT-paste,
+ * no token in the URL.
+ */
+export default function LoginPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const next = params.get('next') ?? '/';
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!email || !password) {
+      setError('Email and password required.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await login(email, password);
+      router.replace(next);
+    } catch (err) {
+      const status = err instanceof AuthError ? err.status : 0;
+      setError(status === 401 ? 'Wrong email or password.' : (err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-sm px-bw-6 py-bw-12">
+      <h1 className="text-bw-2xl font-bold">Sign in</h1>
+      <p className="mt-bw-2 text-bw-sm text-zinc-500">
+        Use your BiteWorthy email + password.
+      </p>
+
+      <form onSubmit={onSubmit} className="mt-bw-6 flex flex-col gap-bw-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-bw-sm font-semibold text-zinc-700">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            required
+            aria-label="email"
+            className="rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-bw-sm font-semibold text-zinc-700">Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            required
+            aria-label="password"
+            className="rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+          />
+        </label>
+
+        {error && (
+          <p className="rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          data-testid="login-submit"
+          className={[
+            'mt-bw-2 rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
+            submitting ? 'opacity-60' : 'hover:bg-bite-dark',
+          ].join(' ')}
+        >
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+
+      <p className="mt-bw-6 text-bw-sm text-zinc-500">
+        Don&rsquo;t have an account?{' '}
+        <Link href={`/signup${next !== '/' ? `?next=${encodeURIComponent(next)}` : ''}`} className="font-semibold text-bite hover:text-bite-dark">
+          Create one
+        </Link>
+      </p>
+    </main>
+  );
+}

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -15,19 +15,19 @@ import {
   searchIngredients,
   type IngredientSearchResult,
 } from '../../lib/onboarding';
-import { setJwtCookie } from '../../lib/jwt-cookie';
 
 /**
- * Phase 3.8 — web mirror of the mobile 4-step onboarding flow.
+ * Phase 3.8 + 4.1 — web mirror of the mobile 4-step onboarding flow.
  *
  *   1. Pick presets ("What can't you eat?")
  *   2. Add specific ingredients ("Anything else?")
  *   3. Set strictness ("How strict?")
- *   4. Done → PATCH /api/v1/profile, save JWT to cookie, navigate home.
+ *   4. Done → PATCH /api/profile (Next proxy reads the bw_session
+ *      cookie + forwards to Rails), navigate home.
  *
- * The reducer + payload composition come from
- * `@biteworthy/filter-engine` (Phase 3.7), so mobile + web stay
- * in lockstep.
+ * Phase 4.1 dropped the paste-the-JWT input; if the request comes
+ * back 401, the user is bounced to /login?next=/onboarding so they
+ * can sign in and resume.
  */
 type Step = 'presets' | 'ingredients' | 'strictness' | 'done';
 
@@ -48,7 +48,6 @@ export default function OnboardingPage() {
   const [loadingPresets, setLoadingPresets] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<IngredientSearchResult[]>([]);
-  const [jwt, setJwt] = useState('');
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -74,18 +73,20 @@ export default function OnboardingPage() {
 
   const finalize = async (e: FormEvent) => {
     e.preventDefault();
-    if (!jwt) {
-      setSaveError('Paste a JWT — Phase 4 will swap to a real session cookie.');
-      return;
-    }
     try {
       setSaving(true);
       setSaveError(null);
-      await saveProfile(toProfilePayload(draft, presets), jwt);
-      setJwtCookie(jwt);
+      await saveProfile(toProfilePayload(draft, presets));
       router.replace('/');
     } catch (err) {
-      setSaveError((err as Error).message);
+      const message = (err as Error).message;
+      // 401 from the proxy means the cookie expired or never existed
+      // — bounce to login and come back here to finish.
+      if (message.includes('401')) {
+        router.replace(`/login?next=${encodeURIComponent('/onboarding')}`);
+        return;
+      }
+      setSaveError(message);
     } finally {
       setSaving(false);
     }
@@ -133,8 +134,6 @@ export default function OnboardingPage() {
           presetCount={draft.selectedPresetSlugs.length}
           ingredientCount={draft.manualIngredientIds.length}
           strictness={draft.strictness}
-          jwt={jwt}
-          onJwtChange={setJwt}
           saving={saving}
           error={saveError}
           onSubmit={finalize}
@@ -372,8 +371,6 @@ function ReviewStep({
   presetCount,
   ingredientCount,
   strictness,
-  jwt,
-  onJwtChange,
   saving,
   error,
   onSubmit,
@@ -381,8 +378,6 @@ function ReviewStep({
   presetCount: number;
   ingredientCount: number;
   strictness: Strictness;
-  jwt: string;
-  onJwtChange: (j: string) => void;
   saving: boolean;
   error: string | null;
   onSubmit: (e: FormEvent) => void;
@@ -402,16 +397,6 @@ function ReviewStep({
         </span>
         , strictness <span className="font-bold">{strictness}</span>.
       </p>
-
-      <input
-        type="password"
-        value={jwt}
-        onChange={(e) => onJwtChange(e.target.value)}
-        placeholder="JWT (paste from /api/v1/auth/login)"
-        autoComplete="off"
-        aria-label="jwt"
-        className="mt-bw-4 w-full rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
-      />
 
       {error && (
         <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { signup, AuthError } from '../../lib/auth';
+
+/**
+ * Phase 4.1 — web signup page. Posts to `/api/auth/signup` (Next
+ * proxy → Rails) and gets the user signed in via the same HttpOnly
+ * cookie path as login.
+ */
+export default function SignupPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const next = params.get('next') ?? '/onboarding';
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!email || !password) {
+      setError('Email and password required.');
+      return;
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await signup(email, password);
+      router.replace(next);
+    } catch (err) {
+      const status = err instanceof AuthError ? err.status : 0;
+      setError(status === 422 ? 'That email is already in use.' : (err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-sm px-bw-6 py-bw-12">
+      <h1 className="text-bw-2xl font-bold">Create account</h1>
+      <p className="mt-bw-2 text-bw-sm text-zinc-500">
+        Free. Stores your dietary filter so it&rsquo;s ready next time.
+      </p>
+
+      <form onSubmit={onSubmit} className="mt-bw-6 flex flex-col gap-bw-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-bw-sm font-semibold text-zinc-700">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            required
+            aria-label="email"
+            className="rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-bw-sm font-semibold text-zinc-700">Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            required
+            minLength={8}
+            aria-label="password"
+            className="rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+          />
+          <span className="text-bw-xs text-zinc-500">8+ characters.</span>
+        </label>
+
+        {error && (
+          <p className="rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          data-testid="signup-submit"
+          className={[
+            'mt-bw-2 rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
+            submitting ? 'opacity-60' : 'hover:bg-bite-dark',
+          ].join(' ')}
+        >
+          {submitting ? 'Creating…' : 'Create account'}
+        </button>
+      </form>
+
+      <p className="mt-bw-6 text-bw-sm text-zinc-500">
+        Already have an account?{' '}
+        <Link href={`/login${next !== '/onboarding' ? `?next=${encodeURIComponent(next)}` : ''}`} className="font-semibold text-bite hover:text-bite-dark">
+          Sign in
+        </Link>
+      </p>
+    </main>
+  );
+}

--- a/apps/web/src/lib/__tests__/auth.test.ts
+++ b/apps/web/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthError, login, logout, signup } from '../auth';
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'ERR',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+describe('login', () => {
+  it('POSTs to /api/auth/login with credentials + JSON body', async () => {
+    const fetchImpl = fakeFetch(200, { user: { id: 'u1', email: 'a@b.com', handle: null, display_name: null } });
+    const result = await login('a@b.com', 'sekret123', { fetchImpl });
+    expect(result.user.email).toBe('a@b.com');
+
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/auth/login');
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('same-origin');
+    expect(JSON.parse(init.body as string)).toEqual({ email: 'a@b.com', password: 'sekret123' });
+  });
+
+  it('throws AuthError carrying status on bad credentials', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'Auth failed: 401' });
+    await expect(login('a@b.com', 'wrong', { fetchImpl })).rejects.toMatchObject({
+      name: 'AuthError',
+      status: 401,
+    });
+  });
+});
+
+describe('signup', () => {
+  it('POSTs to /api/auth/signup', async () => {
+    const fetchImpl = fakeFetch(200, { user: { id: 'u2', email: 'b@c.com', handle: null, display_name: null } });
+    await signup('b@c.com', 'longerpw1', { fetchImpl });
+    expect(String(fetchImpl.mock.calls[0]![0])).toBe('/api/auth/signup');
+  });
+
+  it('throws AuthError on duplicate email', async () => {
+    const fetchImpl = fakeFetch(422, { error: 'taken' });
+    await expect(signup('b@c.com', 'longerpw1', { fetchImpl })).rejects.toBeInstanceOf(AuthError);
+  });
+});
+
+describe('logout', () => {
+  it('POSTs to /api/auth/logout with credentials and no body', async () => {
+    const fetchImpl = fakeFetch(200, { ok: true });
+    await logout({ fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/auth/logout');
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('same-origin');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('throws AuthError on non-2xx', async () => {
+    const fetchImpl = fakeFetch(500, { error: 'logout failed' });
+    await expect(logout({ fetchImpl })).rejects.toBeInstanceOf(AuthError);
+  });
+});

--- a/apps/web/src/lib/__tests__/ingestion.test.ts
+++ b/apps/web/src/lib/__tests__/ingestion.test.ts
@@ -32,25 +32,25 @@ function fakeFetch(status: number, body: unknown) {
 }
 
 describe('ingestFromUrl', () => {
-  it('POSTs JSON body with restaurant_id + source_url and returns the run', async () => {
+  it('POSTs to the Next proxy at /api/ingestion_runs with credentials', async () => {
     const fetchImpl = fakeFetch(201, sampleRun);
 
     const result = await ingestFromUrl({
       restaurantId: 'rest-1',
       sourceUrl: 'https://restaurant.example/menu',
-      jwt: 'jwt-x',
       fetchImpl,
     });
 
     expect(result.id).toBe(sampleRun.id);
     const calls = fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>;
     const [url, init] = calls[0]!;
-    expect(url).toContain('/api/v1/ingestion_runs');
+    expect(url).toBe('/api/ingestion_runs');
     expect(init.method).toBe('POST');
-    expect(init.headers).toMatchObject({
-      Authorization: 'Bearer jwt-x',
-      'Content-Type': 'application/json',
-    });
+    expect(init.credentials).toBe('same-origin');
+    // No Authorization header from the client — the Next proxy adds
+    // it from the bw_session cookie.
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
     expect(JSON.parse(init.body as string)).toEqual({
       restaurant_id: 'rest-1',
       source_url: 'https://restaurant.example/menu',
@@ -64,7 +64,6 @@ describe('ingestFromUrl', () => {
       ingestFromUrl({
         restaurantId: 'rest-1',
         sourceUrl: 'https://broken.example/menu',
-        jwt: 'jwt-x',
         fetchImpl,
       }),
     ).rejects.toMatchObject({
@@ -75,14 +74,13 @@ describe('ingestFromUrl', () => {
 });
 
 describe('ingestFromFile', () => {
-  it('POSTs multipart with the file under inputs[]', async () => {
+  it('POSTs multipart with the file under inputs[] and no client-side auth header', async () => {
     const fetchImpl = fakeFetch(201, { ...sampleRun, input_kind: 'pdf' });
     const file = new File(['%PDF-1.4'], 'menu.pdf', { type: 'application/pdf' });
 
     const result = await ingestFromFile({
       restaurantId: 'rest-1',
       file,
-      jwt: 'jwt-x',
       fetchImpl,
     });
 
@@ -90,8 +88,9 @@ describe('ingestFromFile', () => {
     const calls = fetchImpl.mock.calls as unknown as Array<[string, RequestInit]>;
     const [, init] = calls[0]!;
     expect(init.method).toBe('POST');
-    expect(init.headers).toMatchObject({ Authorization: 'Bearer jwt-x' });
-    // No Content-Type — let fetch set the multipart boundary itself.
+    expect(init.credentials).toBe('same-origin');
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    // No Content-Type either — let fetch set the multipart boundary itself.
     expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
     expect(init.body).toBeInstanceOf(FormData);
   });
@@ -112,7 +111,6 @@ describe('ingestFromFile', () => {
       ingestFromFile({
         restaurantId: 'rest-1',
         file,
-        jwt: 'jwt-x',
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
     ).rejects.toBeInstanceOf(IngestionRequestError);

--- a/apps/web/src/lib/__tests__/onboarding.test.ts
+++ b/apps/web/src/lib/__tests__/onboarding.test.ts
@@ -78,17 +78,21 @@ describe('saveProfile', () => {
     strictness: 'balanced',
   };
 
-  it('PATCHes /api/v1/profile with the payload + Bearer auth', async () => {
+  it('PATCHes the Next proxy at /api/profile with credentials (no client-side JWT)', async () => {
     const fetchImpl = fakeFetch(200, {});
-    await saveProfile(payload, 'jjj.www.ttt', { fetchImpl });
+    await saveProfile(payload, { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
     const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/profile');
     expect(init.method).toBe('PATCH');
-    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jjj.www.ttt');
+    expect(init.credentials).toBe('same-origin');
+    // The Next proxy injects the Authorization header from the cookie.
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
     expect(JSON.parse(init.body as string)).toEqual(payload);
   });
 
-  it('throws on non-2xx', async () => {
-    const fetchImpl = fakeFetch(422, { error: 'invalid' });
-    await expect(saveProfile(payload, 'jwt', { fetchImpl })).rejects.toThrow(/422/);
+  it('throws on non-2xx so the screen can route a 401 to /login', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'Not signed in' });
+    await expect(saveProfile(payload, { fetchImpl })).rejects.toThrow(/401/);
   });
 });

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,89 @@
+/**
+ * Phase 4.1 — web auth helpers.
+ *
+ * Login/signup go through the Next API routes at `/api/auth/*` which
+ * proxy to Rails (`/api/v1/auth/*`), then set the JWT into a server-
+ * managed `bw_session` HttpOnly cookie. Subsequent fetches read the
+ * cookie back via the server helpers below and forward as a Bearer
+ * header to Rails — Rails-side auth contract is unchanged.
+ *
+ * The legacy `bw_jwt` JS-readable cookie from Phase 3.8 stays around
+ * for the dev shortcut + for non-auth flows that need a token in the
+ * URL (claim, password reset). Production reads `bw_session`.
+ */
+'use client';
+
+export interface UserPayload {
+  id: string;
+  email: string;
+  handle: string | null;
+  display_name: string | null;
+}
+
+export interface AuthResponse {
+  user: UserPayload;
+}
+
+export class AuthError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+interface FetchOptions {
+  fetchImpl?: typeof fetch;
+}
+
+async function authPost<T>(
+  path: string,
+  body: unknown,
+  opts: FetchOptions = {},
+): Promise<T> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let detail: string | null = null;
+    try {
+      const parsed = (await res.json()) as { error?: string };
+      detail = parsed?.error ?? null;
+    } catch {
+      // ignore
+    }
+    throw new AuthError(res.status, detail ?? `${path} failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function login(
+  email: string,
+  password: string,
+  opts: FetchOptions = {},
+): Promise<AuthResponse> {
+  return authPost<AuthResponse>('/api/auth/login', { email, password }, opts);
+}
+
+export function signup(
+  email: string,
+  password: string,
+  opts: FetchOptions = {},
+): Promise<AuthResponse> {
+  return authPost<AuthResponse>('/api/auth/signup', { email, password }, opts);
+}
+
+export async function logout(opts: FetchOptions = {}): Promise<void> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/auth/logout', {
+    method: 'POST',
+    credentials: 'same-origin',
+  });
+  if (!res.ok) throw new AuthError(res.status, 'logout failed');
+}

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -1,9 +1,10 @@
 /**
- * Phase 2.8 — web client for `POST /api/v1/ingestion_runs`.
- * Supports both source-URL and file-upload (PDF) modes.
+ * Phase 2.8 + 4.1 — web client for ingestion runs.
+ *
+ * Posts to the Next proxy at `/api/ingestion_runs` (which reads the
+ * `bw_session` cookie and forwards to Rails as a Bearer header), so
+ * the browser never needs to know the JWT.
  */
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
 
 export interface IngestionRunPayload {
   id: string;
@@ -38,16 +39,16 @@ export class IngestionRequestError extends Error {
 
 async function postIngestionRun(
   body: BodyInit,
-  jwt: string,
   fetchImpl: typeof fetch,
   isMultipart: boolean,
 ): Promise<IngestionRunPayload> {
-  const headers: Record<string, string> = { Authorization: `Bearer ${jwt}` };
+  const headers: Record<string, string> = {};
   if (!isMultipart) headers['Content-Type'] = 'application/json';
 
-  const res = await fetchImpl(`${API_BASE}/api/v1/ingestion_runs`, {
+  const res = await fetchImpl('/api/ingestion_runs', {
     method: 'POST',
     headers,
+    credentials: 'same-origin',
     body,
   });
   if (!res.ok) {
@@ -65,13 +66,11 @@ async function postIngestionRun(
 export async function ingestFromUrl(opts: {
   restaurantId: string;
   sourceUrl: string;
-  jwt: string;
   fetchImpl?: typeof fetch;
 }): Promise<IngestionRunPayload> {
-  const { restaurantId, sourceUrl, jwt, fetchImpl = fetch } = opts;
+  const { restaurantId, sourceUrl, fetchImpl = fetch } = opts;
   return postIngestionRun(
     JSON.stringify({ restaurant_id: restaurantId, source_url: sourceUrl }),
-    jwt,
     fetchImpl,
     false,
   );
@@ -80,12 +79,11 @@ export async function ingestFromUrl(opts: {
 export async function ingestFromFile(opts: {
   restaurantId: string;
   file: File;
-  jwt: string;
   fetchImpl?: typeof fetch;
 }): Promise<IngestionRunPayload> {
-  const { restaurantId, file, jwt, fetchImpl = fetch } = opts;
+  const { restaurantId, file, fetchImpl = fetch } = opts;
   const form = new FormData();
   form.append('restaurant_id', restaurantId);
   form.append('inputs[]', file, file.name);
-  return postIngestionRun(form, jwt, fetchImpl, true);
+  return postIngestionRun(form, fetchImpl, true);
 }

--- a/apps/web/src/lib/onboarding.ts
+++ b/apps/web/src/lib/onboarding.ts
@@ -45,22 +45,32 @@ export async function searchIngredients(
 }
 
 /**
- * PATCH /api/v1/profile (Phase 1.3) with the assembled draft. The
- * endpoint replaces the whole avoid list — the reducer's
- * `toProfilePayload` returns the wholesale-replacement payload.
+ * PATCH /api/profile via the Next API route at
+ * `apps/web/src/app/api/profile/route.ts`. The proxy reads the
+ * HttpOnly `bw_session` cookie and forwards to Rails as a Bearer
+ * header — the client never sees the JWT (Phase 4.1).
+ *
+ * Throws on non-2xx; 401 means the session expired and the caller
+ * should redirect to `/login`.
  */
 export async function saveProfile(
   payload: SaveProfilePayload,
-  jwt: string,
-  opts: ApiOptions = {},
+  opts: { fetchImpl?: typeof fetch } = {},
 ): Promise<void> {
-  await api<unknown>('/profile', {
-    ...opts,
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/profile', {
     method: 'PATCH',
-    headers: {
-      Authorization: `Bearer ${jwt}`,
-      ...(opts.headers ?? {}),
-    },
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify(payload),
   });
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new Error(`saveProfile failed: ${res.status} ${JSON.stringify(body)}`);
+  }
 }

--- a/apps/web/src/lib/server-auth.ts
+++ b/apps/web/src/lib/server-auth.ts
@@ -1,0 +1,23 @@
+/**
+ * Phase 4.1 — server-side helpers for reading the auth cookie in
+ * Next route handlers + SSR pages.
+ *
+ * `getServerJwt()` reads the HttpOnly `bw_session` cookie set by the
+ * `/api/auth/*` routes. Pass the returned token straight into
+ * `fetchRestaurantItems({ jwt })` etc. and the Rails endpoint applies
+ * `current_user.profile` automatically (Phase 1.7 contract).
+ *
+ * The cookie name is centralized here so callers don't have to spell
+ * it (and the dev shortcut + legacy `bw_jwt` reader stays in
+ * `jwt-cookie.ts` for the client-side path).
+ */
+import { cookies } from 'next/headers';
+
+export const SESSION_COOKIE = 'bw_session';
+
+/** Async because next/headers' `cookies()` is a thenable in Next 15. */
+export async function getServerJwt(): Promise<string | null> {
+  const jar = await cookies();
+  const value = jar.get(SESSION_COOKIE)?.value;
+  return value && value.length > 0 ? value : null;
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,9 +11,9 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
-**Phase 4** ⭐ Reviews + accounts. Subplan: `docs/plans/phase-4.md`. **Loop-proposed batch** (this PR is the plan-update PR); humans review before items auto-run.
+**Phase 4** ⭐ Reviews + accounts. Subplan: `docs/plans/phase-4.md`.
 
-1. **Phase 4.1 — Real session cookies (retire JWT-pasting)** (`docs/plans/phase-4.md#41`) — this PR is the plan
+1. **Phase 4.1 — Real session cookies (retire JWT-pasting)** (`docs/plans/phase-4.md#41`) — this PR
 2. **Phase 4.2 — Persistent "never hide this dish" override** (`docs/plans/phase-4.md#42`)
 3. **Phase 4.3 — Review API + photo attachment** (`docs/plans/phase-4.md#43`)
 4. **Phase 4.4 — Mobile review UX** (`docs/plans/phase-4.md#44`)
@@ -54,6 +54,7 @@ the merge / review / status rules.
 - ✅ Phase 3.7 — applyProfile + display helpers consolidated in filter-engine (#152)
 - ✅ Phase 3.8 — web profile onboarding (#153)
 - ✅ Phase 3.9 — shareable filter URLs (#154) — **Phase 3 feature-complete**
+- ✅ Phase 4 — subplan committed (#155)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,35 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 09:00 — tick #61. PR #155 (Phase 4 plan) merged at 08:47 UTC.
+**Major user unblocks during this tick**: ANTHROPIC_API_KEY now in
+GitHub Actions secrets + local .env, and bite-worthy.com domain
+purchased. Documented as a punch-list response; user requested
+continuing the planned flow. Picked up Phase 4.1 — retire the
+JWT-paste workaround Phases 1–3 deferred. Web side: new
+`apps/web/src/lib/auth.ts` (login/signup/logout client helpers
+posting to Next API routes) + `apps/web/src/lib/server-auth.ts`
+(`getServerJwt` for SSR cookie reads). Three new Next API routes:
+`api/auth/[action]` proxies to Rails + sets HttpOnly bw_session
+cookie; `api/profile` PATCH proxies with the cookie's JWT;
+`api/ingestion_runs` POST proxies multipart + JSON. New
+/login + /signup pages with `?next=…` redirect. Updated /onboarding
++ /ingest to drop JWT input fields; 401s bounce to /login. Mobile
+side: `apps/mobile/lib/auth.ts` wrapping expo-secure-store
+(getJwt/setJwt/clearJwt + login/signup/logout that pull JWT off
+Authorization response header). New /login + /signup screens.
+Updated /onboarding + /ingest + /ingest/verify + /restaurants/[id]
+to read JWT from keychain instead of paste/query-param. Tests:
+9 new vitest cases for auth.ts, 11 new jest cases for the mobile
+auth wrapper (round-trip, error fallback, header extraction,
+best-effort logout). Existing ingestion + onboarding tests
+updated to assert the new proxy URL + no client-side Authorization
+header. Two flaky admin specs (admin_spec, dashboard_spec) that
+broke when the user's .env set a non-default ADMIN_PASSWORD —
+fixed with `around` hooks that pin the env vars during the spec
+and restore on teardown. Local: rspec 199/0/1 pending; web vitest
+27/27; mobile jest 35/35; pnpm typecheck/lint cached green.
+
 2026-05-01 08:30 — tick #60. PR #154 (Phase 3.9) merged at 08:38 UTC.
 **Phase 3 feature-complete** (3.1–3.9 all merged: seeds → mobile
 onboarding → mobile restaurant page → transparency chips →


### PR DESCRIPTION
## Summary

Phase 4.1 retires the JWT-paste workaround Phases 1–3 deferred. Web users sign in to a server-managed `bw_session` HttpOnly cookie; mobile users sign in to the device keychain via `expo-secure-store`. The Rails API contract is unchanged — JWTs still flow on the wire as Bearer headers; the storage layer just stops being the user's clipboard. Subplan: `docs/plans/phase-4.md#41`.

### Web
- **`apps/web/src/app/api/auth/[action]/route.ts`** — login/signup proxy to Rails and set `bw_session` HttpOnly cookie; logout best-effort calls Rails to rotate the user's `jti` and clears the cookie.
- **`apps/web/src/app/api/profile/route.ts`** — PATCH proxy that injects the cookie's JWT as a Bearer header.
- **`apps/web/src/app/api/ingestion_runs/route.ts`** — POST proxy that forwards multipart + JSON with the cookie's JWT.
- **`apps/web/src/lib/auth.ts`** — client helpers (`login`, `signup`, `logout`, `AuthError`).
- **`apps/web/src/lib/server-auth.ts`** — `getServerJwt()` for SSR pages + route handlers.
- **`/login` and `/signup`** pages with `?next=…` redirect.
- **`/onboarding` and `/ingest`** dropped their JWT input fields; 401 from any proxy bounces to `/login?next=…`.

### Mobile
- **`apps/mobile/lib/auth.ts`** wraps `expo-secure-store` with `getJwt` / `setJwt` / `clearJwt` plus `login` / `signup` / `logout` (pulls JWT from the response `Authorization` header).
- **`/login` and `/signup`** screens with `?next=…` redirect.
- **`/onboarding`, `/ingest`, `/ingest/verify`, `/restaurants/[id]`** read the JWT from the keychain instead of paste/query-param. 401s bounce to `/login`.

### Drive-by fix
Two flaky admin specs (`admin_spec.rb`, `admin/dashboard_spec.rb`) broke when `dotenv-rails` started loading the new local `.env` in the test env, leaking a non-default `ADMIN_PASSWORD`. Added `around` hooks pinning `ADMIN_USERNAME`/`PASSWORD` to `admin`/`admin` for the duration of those specs and restoring on teardown.

## Out of scope
- Devise's `:rememberable` (the subplan mentions it for 30-day cookies). The cookie's already 30-day via the Next API route's `Max-Age=2592000`; adding `:rememberable` would only matter if Rails was serving the cookie itself. Defer until/unless we move cookie management server-side.
- iOS Apple-Sign-In + Google-Sign-In integration with the new keychain layer (the existing `/api/v1/auth/:provider` OmniAuth path still works; mobile gains a "Sign in with Apple" button later).
- Forgot-password / email confirmation UI (Phase 4.X — needs SMTP, see subplan stop conditions).

## Test plan
- [x] **Web vitest** 27/27 (9 new for `auth.ts`).
- [x] **Mobile jest** 35/35 (11 new for the secure-store wrapper).
- [x] **Rspec** 199/0/1 pending — fixed two admin specs that broke on the user's new `.env`.
- [x] `pnpm typecheck` / `pnpm lint` cached green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)