### PR TITLE
feat(api,web,mobile): persistent never-hide override (phase 4.2)

### DIFF
--- a/apps/api/app/controllers/api/v1/item_overrides_controller.rb
+++ b/apps/api/app/controllers/api/v1/item_overrides_controller.rb
@@ -1,0 +1,35 @@
+module Api
+  module V1
+    # Phase 4.2 — POST /api/v1/items/:id/never_hide marks an item as
+    # "always shown for me" for the authenticated user. DELETE removes
+    # the override. Both are idempotent.
+    #
+    # `current_user.profile` still drives the default filter; this just
+    # opts out of the hide step for one specific item.
+    class ItemOverridesController < BaseController
+      before_action :load_item
+
+      def create
+        UserItemOverride.find_or_create_by!(user: current_user, item: @item) do |o|
+          o.never_hide = true
+        end
+        render json: serialize_override(true), status: :ok
+      end
+
+      def destroy
+        UserItemOverride.where(user: current_user, item: @item).destroy_all
+        render json: serialize_override(false), status: :ok
+      end
+
+      private
+
+      def load_item
+        @item = Item.published.find(params[:id])
+      end
+
+      def serialize_override(active)
+        { item_id: @item.id, overridden_by_user: active }
+      end
+    end
+  end
+end

--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -29,9 +29,10 @@ module Api
                                .order(popularity: :desc, name: :asc)
                                .to_a
 
-        filter = build_filter
-        labels = build_label_lookup(items, filter)
-        rendered = items.map { |item| serialize_item(item, filter, labels) }
+        filter   = build_filter
+        labels   = build_label_lookup(items, filter)
+        override_ids = current_user_override_item_ids(items)
+        rendered = items.map { |item| serialize_item(item, filter, labels, override_ids) }
 
         render json: {
           restaurant_id: restaurant.id,
@@ -43,7 +44,7 @@ module Api
       def show
         item = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id]).items.published.find(params[:id])
         filter = build_filter
-        render json: serialize_item(item, filter, build_label_lookup([item], filter))
+        render json: serialize_item(item, filter, build_label_lookup([item], filter), current_user_override_item_ids([item]))
       end
 
       private
@@ -152,23 +153,37 @@ module Api
 
       # Try to keep this stable — mobile + web bind to these keys via
       # generated TS types; Phase 1.6's openapi.json should match.
-      def serialize_item(item, filter, labels)
+      def serialize_item(item, filter, labels, override_ids = Set.new)
         reasons = hide_reasons(item, filter, labels)
         section = item.menu_section
         {
-          id:                 item.id,
-          restaurant_id:      item.restaurant_id,
-          name:               item.name,
-          description:        item.description,
-          confidence:         item.confidence,
-          popularity:         item.popularity,
-          ingredient_ids:     item.ingredient_ids,
-          tag_ids:            item.tag_ids,
-          menu_section_id:    section&.id,
-          menu_section_name:  section&.name,
-          status:             reasons.empty? ? "visible" : "hidden",
-          reasons:            reasons
+          id:                  item.id,
+          restaurant_id:       item.restaurant_id,
+          name:                item.name,
+          description:         item.description,
+          confidence:          item.confidence,
+          popularity:          item.popularity,
+          ingredient_ids:      item.ingredient_ids,
+          tag_ids:             item.tag_ids,
+          menu_section_id:     section&.id,
+          menu_section_name:   section&.name,
+          status:              reasons.empty? ? "visible" : "hidden",
+          reasons:             reasons,
+          overridden_by_user:  override_ids.include?(item.id)
         }
+      end
+
+      # Phase 4.2 — bulk-load the authenticated user's "never hide"
+      # overrides for the items in this response. Returns an empty
+      # Set when anonymous so the boolean stays accurate (anonymous
+      # callers always see `overridden_by_user: false`).
+      def current_user_override_item_ids(items)
+        return Set.new unless current_user
+        ids = items.map(&:id)
+        return Set.new if ids.empty?
+        Set.new(
+          UserItemOverride.where(user_id: current_user.id, item_id: ids, never_hide: true).pluck(:item_id)
+        )
       end
 
       def filter_summary(filter)

--- a/apps/api/app/models/item.rb
+++ b/apps/api/app/models/item.rb
@@ -13,6 +13,7 @@ class Item < ApplicationRecord
   has_many :item_tags,        dependent: :destroy
   has_many :tags,        through: :item_tags
   has_many :reviews,          dependent: :destroy
+  has_many :user_item_overrides, dependent: :destroy
 
   validates :name, presence: true
   validates :status,     inclusion: { in: STATUSES }

--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
   has_one  :profile, class_name: "UserProfile", dependent: :destroy
   has_many :reviews, dependent: :destroy
   has_many :suggestions, dependent: :nullify
+  has_many :user_item_overrides, dependent: :destroy
+  has_many :overridden_items, through: :user_item_overrides, source: :item
 
   validates :handle, presence: true, uniqueness: true,
                      format: { with: /\A[a-z0-9_]{3,30}\z/i }

--- a/apps/api/app/models/user_item_override.rb
+++ b/apps/api/app/models/user_item_override.rb
@@ -1,0 +1,14 @@
+class UserItemOverride < ApplicationRecord
+  # Phase 4.2 — persistent "show anyway" / "never hide this dish"
+  # override. Survives logout/login (session-only equivalent lives
+  # in the React Native + Next clients per Phase 3.4).
+  #
+  # `never_hide: true` is currently the only mode. The column is here
+  # rather than encoded as presence-of-row so future modes can land
+  # without a migration.
+
+  belongs_to :user
+  belongs_to :item
+
+  validates :user_id, uniqueness: { scope: :item_id }
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -58,6 +58,12 @@ Rails.application.routes.draw do
       resources :ingredients, only: [:index]
       resources :tags, only: [:index]
       resources :dietary_profiles, only: [:index]
+      resources :items, only: [] do
+        member do
+          post   :never_hide, to: "item_overrides#create"
+          delete :never_hide, to: "item_overrides#destroy"
+        end
+      end
       resources :ingestion_runs, only: [:create, :show] do
         resources :items, only: [:index, :update], controller: "ingestion_items"
       end

--- a/apps/api/db/migrate/20260430095252_create_user_item_overrides.rb
+++ b/apps/api/db/migrate/20260430095252_create_user_item_overrides.rb
@@ -1,0 +1,18 @@
+class CreateUserItemOverrides < ActiveRecord::Migration[8.1]
+  # Phase 4.2 — persistent "never hide this dish" overrides. Phase 3.4
+  # shipped the session-only equivalent; this table makes it durable
+  # so the override survives a logout/login cycle.
+  #
+  # `never_hide` is currently the only mode but lives as a column
+  # (not a presence-of-row flag) so a future "always_show_strict" or
+  # "always_hide_anyway" mode can land without a migration.
+  def change
+    create_table :user_item_overrides, id: :uuid do |t|
+      t.references :user, type: :uuid, null: false, foreign_key: true
+      t.references :item, type: :uuid, null: false, foreign_key: true
+      t.boolean    :never_hide, null: false, default: true
+      t.timestamps
+    end
+    add_index :user_item_overrides, [:user_id, :item_id], unique: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_231545) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_095252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -322,6 +322,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_231545) do
     t.index ["slug"], name: "index_tags_on_slug", unique: true
   end
 
+  create_table "user_item_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "item_id", null: false
+    t.boolean "never_hide", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["item_id"], name: "index_user_item_overrides_on_item_id"
+    t.index ["user_id", "item_id"], name: "index_user_item_overrides_on_user_id_and_item_id", unique: true
+    t.index ["user_id"], name: "index_user_item_overrides_on_user_id"
+  end
+
   create_table "user_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "avoid_ingredient_ids", default: [], null: false, array: true
     t.uuid "avoid_tag_ids", default: [], null: false, array: true
@@ -398,6 +409,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_231545) do
   add_foreign_key "reviews", "users"
   add_foreign_key "suggestions", "users"
   add_foreign_key "suggestions", "users", column: "resolved_by_user_id"
+  add_foreign_key "user_item_overrides", "items"
+  add_foreign_key "user_item_overrides", "users"
   add_foreign_key "user_profiles", "dietary_profiles", column: "primary_dietary_profile_id"
   add_foreign_key "user_profiles", "users"
 end

--- a/apps/api/spec/factories/user_item_overrides.rb
+++ b/apps/api/spec/factories/user_item_overrides.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user_item_override do
+    user
+    item
+    never_hide { true }
+  end
+end

--- a/apps/api/spec/models/user_item_override_spec.rb
+++ b/apps/api/spec/models/user_item_override_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe UserItemOverride, type: :model do
+  let(:user)       { create(:user) }
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:item)       { create(:item, :published, restaurant: restaurant) }
+
+  it "persists with sensible defaults" do
+    override = described_class.create!(user: user, item: item)
+    expect(override.never_hide).to be(true)
+  end
+
+  it "enforces uniqueness on (user_id, item_id)" do
+    described_class.create!(user: user, item: item)
+    duplicate = described_class.new(user: user, item: item)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:user_id]).to be_present
+  end
+
+  it "does not collide across users for the same item" do
+    described_class.create!(user: user, item: item)
+    other_user = create(:user)
+    expect {
+      described_class.create!(user: other_user, item: item)
+    }.not_to raise_error
+  end
+
+  it "exposes the through-association on User" do
+    described_class.create!(user: user, item: item)
+    expect(user.overridden_items).to include(item)
+  end
+
+  it "tears down with the user" do
+    described_class.create!(user: user, item: item)
+    expect { user.destroy }.to change(described_class, :count).by(-1)
+  end
+end

--- a/apps/api/spec/requests/api/v1/item_overrides_spec.rb
+++ b/apps/api/spec/requests/api/v1/item_overrides_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "POST/DELETE /api/v1/items/:id/never_hide", type: :request do
+  let(:user)       { create(:user) }
+  let(:headers)    { auth_headers_for(user) }
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:item)       { create(:item, :published, restaurant: restaurant) }
+
+  describe "POST" do
+    it "creates a never_hide override and echoes the new state" do
+      expect {
+        post "/api/v1/items/#{item.id}/never_hide", headers: headers
+      }.to change(UserItemOverride, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "item_id"             => item.id,
+        "overridden_by_user"  => true
+      )
+    end
+
+    it "is idempotent (repeat calls don't dup rows)" do
+      post "/api/v1/items/#{item.id}/never_hide", headers: headers
+      expect {
+        post "/api/v1/items/#{item.id}/never_hide", headers: headers
+      }.not_to change(UserItemOverride, :count)
+    end
+
+    it "401s anonymously" do
+      post "/api/v1/items/#{item.id}/never_hide"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "404s for an unpublished item (no leaking draft ids)" do
+      draft_item = create(:item, restaurant: restaurant) # default :draft
+      post "/api/v1/items/#{draft_item.id}/never_hide", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE" do
+    before { create(:user_item_override, user: user, item: item) }
+
+    it "removes the override and echoes the new state" do
+      expect {
+        delete "/api/v1/items/#{item.id}/never_hide", headers: headers
+      }.to change(UserItemOverride, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "item_id"             => item.id,
+        "overridden_by_user"  => false
+      )
+    end
+
+    it "is idempotent (deleting an absent override returns ok)" do
+      delete "/api/v1/items/#{item.id}/never_hide", headers: headers # first call
+      expect {
+        delete "/api/v1/items/#{item.id}/never_hide", headers: headers
+      }.not_to change(UserItemOverride, :count)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
@@ -162,6 +162,25 @@ RSpec.describe "GET /api/v1/restaurants/:id/items", type: :request do
       expect(items["Salmon Bowl"]["status"]).to eq("hidden")
       expect(body["filter"]["source"]).to        eq("user_profile")
     end
+
+    it "surfaces overridden_by_user=true for items the user marked never-hide (Phase 4.2)" do
+      create(:user_item_override, user: user, item: cheese_quesadilla)
+
+      get "/api/v1/restaurants/#{restaurant.id}/items", headers: headers
+
+      items = response.parsed_body["items"].index_by { |i| i["name"] }
+      expect(items["Cheese Quesadilla"]["overridden_by_user"]).to be(true)
+      expect(items["Carne Asada Taco"]["overridden_by_user"]).to be(false)
+    end
+
+    it "always returns overridden_by_user=false anonymously" do
+      create(:user_item_override, user: user, item: cheese_quesadilla)
+
+      get "/api/v1/restaurants/#{restaurant.id}/items"
+
+      items = response.parsed_body["items"].index_by { |i| i["name"] }
+      expect(items["Cheese Quesadilla"]["overridden_by_user"]).to be(false)
+    end
   end
 
   describe "menu section payload (Phase 3.3)" do

--- a/apps/mobile/__tests__/lib/restaurants.test.ts
+++ b/apps/mobile/__tests__/lib/restaurants.test.ts
@@ -1,8 +1,10 @@
 import {
+  clearNeverHide,
   fetchRestaurant,
   fetchRestaurantItems,
   groupItemsBySection,
   RestaurantFetchError,
+  setNeverHide,
   type Restaurant,
   type RestaurantItem,
   type RestaurantItemsResponse,
@@ -169,5 +171,40 @@ describe('groupItemsBySection', () => {
 
   it('returns an empty array for no items', () => {
     expect(groupItemsBySection([])).toEqual([]);
+  });
+});
+
+describe('setNeverHide / clearNeverHide (Phase 4.2)', () => {
+  it('POSTs with Bearer JWT and returns the new state', async () => {
+    const fetchImpl = fakeFetch(200, { item_id: 'item-1', overridden_by_user: true });
+    const result = await setNeverHide('item-1', 'jjj.www.ttt', { fetchImpl });
+    expect(result.overridden_by_user).toBe(true);
+
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toContain('/api/v1/items/item-1/never_hide');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jjj.www.ttt');
+  });
+
+  it('DELETE clears the override', async () => {
+    const fetchImpl = fakeFetch(200, { item_id: 'item-1', overridden_by_user: false });
+    const result = await clearNeverHide('item-1', 'jwt', { fetchImpl });
+    expect(result.overridden_by_user).toBe(false);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('encodes item ids that contain reserved URL chars', async () => {
+    const fetchImpl = fakeFetch(200, { item_id: 'a/b', overridden_by_user: true });
+    await setNeverHide('a/b', 'jwt', { fetchImpl });
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain('/items/a%2Fb/never_hide');
+  });
+
+  it('throws RestaurantFetchError on non-2xx', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'unauth' });
+    await expect(setNeverHide('item-1', 'bad', { fetchImpl })).rejects.toBeInstanceOf(
+      RestaurantFetchError,
+    );
   });
 });

--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -20,8 +20,10 @@ import {
 import { buildShareUrl } from '../../lib/share-url';
 import { getJwt } from '../../lib/auth';
 import {
+  clearNeverHide,
   fetchRestaurant,
   fetchRestaurantItems,
+  setNeverHide,
   type FilterSummary,
   type Restaurant,
   type RestaurantItem,
@@ -130,6 +132,31 @@ export default function RestaurantScreen() {
     });
   };
 
+  // Phase 4.2 — flip an item's persistent override server-side and
+  // patch local state so the chip updates without a full refetch.
+  // No-op without a JWT — the screen falls back to session overrides.
+  const setPersistentOverride = async (itemId: string, next: boolean) => {
+    if (!jwt) return;
+    try {
+      if (next) await setNeverHide(itemId, jwt);
+      else await clearNeverHide(itemId, jwt);
+    } catch (e) {
+      setError((e as Error).message);
+      return;
+    }
+    setSections((prev) =>
+      prev.map((section) => ({
+        ...section,
+        visible: section.visible.map((it) =>
+          it.id === itemId ? { ...it, overridden_by_user: next } : it,
+        ),
+        hidden: section.hidden.map((it) =>
+          it.id === itemId ? { ...it, overridden_by_user: next } : it,
+        ),
+      })),
+    );
+  };
+
   const overriddenSections = useMemo(
     () => applyOverrides(sections, shownAnyway),
     [sections, shownAnyway],
@@ -179,6 +206,8 @@ export default function RestaurantScreen() {
           section={section}
           shownAnyway={shownAnyway}
           onToggleOverride={toggleOverride}
+          onSetPersistentOverride={setPersistentOverride}
+          allowPersistent={!!jwt}
         />
       ))}
 
@@ -275,10 +304,14 @@ function SectionBlock({
   section,
   shownAnyway,
   onToggleOverride,
+  onSetPersistentOverride,
+  allowPersistent,
 }: {
   section: ItemSection<RestaurantItem>;
   shownAnyway: Set<string>;
   onToggleOverride: (itemId: string) => void;
+  onSetPersistentOverride: (itemId: string, next: boolean) => void;
+  allowPersistent: boolean;
 }) {
   const [hiddenOpen, setHiddenOpen] = useState(false);
   return (
@@ -289,8 +322,10 @@ function SectionBlock({
         <ItemRow
           key={item.id}
           item={item}
-          overridden={shownAnyway.has(item.id)}
+          overridden={shownAnyway.has(item.id) || item.overridden_by_user === true}
           onToggleOverride={onToggleOverride}
+          onSetPersistentOverride={onSetPersistentOverride}
+          allowPersistent={allowPersistent}
         />
       ))}
 
@@ -321,6 +356,8 @@ function SectionBlock({
             hidden
             overridden={false}
             onToggleOverride={onToggleOverride}
+            onSetPersistentOverride={onSetPersistentOverride}
+            allowPersistent={allowPersistent}
           />
         ))}
     </View>
@@ -332,11 +369,15 @@ function ItemRow({
   hidden = false,
   overridden,
   onToggleOverride,
+  onSetPersistentOverride,
+  allowPersistent,
 }: {
   item: RestaurantItem;
   hidden?: boolean;
   overridden: boolean;
   onToggleOverride: (itemId: string) => void;
+  onSetPersistentOverride: (itemId: string, next: boolean) => void;
+  allowPersistent: boolean;
 }) {
   // An item with reasons but rendered in the visible column means the
   // user tapped "show anyway" — keep the chips visible as a cue.
@@ -362,15 +403,38 @@ function ItemRow({
       )}
 
       {item.reasons.length > 0 && (
-        <Pressable
-          accessibilityLabel={`toggle-override-${item.id}`}
-          onPress={() => onToggleOverride(item.id)}
-          style={styles.overrideButton}
-        >
-          <Text style={styles.overrideText}>
-            {overridden ? 'Hide again' : 'Show anyway'}
-          </Text>
-        </Pressable>
+        <View style={styles.overrideRow}>
+          {item.overridden_by_user ? (
+            <Pressable
+              accessibilityLabel={`undo-never-hide-${item.id}`}
+              onPress={() => onSetPersistentOverride(item.id, false)}
+              style={styles.overrideButton}
+            >
+              <Text style={styles.overrideText}>Always shown — undo</Text>
+            </Pressable>
+          ) : (
+            <>
+              <Pressable
+                accessibilityLabel={`toggle-override-${item.id}`}
+                onPress={() => onToggleOverride(item.id)}
+                style={styles.overrideButton}
+              >
+                <Text style={styles.overrideText}>
+                  {overridden ? 'Hide again' : 'Show anyway'}
+                </Text>
+              </Pressable>
+              {overridden && allowPersistent && (
+                <Pressable
+                  accessibilityLabel={`set-never-hide-${item.id}`}
+                  onPress={() => onSetPersistentOverride(item.id, true)}
+                  style={styles.overrideButton}
+                >
+                  <Text style={styles.persistentOverrideText}>Never hide this dish</Text>
+                </Pressable>
+              )}
+            </>
+          )}
+        </View>
       )}
     </View>
   );
@@ -548,13 +612,23 @@ const styles = StyleSheet.create({
     color: colors.hide,
     fontWeight: '600',
   },
+  overrideRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: space['3'],
+    marginTop: space['1'],
+  },
   overrideButton: {
-    marginTop: space['2'],
     paddingVertical: space['1'],
     alignSelf: 'flex-start',
   },
   overrideText: {
     color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+  },
+  persistentOverrideText: {
+    color: colors.textMuted,
     fontSize: fontSize.sm,
     fontWeight: '600',
   },

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -54,6 +54,8 @@ export interface RestaurantItem extends FilterableItem {
   popularity: number;
   status: ItemStatus;
   reasons: HideReason[];
+  /** Phase 4.2 — set by the API when authenticated. */
+  overridden_by_user?: boolean;
 }
 
 export interface FilterSummary {
@@ -115,3 +117,35 @@ export async function fetchRestaurantItems(
 
 // Re-export from filter-engine so mobile callers don't need a second import.
 export { groupItemsBySection } from '@biteworthy/filter-engine';
+
+/**
+ * Phase 4.2 — POST/DELETE the persistent never-hide override.
+ * Idempotent on both ends; returns the new state.
+ */
+export async function setNeverHide(
+  itemId: string,
+  jwt: string,
+  opts: FetchOptions = {},
+): Promise<{ item_id: string; overridden_by_user: boolean }> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/items/${encodeURIComponent(itemId)}/never_hide`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+  });
+  if (!res.ok) throw new RestaurantFetchError(res.status, `setNeverHide ${itemId} failed: ${res.status}`);
+  return (await res.json()) as { item_id: string; overridden_by_user: boolean };
+}
+
+export async function clearNeverHide(
+  itemId: string,
+  jwt: string,
+  opts: FetchOptions = {},
+): Promise<{ item_id: string; overridden_by_user: boolean }> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/items/${encodeURIComponent(itemId)}/never_hide`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+  });
+  if (!res.ok) throw new RestaurantFetchError(res.status, `clearNeverHide ${itemId} failed: ${res.status}`);
+  return (await res.json()) as { item_id: string; overridden_by_user: boolean };
+}

--- a/apps/web/src/app/api/items/[id]/never_hide/route.ts
+++ b/apps/web/src/app/api/items/[id]/never_hide/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Phase 4.2 — proxy POST/DELETE /api/items/:id/never_hide to Rails
+ * with the bw_session cookie's JWT injected as Bearer.
+ *
+ * Same pattern as the Phase 4.1 proxy routes for /api/profile and
+ * /api/ingestion_runs.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+async function proxy(method: 'POST' | 'DELETE', id: string) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+  const upstream = await fetch(`${API_BASE}/api/v1/items/${encodeURIComponent(id)}/never_hide`, {
+    method,
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+  });
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxy('POST', id);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxy('DELETE', id);
+}

--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -11,7 +11,9 @@ import {
   type Strictness,
 } from '@biteworthy/filter-engine';
 import {
+  clearNeverHide,
   fetchRestaurantItems,
+  setNeverHide,
   type FilterSummary,
   type Restaurant,
   type RestaurantItem,
@@ -91,6 +93,29 @@ export function RestaurantClient({
     });
   };
 
+  // Phase 4.2 — flip an item's persistent override and patch local
+  // state in place so the UI updates without a full refetch.
+  const setPersistentOverride = async (itemId: string, next: boolean) => {
+    try {
+      if (next) await setNeverHide(itemId);
+      else await clearNeverHide(itemId);
+    } catch (e) {
+      setError((e as Error).message);
+      return;
+    }
+    setSections((prev) =>
+      prev.map((section) => ({
+        ...section,
+        visible: section.visible.map((it) =>
+          it.id === itemId ? { ...it, overridden_by_user: next } : it,
+        ),
+        hidden: section.hidden.map((it) =>
+          it.id === itemId ? { ...it, overridden_by_user: next } : it,
+        ),
+      })),
+    );
+  };
+
   const totalHidden = overriddenSections.reduce((acc, s) => acc + s.hidden.length, 0);
   const totalVisible = overriddenSections.reduce((acc, s) => acc + s.visible.length, 0);
 
@@ -134,6 +159,7 @@ export function RestaurantClient({
           section={section}
           shownAnyway={shownAnyway}
           onToggleOverride={toggleOverride}
+          onSetPersistentOverride={setPersistentOverride}
         />
       ))}
     </main>
@@ -200,10 +226,12 @@ function SectionBlock({
   section,
   shownAnyway,
   onToggleOverride,
+  onSetPersistentOverride,
 }: {
   section: ItemSection<RestaurantItem>;
   shownAnyway: Set<string>;
   onToggleOverride: (itemId: string) => void;
+  onSetPersistentOverride: (itemId: string, next: boolean) => void;
 }) {
   const [hiddenOpen, setHiddenOpen] = useState(false);
   return (
@@ -214,8 +242,9 @@ function SectionBlock({
           <ItemRow
             key={item.id}
             item={item}
-            overridden={shownAnyway.has(item.id)}
+            overridden={shownAnyway.has(item.id) || item.overridden_by_user === true}
             onToggleOverride={onToggleOverride}
+            onSetPersistentOverride={onSetPersistentOverride}
           />
         ))}
         {section.visible.length === 0 && section.hidden.length > 0 && (
@@ -249,6 +278,7 @@ function SectionBlock({
               hidden
               overridden={false}
               onToggleOverride={onToggleOverride}
+              onSetPersistentOverride={onSetPersistentOverride}
             />
           ))}
         </ul>
@@ -262,15 +292,19 @@ function ItemRow({
   hidden = false,
   overridden,
   onToggleOverride,
+  onSetPersistentOverride,
 }: {
   item: RestaurantItem;
   hidden?: boolean;
   overridden: boolean;
   onToggleOverride: (itemId: string) => void;
+  onSetPersistentOverride: (itemId: string, next: boolean) => void;
 }) {
   // Item shown in the visible list but with reasons[] = the user
-  // tapped "Show anyway". Keep chips visible as a transparency cue.
+  // tapped "Show anyway" (session) or set "never hide" (persistent).
+  // Keep chips visible as a transparency cue.
   const showChips = hidden || overridden;
+  const persistent = item.overridden_by_user === true;
   return (
     <li
       data-testid={`item-${item.id}`}
@@ -292,13 +326,38 @@ function ItemRow({
       )}
 
       {item.reasons.length > 0 && (
-        <button
-          type="button"
-          onClick={() => onToggleOverride(item.id)}
-          className="mt-bw-2 text-bw-sm font-semibold text-bite hover:text-bite-dark"
-        >
-          {overridden ? 'Hide again' : 'Show anyway'}
-        </button>
+        <div className="mt-bw-2 flex flex-wrap gap-bw-3 text-bw-sm font-semibold">
+          {persistent ? (
+            <button
+              type="button"
+              onClick={() => onSetPersistentOverride(item.id, false)}
+              data-testid={`undo-never-hide-${item.id}`}
+              className="text-bite hover:text-bite-dark"
+            >
+              Always shown — undo
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => onToggleOverride(item.id)}
+                className="text-bite hover:text-bite-dark"
+              >
+                {overridden ? 'Hide again' : 'Show anyway'}
+              </button>
+              {overridden && (
+                <button
+                  type="button"
+                  onClick={() => onSetPersistentOverride(item.id, true)}
+                  data-testid={`set-never-hide-${item.id}`}
+                  className="text-zinc-600 hover:text-zinc-800"
+                >
+                  Never hide this dish
+                </button>
+              )}
+            </>
+          )}
+        </div>
       )}
     </li>
   );

--- a/apps/web/src/lib/__tests__/restaurants.test.ts
+++ b/apps/web/src/lib/__tests__/restaurants.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  clearNeverHide,
   fetchRestaurant,
   fetchRestaurantItems,
+  setNeverHide,
   type Restaurant,
   type RestaurantItemsResponse,
 } from '../restaurants';
@@ -91,5 +93,33 @@ describe('fetchRestaurantItems', () => {
     await fetchRestaurantItems('cream-bean-berry-1', { fetchImpl, jwt: 'jjj.www.ttt' });
     const init = fetchImpl.mock.calls[0]![1] as RequestInit;
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jjj.www.ttt');
+  });
+});
+
+describe('setNeverHide / clearNeverHide (Phase 4.2)', () => {
+  it('POSTs the Next proxy with credentials and no client-side JWT header', async () => {
+    const fetchImpl = fakeFetch(200, { item_id: 'item-1', overridden_by_user: true });
+    const result = await setNeverHide('item-1', { fetchImpl });
+    expect(result.overridden_by_user).toBe(true);
+
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/items/item-1/never_hide');
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('same-origin');
+    expect((init.headers as Record<string, string> | undefined)?.Authorization).toBeUndefined();
+  });
+
+  it('DELETE clears the override', async () => {
+    const fetchImpl = fakeFetch(200, { item_id: 'item-1', overridden_by_user: false });
+    const result = await clearNeverHide('item-1', { fetchImpl });
+    expect(result.overridden_by_user).toBe(false);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'unauth' });
+    await expect(setNeverHide('item-1', { fetchImpl })).rejects.toThrow(/401/);
   });
 });

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -47,6 +47,8 @@ export interface RestaurantItem extends FilterableItem {
   popularity: number;
   status: 'visible' | 'hidden';
   reasons: HideReason[];
+  /** Phase 4.2 — set by the API when authenticated. */
+  overridden_by_user?: boolean;
 }
 
 export interface FilterSummary {
@@ -97,4 +99,34 @@ export async function fetchRestaurantItems(
   const headers: Record<string, string> = {};
   if (opts.jwt) headers.Authorization = `Bearer ${opts.jwt}`;
   return api<RestaurantItemsResponse>(path, { headers, fetchImpl: opts.fetchImpl });
+}
+
+/**
+ * Phase 4.2 — POST/DELETE the persistent never-hide override via the
+ * Next proxy at /api/items/:id/never_hide. Returns the new state.
+ */
+export async function setNeverHide(
+  itemId: string,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<{ item_id: string; overridden_by_user: boolean }> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`/api/items/${encodeURIComponent(itemId)}/never_hide`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  });
+  if (!res.ok) throw new Error(`setNeverHide failed: ${res.status}`);
+  return (await res.json()) as { item_id: string; overridden_by_user: boolean };
+}
+
+export async function clearNeverHide(
+  itemId: string,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<{ item_id: string; overridden_by_user: boolean }> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`/api/items/${encodeURIComponent(itemId)}/never_hide`, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+  });
+  if (!res.ok) throw new Error(`clearNeverHide failed: ${res.status}`);
+  return (await res.json()) as { item_id: string; overridden_by_user: boolean };
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,8 +13,7 @@ the merge / review / status rules.
 
 **Phase 4** ⭐ Reviews + accounts. Subplan: `docs/plans/phase-4.md`.
 
-1. **Phase 4.1 — Real session cookies (retire JWT-pasting)** (`docs/plans/phase-4.md#41`) — this PR
-2. **Phase 4.2 — Persistent "never hide this dish" override** (`docs/plans/phase-4.md#42`)
+1. **Phase 4.2 — Persistent "never hide this dish" override** (`docs/plans/phase-4.md#42`) — this PR
 3. **Phase 4.3 — Review API + photo attachment** (`docs/plans/phase-4.md#43`)
 4. **Phase 4.4 — Mobile review UX** (`docs/plans/phase-4.md#44`)
 5. **Phase 4.5 — Web review UX** (`docs/plans/phase-4.md#45`)
@@ -55,6 +54,7 @@ the merge / review / status rules.
 - ✅ Phase 3.8 — web profile onboarding (#153)
 - ✅ Phase 3.9 — shareable filter URLs (#154) — **Phase 3 feature-complete**
 - ✅ Phase 4 — subplan committed (#155)
+- ✅ Phase 4.1 — real session cookies + login/signup (#156)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,31 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 09:30 — tick #62. PR #156 (Phase 4.1) merged at 09:51 UTC.
+Picked up Phase 4.2 — persistent "never hide this dish" override.
+Closes the deferred half from Phase 3.4. New `user_item_overrides`
+table (user_id, item_id, never_hide bool) with composite unique
+index. UserItemOverride model + has_many wires on User + Item;
+`User#overridden_items` through-association reads cleanly. New
+`POST/DELETE /api/v1/items/:id/never_hide` endpoints (idempotent,
+authenticated, 404 for unpublished items). Items endpoint now emits
+`overridden_by_user: bool` per item — true only for the
+authenticated user's overrides; anonymous always false.
+filter-engine: extended `FilteredItem` with optional
+`overridden_by_user` and updated `applyOverrides` to union
+session + persistent overrides into the visible bucket. Web: new
+`/api/items/[id]/never_hide` Next proxy + `setNeverHide` /
+`clearNeverHide` client helpers. RestaurantClient gains "Never hide
+this dish" sub-action under "Show anyway"; persistent state shows
+"Always shown — undo". Mobile: same fetchers + buttons (gated by
+`allowPersistent` boolean since the screen still renders anonymously).
+Tests: 5 model specs, 6 controller specs, 2 new items-endpoint
+specs (auth + anonymous), 4 mobile jest cases for the fetchers,
+3 web vitest cases for the helpers, 3 new filter-engine vitest
+cases for the persistent override path. Local: rspec 212/0/1
+pending; web vitest 30/30; mobile jest 39/39; filter-engine vitest
+60/60; pnpm typecheck/lint cached green.
+
 2026-05-01 09:00 — tick #61. PR #155 (Phase 4 plan) merged at 08:47 UTC.
 **Major user unblocks during this tick**: ANTHROPIC_API_KEY now in
 GitHub Actions secrets + local .env, and bite-worthy.com domain

--- a/packages/filter-engine/src/index.test.ts
+++ b/packages/filter-engine/src/index.test.ts
@@ -355,4 +355,55 @@ describe('applyOverrides', () => {
     const result = applyOverrides([tacos, bowls], new Set(['h']));
     expect(result[1]).toBe(bowls);
   });
+
+  describe('persistent overrides (Phase 4.2)', () => {
+    function persistentlyOverridden(id: string): FilteredItem {
+      return {
+        id,
+        ingredient_ids: [],
+        tag_ids: [],
+        confidence: 'confirmed',
+        menu_section_id: null,
+        menu_section_name: null,
+        status: 'hidden',
+        reasons: [],
+        overridden_by_user: true,
+      };
+    }
+
+    it('promotes items flagged overridden_by_user without an explicit shownAnyway entry', () => {
+      const sections: ItemSection[] = [
+        {
+          id: 'tacos',
+          name: 'Tacos',
+          visible: [fItem('v', 'visible')],
+          hidden: [persistentlyOverridden('p1'), fItem('h1', 'hidden')],
+        },
+      ];
+      const out = applyOverrides(sections, new Set());
+      expect(out[0]!.visible.map((i) => i.id)).toEqual(['v', 'p1']);
+      expect(out[0]!.hidden.map((i) => i.id)).toEqual(['h1']);
+    });
+
+    it('unions session + persistent overrides into one bucket', () => {
+      const sections: ItemSection[] = [
+        {
+          id: 'tacos',
+          name: 'Tacos',
+          visible: [],
+          hidden: [persistentlyOverridden('p1'), fItem('s1', 'hidden')],
+        },
+      ];
+      const out = applyOverrides(sections, new Set(['s1']));
+      expect(out[0]!.visible.map((i) => i.id)).toEqual(['p1', 's1']);
+      expect(out[0]!.hidden).toEqual([]);
+    });
+
+    it('preserves identity when neither override kind hits', () => {
+      const sections: ItemSection[] = [
+        { id: 'tacos', name: 'Tacos', visible: [], hidden: [fItem('h', 'hidden')] },
+      ];
+      expect(applyOverrides(sections, new Set())).toBe(sections);
+    });
+  });
 });

--- a/packages/filter-engine/src/index.ts
+++ b/packages/filter-engine/src/index.ts
@@ -60,6 +60,14 @@ export interface FilterableItem {
 export interface FilteredItem extends FilterableItem {
   status: ItemStatus;
   reasons: HideReason[];
+  /**
+   * Phase 4.2 — true when the authenticated user has flagged this
+   * item as "never hide for me." Optional so anonymous responses
+   * (which always set it `false` server-side) don't have to spell it
+   * out, and so factories / fixtures can omit it in tests that don't
+   * exercise the override path.
+   */
+  overridden_by_user?: boolean;
 }
 
 /**
@@ -242,12 +250,18 @@ export function applyOverrides<T extends FilteredItem>(
   sections: ItemSection<T>[],
   shownAnyway: ReadonlySet<string>,
 ): ItemSection<T>[] {
-  if (shownAnyway.size === 0) return sections;
+  // Phase 4.2 — items the server already marked `overridden_by_user`
+  // get the same treatment as session-only "show anyway" picks: they
+  // move from `hidden` to `visible`. The `shownAnyway` set is unioned
+  // with the per-item flag so callers don't have to merge manually.
+  const hasPersistentOverrides = sections.some((s) => s.hidden.some((i) => i.overridden_by_user));
+  if (shownAnyway.size === 0 && !hasPersistentOverrides) return sections;
+
   return sections.map((section) => {
     const stillHidden: T[] = [];
     const promoted: T[] = [];
     for (const item of section.hidden) {
-      if (shownAnyway.has(item.id)) promoted.push(item);
+      if (shownAnyway.has(item.id) || item.overridden_by_user) promoted.push(item);
       else stillHidden.push(item);
     }
     if (promoted.length === 0) return section;


### PR DESCRIPTION
## Summary

Phase 4.2 closes the deferred half from Phase 3.4: a "Show anyway" tap can now be promoted to "Never hide this dish" — the override survives logout/login. Subplan: `docs/plans/phase-4.md#42`.

### API
- New `user_item_overrides` table (`user_id`, `item_id`, `never_hide bool`) with a composite unique index on `(user_id, item_id)`.
- `UserItemOverride` model + `has_many` wires on `User` and `Item`. `User#overridden_items` reads cleanly via `through`.
- **`POST /api/v1/items/:id/never_hide`** + **`DELETE /api/v1/items/:id/never_hide`** — idempotent both ways, authenticated, 404 for unpublished items.
- The items endpoint now emits **`overridden_by_user: bool`** per item — true only for the authenticated user's overrides; anonymous always false.

### filter-engine
- `FilteredItem` gains an optional `overridden_by_user` field.
- `applyOverrides` unions session `shownAnyway` with persistent `overridden_by_user` into one visible bucket. Identity preserved when neither hits.

### Web
- New `/api/items/[id]/never_hide` Next proxy route (POST + DELETE) injecting the cookie's JWT.
- `setNeverHide` / `clearNeverHide` client helpers.
- `RestaurantClient`: under "Show anyway", a sub-action "Never hide this dish"; persistent state collapses to a single "Always shown — undo" button.

### Mobile
- Same fetchers + buttons. Sub-action gated by `allowPersistent` (false when no JWT in keychain so anonymous browse still works).

## Out of scope
- Bulk admin tooling for managing user overrides (Avo can list `UserItemOverride` later if useful).
- Per-restaurant or per-tag overrides ("never hide anything from Cream Bean Berry") — different shape, not in the subplan.

## Test plan
- [x] **Rspec** 212/0/1 pending — 5 model specs + 6 controller specs + 2 new items-endpoint specs (overridden_by_user surfaces for auth user, false for anonymous).
- [x] **filter-engine vitest** 60/60 (3 new for the persistent-override path).
- [x] **Web vitest** 30/30 (3 new for the helpers).
- [x] **Mobile jest** 39/39 (4 new for the fetchers).
- [x] `pnpm typecheck` / `pnpm lint` cached green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)