### PR TITLE
feat(web): web review UX (phase 4.5)

### DIFF
--- a/apps/web/src/app/api/items/[id]/reviews/route.ts
+++ b/apps/web/src/app/api/items/[id]/reviews/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Phase 4.5 — proxy GET + POST /api/items/:id/reviews to Rails.
+ *
+ * GET is anonymous (mirrors the public Rails endpoint).
+ * POST proxies multipart or JSON, injecting the cookie's JWT as
+ * Bearer. Same shape as the Phase 4.1 ingestion_runs proxy.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const search = request.nextUrl.search ?? '';
+  const upstream = await fetch(
+    `${API_BASE}/api/v1/items/${encodeURIComponent(id)}/reviews${search}`,
+    { headers: { Accept: 'application/json' } },
+  );
+  const body = await upstream.text();
+  return new NextResponse(body, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+
+  const contentType = request.headers.get('Content-Type') ?? 'application/octet-stream';
+  const isMultipart = contentType.startsWith('multipart/form-data');
+
+  const headers: Record<string, string> = { Authorization: `Bearer ${jwt}` };
+  let body: BodyInit;
+  if (isMultipart) {
+    headers['Content-Type'] = contentType;
+    body = await request.arrayBuffer();
+  } else {
+    headers['Content-Type'] = 'application/json';
+    headers['Accept'] = 'application/json';
+    body = await request.text();
+  }
+
+  const upstream = await fetch(
+    `${API_BASE}/api/v1/items/${encodeURIComponent(id)}/reviews`,
+    { method: 'POST', headers, body },
+  );
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/reviews/[id]/route.ts
+++ b/apps/web/src/app/api/reviews/[id]/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Phase 4.5 — proxy PATCH + DELETE /api/reviews/:id to Rails with
+ * the cookie's JWT. Owner-gated 403 lives on the Rails side.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+async function proxy(method: 'PATCH' | 'DELETE', id: string, request: NextRequest) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+
+  const headers: Record<string, string> = { Authorization: `Bearer ${jwt}` };
+  let body: BodyInit | undefined;
+  if (method === 'PATCH') {
+    headers['Content-Type'] = 'application/json';
+    headers['Accept'] = 'application/json';
+    body = await request.text();
+  }
+
+  const upstream = await fetch(`${API_BASE}/api/v1/reviews/${encodeURIComponent(id)}`, {
+    method,
+    headers,
+    body,
+  });
+  const responseText = await upstream.text();
+  return new NextResponse(responseText.length > 0 ? responseText : null, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxy('PATCH', id, request);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxy('DELETE', id, request);
+}

--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -157,6 +157,7 @@ export function RestaurantClient({
         <SectionBlock
           key={section.id ?? '__none__'}
           section={section}
+          restaurantSlug={slug}
           shownAnyway={shownAnyway}
           onToggleOverride={toggleOverride}
           onSetPersistentOverride={setPersistentOverride}
@@ -224,11 +225,13 @@ export function StrictnessToggle({
 
 function SectionBlock({
   section,
+  restaurantSlug,
   shownAnyway,
   onToggleOverride,
   onSetPersistentOverride,
 }: {
   section: ItemSection<RestaurantItem>;
+  restaurantSlug: string;
   shownAnyway: Set<string>;
   onToggleOverride: (itemId: string) => void;
   onSetPersistentOverride: (itemId: string, next: boolean) => void;
@@ -242,6 +245,7 @@ function SectionBlock({
           <ItemRow
             key={item.id}
             item={item}
+            restaurantSlug={restaurantSlug}
             overridden={shownAnyway.has(item.id) || item.overridden_by_user === true}
             onToggleOverride={onToggleOverride}
             onSetPersistentOverride={onSetPersistentOverride}
@@ -275,6 +279,7 @@ function SectionBlock({
             <ItemRow
               key={item.id}
               item={item}
+              restaurantSlug={restaurantSlug}
               hidden
               overridden={false}
               onToggleOverride={onToggleOverride}
@@ -289,12 +294,14 @@ function SectionBlock({
 
 function ItemRow({
   item,
+  restaurantSlug,
   hidden = false,
   overridden,
   onToggleOverride,
   onSetPersistentOverride,
 }: {
   item: RestaurantItem;
+  restaurantSlug: string;
   hidden?: boolean;
   overridden: boolean;
   onToggleOverride: (itemId: string) => void;
@@ -305,6 +312,7 @@ function ItemRow({
   // Keep chips visible as a transparency cue.
   const showChips = hidden || overridden;
   const persistent = item.overridden_by_user === true;
+  const reviewsCount = item.reviews_count ?? 0;
   return (
     <li
       data-testid={`item-${item.id}`}
@@ -316,6 +324,15 @@ function ItemRow({
       {item.description && (
         <p className="mt-1 text-bw-sm text-zinc-500">{item.description}</p>
       )}
+      <a
+        href={`/restaurants/${encodeURIComponent(restaurantSlug)}/items/${encodeURIComponent(item.id)}`}
+        data-testid={`open-item-${item.id}`}
+        className="mt-1 inline-block text-bw-xs font-semibold text-bite hover:text-bite-dark"
+      >
+        {reviewsCount === 0
+          ? 'Be the first to review'
+          : `${reviewsCount} review${reviewsCount === 1 ? '' : 's'} →`}
+      </a>
 
       {showChips && item.reasons.length > 0 && (
         <div className="mt-bw-2 flex flex-wrap gap-bw-1">

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/ReviewsClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/ReviewsClient.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  createReview,
+  fetchReviews,
+  ReviewError,
+  type ReviewPayload,
+  type ReviewsResponse,
+} from '../../../../../lib/reviews';
+
+/**
+ * Phase 4.5 — client island for the SSR item detail page.
+ *
+ * Renders the reviews list (seeded from SSR), the inline compose
+ * form, and a "Load more" button when there are more than 20
+ * reviews. Anonymous compose attempts bounce to /login; the rest
+ * of the page (item header, breadcrumb, initial reviews) is always
+ * server-rendered for SEO.
+ */
+const PAGE_SIZE = 20;
+
+export function ReviewsClient({
+  itemId,
+  initial,
+}: {
+  itemId: string;
+  initial: ReviewsResponse;
+}) {
+  const router = useRouter();
+
+  const [reviews, setReviews] = useState<ReviewPayload[]>(initial.reviews);
+  const [total, setTotal] = useState(initial.total);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  const loadMore = async () => {
+    try {
+      setLoadingMore(true);
+      const next = await fetchReviews(itemId, { offset: reviews.length, limit: PAGE_SIZE });
+      setReviews((prev) => [...prev, ...next.reviews]);
+      setTotal(next.total);
+    } catch {
+      // Best-effort — surface as a quiet console warning, no toast.
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const onPosted = (saved: ReviewPayload) => {
+    setReviews((prev) => [saved, ...prev]);
+    setTotal((n) => n + 1);
+    setComposerOpen(false);
+  };
+
+  return (
+    <section className="mt-bw-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-bw-lg font-bold">
+          {total} review{total === 1 ? '' : 's'}
+        </h2>
+        {!composerOpen && (
+          <button
+            type="button"
+            onClick={() => setComposerOpen(true)}
+            data-testid="open-composer"
+            className="rounded-bw-md bg-bite px-bw-3 py-bw-2 text-bw-sm font-bold text-white hover:bg-bite-dark"
+          >
+            Write a review
+          </button>
+        )}
+      </div>
+
+      {composerOpen && (
+        <Composer
+          itemId={itemId}
+          onCancel={() => setComposerOpen(false)}
+          onPosted={onPosted}
+          onUnauthenticated={() => {
+            router.replace(
+              `/login?next=${encodeURIComponent(`/restaurants/_/items/${itemId}`)}`,
+            );
+          }}
+        />
+      )}
+
+      <ul className="mt-bw-4 divide-y divide-zinc-100">
+        {reviews.map((r) => (
+          <ReviewCard key={r.id} review={r} />
+        ))}
+        {reviews.length === 0 && (
+          <li className="py-bw-6 text-center text-bw-sm text-zinc-500">
+            No reviews yet — be the first.
+          </li>
+        )}
+      </ul>
+
+      {reviews.length < total && (
+        <button
+          type="button"
+          onClick={loadMore}
+          disabled={loadingMore}
+          data-testid="load-more"
+          className="mt-bw-4 w-full rounded-bw-md border border-zinc-200 bg-white px-bw-3 py-bw-2 text-bw-sm font-semibold text-zinc-700 hover:border-zinc-300"
+        >
+          {loadingMore ? 'Loading…' : `Load more (${total - reviews.length} remaining)`}
+        </button>
+      )}
+    </section>
+  );
+}
+
+function ReviewCard({ review }: { review: ReviewPayload }) {
+  return (
+    <li className="py-bw-3" data-testid={`review-${review.id}`}>
+      <p className="text-bw-sm font-semibold text-zinc-900">
+        {review.user.display_name ?? review.user.handle ?? 'Diner'}{' '}
+        <span className="text-bite">
+          {'★'.repeat(review.rating)}
+          <span className="text-zinc-300">{'☆'.repeat(5 - review.rating)}</span>
+        </span>
+      </p>
+      {review.body && (
+        <p className="mt-1 text-bw-base text-zinc-700">{review.body}</p>
+      )}
+      {review.photo_url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={review.photo_url}
+          alt="Reviewer's photo"
+          className="mt-bw-2 max-h-80 w-full rounded-bw-md object-cover"
+        />
+      )}
+    </li>
+  );
+}
+
+function Composer({
+  itemId,
+  onCancel,
+  onPosted,
+  onUnauthenticated,
+}: {
+  itemId: string;
+  onCancel: () => void;
+  onPosted: (saved: ReviewPayload) => void;
+  onUnauthenticated: () => void;
+}) {
+  const [rating, setRating] = useState(0);
+  const [body, setBody] = useState('');
+  const [photo, setPhoto] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (rating < 1 || rating > 5) {
+      setError('Pick a rating first.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      const saved = await createReview(itemId, {
+        rating,
+        body: body.trim() || undefined,
+        photo,
+      });
+      onPosted(saved);
+    } catch (e) {
+      if (e instanceof ReviewError && e.status === 401) {
+        onUnauthenticated();
+        return;
+      }
+      setError((e as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="mt-bw-4 rounded-bw-md border border-zinc-200 p-bw-4" data-testid="review-composer">
+      <p className="text-bw-sm font-semibold text-zinc-700">How was it?</p>
+      <div className="mt-bw-2 flex items-center gap-1">
+        {[1, 2, 3, 4, 5].map((n) => (
+          <button
+            type="button"
+            key={n}
+            onClick={() => setRating(n)}
+            data-testid={`star-${n}`}
+            aria-pressed={rating >= n}
+            className={['text-3xl', rating >= n ? 'text-bite' : 'text-zinc-300'].join(' ')}
+          >
+            ★
+          </button>
+        ))}
+      </div>
+
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Optional notes — what was good, what wasn't"
+        aria-label="review-body"
+        className="mt-bw-3 w-full rounded-bw-md border border-zinc-300 p-bw-2 text-bw-base"
+        rows={3}
+      />
+
+      <label className="mt-bw-2 block text-bw-sm font-semibold text-zinc-700">
+        Photo (optional)
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/heic,image/heif,image/webp"
+          onChange={(e) => setPhoto(e.target.files?.[0] ?? null)}
+          aria-label="photo"
+          className="mt-1 block w-full text-bw-sm"
+        />
+      </label>
+
+      {error && (
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-bw-3 flex items-center gap-bw-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-bw-md border border-zinc-200 bg-white px-bw-3 py-bw-2 text-bw-sm font-semibold text-zinc-700 hover:border-zinc-300"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          data-testid="submit-review"
+          className={[
+            'rounded-bw-md bg-bite px-bw-4 py-bw-2 text-bw-sm font-bold text-white',
+            submitting ? 'opacity-60' : 'hover:bg-bite-dark',
+          ].join(' ')}
+        >
+          {submitting ? 'Posting…' : 'Post review'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import {
+  fetchItem,
+  fetchRestaurant,
+  type Restaurant,
+  type RestaurantItem,
+} from '../../../../../lib/restaurants';
+import { fetchReviewsServer, type ReviewsResponse } from '../../../../../lib/reviews';
+import { ReviewsClient } from './ReviewsClient';
+
+/**
+ * Phase 4.5 — server-rendered item detail page with reviews.
+ *
+ * URL is `/restaurants/<slug>/items/<id>` so search engines see the
+ * full review text + photos for SEO. Initial reviews are fetched on
+ * the server (anonymous public endpoint); the client island handles
+ * the compose form + paginated load-more without re-rendering the
+ * static parts.
+ */
+type Params = { slug: string; id: string };
+
+export default async function ItemDetailPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { slug, id } = await params;
+
+  const [restaurant, item, initialReviews] = await Promise.all([
+    fetchRestaurant(slug).catch(() => null),
+    fetchItem(slug, id).catch(() => null),
+    fetchReviewsServer(id).catch(() => null),
+  ]);
+
+  if (!restaurant || !item) notFound();
+
+  return (
+    <Page restaurant={restaurant} item={item} initialReviews={initialReviews ?? emptyReviews(id)} />
+  );
+}
+
+function Page({
+  restaurant,
+  item,
+  initialReviews,
+}: {
+  restaurant: Restaurant;
+  item: RestaurantItem;
+  initialReviews: ReviewsResponse;
+}) {
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 py-bw-12">
+      <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">
+        <Link href={`/restaurants/${restaurant.slug}`} className="hover:underline">
+          ← {restaurant.name}
+        </Link>
+      </p>
+      <h1 className="mt-bw-2 text-bw-3xl font-bold">{item.name}</h1>
+      {item.description && (
+        <p className="mt-bw-2 text-bw-base text-zinc-700">{item.description}</p>
+      )}
+
+      <ReviewsClient itemId={item.id} initial={initialReviews} />
+    </main>
+  );
+}
+
+function emptyReviews(itemId: string): ReviewsResponse {
+  return { item_id: itemId, reviews: [], total: 0 };
+}

--- a/apps/web/src/lib/__tests__/reviews.test.ts
+++ b/apps/web/src/lib/__tests__/reviews.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createReview,
+  deleteReview,
+  fetchReviews,
+  ReviewError,
+  updateReview,
+  type ReviewPayload,
+  type ReviewsResponse,
+} from '../reviews';
+
+const sampleReview: ReviewPayload = {
+  id: 'rev-1',
+  item_id: 'item-1',
+  user: { id: 'u-1', handle: 'diner', display_name: 'Diner' },
+  rating: 5,
+  body: 'Loved it.',
+  photo_url: null,
+  created_at: '2026-04-30T10:00:00Z',
+  updated_at: '2026-04-30T10:00:00Z',
+};
+
+const sampleResponse: ReviewsResponse = {
+  item_id: 'item-1',
+  reviews: [sampleReview],
+  total: 1,
+};
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'ERR',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+describe('fetchReviews', () => {
+  it('GETs the Next proxy at /api/items/:id/reviews with credentials', async () => {
+    const fetchImpl = fakeFetch(200, sampleResponse);
+    const out = await fetchReviews('item-1', { fetchImpl });
+    expect(out.total).toBe(1);
+
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/items/item-1/reviews');
+    expect(init.credentials).toBe('same-origin');
+  });
+
+  it('passes limit + offset query params when supplied', async () => {
+    const fetchImpl = fakeFetch(200, sampleResponse);
+    await fetchReviews('item-1', { fetchImpl, limit: 5, offset: 10 });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('limit=5');
+    expect(url).toContain('offset=10');
+  });
+
+  it('omits both when undefined', async () => {
+    const fetchImpl = fakeFetch(200, sampleResponse);
+    await fetchReviews('item-1', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).not.toContain('limit=');
+    expect(url).not.toContain('offset=');
+  });
+
+  it('throws ReviewError on non-2xx', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'not found' });
+    await expect(fetchReviews('missing', { fetchImpl })).rejects.toBeInstanceOf(ReviewError);
+  });
+});
+
+describe('createReview', () => {
+  it('POSTs JSON when no photo is supplied (no client-side Authorization)', async () => {
+    const fetchImpl = fakeFetch(201, sampleReview);
+    await createReview('item-1', { rating: 5, body: 'Great' }, { fetchImpl });
+
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('same-origin');
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toEqual({ rating: 5, body: 'Great' });
+  });
+
+  it('POSTs multipart when a File is attached', async () => {
+    const fetchImpl = fakeFetch(201, sampleReview);
+    const photo = new File(['fake'], 'photo.jpg', { type: 'image/jpeg' });
+    await createReview('item-1', { rating: 4, body: 'See pic', photo }, { fetchImpl });
+
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.headers as Record<string, string> | undefined)?.['Content-Type']).toBeUndefined();
+  });
+
+  it('throws ReviewError on validation failure', async () => {
+    const fetchImpl = fakeFetch(422, { error: 'Rating must be in 1..5' });
+    await expect(createReview('item-1', { rating: 99 }, { fetchImpl })).rejects.toBeInstanceOf(
+      ReviewError,
+    );
+  });
+
+  it('surfaces a 401 ReviewError with the right status (caller bounces to /login)', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'Not signed in' });
+    await expect(createReview('item-1', { rating: 5 }, { fetchImpl })).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+});
+
+describe('updateReview', () => {
+  it('PATCHes /api/reviews/:id', async () => {
+    const fetchImpl = fakeFetch(200, sampleReview);
+    await updateReview('rev-1', { rating: 4 }, { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/reviews/rev-1');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body as string)).toEqual({ rating: 4 });
+  });
+
+  it('throws on 403 with status preserved', async () => {
+    const fetchImpl = fakeFetch(403, { error: 'Only author' });
+    await expect(updateReview('rev-1', { rating: 1 }, { fetchImpl })).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+});
+
+describe('deleteReview', () => {
+  it('DELETEs the proxy URL', async () => {
+    const fetchImpl = fakeFetch(204, {});
+    await deleteReview('rev-1', { fetchImpl });
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe('DELETE');
+    expect(init.credentials).toBe('same-origin');
+  });
+});

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -49,6 +49,8 @@ export interface RestaurantItem extends FilterableItem {
   reasons: HideReason[];
   /** Phase 4.2 — set by the API when authenticated. */
   overridden_by_user?: boolean;
+  /** Phase 4.4 — total review count, populated for both anon + auth. */
+  reviews_count?: number;
 }
 
 export interface FilterSummary {
@@ -84,6 +86,18 @@ export async function fetchRestaurant(
   return api<Restaurant>(`/restaurants/${encodeURIComponent(slugOrId)}`, {
     fetchImpl: opts.fetchImpl,
   });
+}
+
+/** Phase 4.5 — fetch a single item by id under a restaurant. */
+export async function fetchItem(
+  restaurantSlugOrId: string,
+  itemId: string,
+  opts: FetchOptions = {},
+): Promise<RestaurantItem> {
+  return api<RestaurantItem>(
+    `/restaurants/${encodeURIComponent(restaurantSlugOrId)}/items/${encodeURIComponent(itemId)}`,
+    { fetchImpl: opts.fetchImpl },
+  );
 }
 
 export async function fetchRestaurantItems(

--- a/apps/web/src/lib/reviews.ts
+++ b/apps/web/src/lib/reviews.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 4.5 — web review API client.
+ *
+ * Mirrors the mobile client at apps/mobile/lib/api/reviews.ts but
+ * routes through the Next proxy at /api/items/:id/reviews and
+ * /api/reviews/:id, which inject the bw_session cookie's JWT as a
+ * Bearer header. The browser never touches the JWT directly.
+ *
+ * SSR pages can call `fetchReviewsServer` directly against Rails (no
+ * auth needed for the public index endpoint).
+ */
+import { api, type ApiOptions } from './api';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export interface ReviewAuthor {
+  id: string;
+  handle: string | null;
+  display_name: string | null;
+}
+
+export interface ReviewPayload {
+  id: string;
+  item_id: string;
+  user: ReviewAuthor;
+  rating: number;
+  body: string | null;
+  photo_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ReviewsResponse {
+  item_id: string;
+  reviews: ReviewPayload[];
+  total: number;
+}
+
+export class ReviewError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ReviewError';
+  }
+}
+
+export interface PaginationOptions {
+  limit?: number;
+  offset?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Anonymous browser fetch via the Next proxy. Use this from client
+ * components.
+ */
+export async function fetchReviews(
+  itemId: string,
+  opts: PaginationOptions = {},
+): Promise<ReviewsResponse> {
+  const { fetchImpl = fetch, limit, offset } = opts;
+  const url = new URL(`/api/items/${encodeURIComponent(itemId)}/reviews`, 'http://placeholder');
+  if (typeof limit === 'number') url.searchParams.set('limit', String(limit));
+  if (typeof offset === 'number') url.searchParams.set('offset', String(offset));
+  const path = `${url.pathname}${url.search}`;
+  const res = await fetchImpl(path, { credentials: 'same-origin' });
+  if (!res.ok) throw new ReviewError(res.status, `fetchReviews ${itemId} failed: ${res.status}`);
+  return (await res.json()) as ReviewsResponse;
+}
+
+/**
+ * Server-side fetch (SSR). Hits Rails directly — no cookie / proxy
+ * needed since the index endpoint is public.
+ */
+export async function fetchReviewsServer(itemId: string): Promise<ReviewsResponse> {
+  return api<ReviewsResponse>(`/items/${encodeURIComponent(itemId)}/reviews`);
+}
+
+export interface NewReview {
+  rating: number;
+  body?: string;
+  /**
+   * Browser File from an <input type="file"> picker. Sends multipart;
+   * omit for text-only reviews (sends JSON).
+   */
+  photo?: File | null;
+}
+
+export async function createReview(
+  itemId: string,
+  review: NewReview,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<ReviewPayload> {
+  const { fetchImpl = fetch } = opts;
+  const path = `/api/items/${encodeURIComponent(itemId)}/reviews`;
+  let body: BodyInit;
+  const headers: Record<string, string> = {};
+  if (review.photo) {
+    const form = new FormData();
+    form.append('rating', String(review.rating));
+    if (review.body != null) form.append('body', review.body);
+    form.append('photo', review.photo, review.photo.name);
+    body = form;
+    // No Content-Type — fetch sets the multipart boundary.
+  } else {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify({ rating: review.rating, body: review.body });
+  }
+  const res = await fetchImpl(path, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers,
+    body,
+  });
+  if (!res.ok) throw await reviewError(res, `createReview ${itemId}`);
+  return (await res.json()) as ReviewPayload;
+}
+
+export interface UpdateReview {
+  rating?: number;
+  body?: string | null;
+}
+
+export async function updateReview(
+  reviewId: string,
+  patch: UpdateReview,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<ReviewPayload> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`/api/reviews/${encodeURIComponent(reviewId)}`, {
+    method: 'PATCH',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw await reviewError(res, `updateReview ${reviewId}`);
+  return (await res.json()) as ReviewPayload;
+}
+
+export async function deleteReview(
+  reviewId: string,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<void> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`/api/reviews/${encodeURIComponent(reviewId)}`, {
+    method: 'DELETE',
+    credentials: 'same-origin',
+  });
+  if (!res.ok) throw await reviewError(res, `deleteReview ${reviewId}`);
+}
+
+async function reviewError(res: Response, label: string): Promise<ReviewError> {
+  let body: { error?: string } | null = null;
+  try {
+    body = (await res.json()) as { error?: string };
+  } catch {
+    // ignore
+  }
+  return new ReviewError(res.status, `${label} failed: ${res.status}${body?.error ? ` — ${body.error}` : ''}`);
+}
+
+// Re-export to keep imports from screens tidy.
+export { type ApiOptions };
+export { API_BASE };

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ the merge / review / status rules.
 
 **Phase 4** ⭐ Reviews + accounts. Subplan: `docs/plans/phase-4.md`.
 
-1. **Phase 4.4 — Mobile review UX** (`docs/plans/phase-4.md#44`) — this PR
+1. **Phase 4.5 — Web review UX** (`docs/plans/phase-4.md#45`) — this PR
 3. **Phase 4.3 — Review API + photo attachment** (`docs/plans/phase-4.md#43`)
 4. **Phase 4.4 — Mobile review UX** (`docs/plans/phase-4.md#44`)
 5. **Phase 4.5 — Web review UX** (`docs/plans/phase-4.md#45`)
@@ -57,6 +57,7 @@ the merge / review / status rules.
 - ✅ Phase 4.1 — real session cookies + login/signup (#156)
 - ✅ Phase 4.2 — persistent "never hide this dish" override (#157)
 - ✅ Phase 4.3 — review API + photo attachment (#158)
+- ✅ Phase 4.4 — mobile review UX (#159)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,31 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 11:00 — tick #65. PR #159 (Phase 4.4) merged at 10:48 UTC.
+Picked up Phase 4.5 — web review UX. Mirror of mobile 4.4 on Next.js.
+Two new Next API proxy routes: `/api/items/[id]/reviews` (GET +
+POST, multipart-aware) and `/api/reviews/[id]` (PATCH + DELETE).
+Both proxy through `getServerJwt` from the bw_session cookie. New
+`apps/web/src/lib/reviews.ts` API client (fetchReviews via proxy,
+fetchReviewsServer for SSR direct, createReview that switches
+JSON/multipart based on photo presence, updateReview, deleteReview);
+401 surfaces as ReviewError with status preserved so the caller can
+bounce to /login. New `fetchItem(slug, id)` server-side fetcher in
+restaurants.ts. SSR page at
+`apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx` runs
+`Promise.all` over restaurant + item + initial reviews; notFound()
+on either restaurant or item miss; reviews fall back to empty array
+on fetch error. Client island ReviewsClient handles compose form
+(5-star tap, optional body textarea, optional File photo) + Load
+more pagination starting at offset=20. The existing RestaurantClient
+got per-item review badges that link to `/restaurants/<slug>/items/<id>`
+matching the mobile flow. Tests: 11 new vitest cases covering
+proxy URL construction, query-param presence/absence, JSON vs
+multipart switching, 401/403/404 → ReviewError, no client-side
+Authorization header (proxy injects from cookie). Local: rspec
+229/0/1 pending; web vitest 41/41; mobile jest 50/50; pnpm
+typecheck/lint cached green.
+
 2026-05-01 10:30 — tick #64. PR #158 (Phase 4.3) merged at 10:17 UTC.
 Picked up Phase 4.4 — mobile review UX. Tiny backend change first:
 items endpoint emits `reviews_count: int` per item via one bulk


### PR DESCRIPTION
## Summary

Phase 4.5 ports the mobile review flow to Next.js. SSR item detail page at `/restaurants/<slug>/items/<id>` for SEO; client island handles the compose form + Load-more pagination. Subplan: `docs/plans/phase-4.md#45`.

### Web
- **Two new Next API proxy routes** (same pattern as Phase 4.1 / 4.2 proxies):
  - `/api/items/[id]/reviews` — `GET` (public anonymous forward) + `POST` (multipart-aware, injects `bw_session` cookie's JWT as Bearer).
  - `/api/reviews/[id]` — `PATCH` + `DELETE` through the same cookie-injection path.
- **`apps/web/src/lib/reviews.ts`** — `fetchReviews` (browser via proxy), `fetchReviewsServer` (SSR direct, no auth needed since the index endpoint is public), `createReview` (auto JSON when text-only, multipart when `File` is attached), `updateReview`, `deleteReview`. `ReviewError` preserves the status so callers can bounce 401 → `/login`.
- **`apps/web/src/lib/restaurants.ts`** gained `fetchItem(slug, id)` for SSR.
- **`apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx`** — server component runs `Promise.all` over restaurant + item + initial reviews; `notFound()` on either restaurant or item miss.
- **`ReviewsClient` island** — compose form (5-star tap, optional body, optional `File` photo) + Load-more pagination at offset 20. 401 from the proxy bounces to `/login`.
- **`RestaurantClient` items** render per-item "X reviews" / "Be the first to review" badges linking to `/restaurants/<slug>/items/<id>`, matching the mobile flow.

## Out of scope
- Edit / delete from the detail page — endpoints are wired up but the UI for "edit my review" lands with the user-profile pages in Phase 4.7.
- UI render test for the page — same `jest-expo` / `@testing-library/react` Discovered followup that's blocked snapshots since Phase 3.5.

## Test plan
- [x] **Web vitest** 41/41 (11 new for the API client: proxy URL construction, query-param presence/absence, JSON vs multipart switching, 401/403/404 → `ReviewError`, no client-side `Authorization` header).
- [x] **Mobile jest** 50/50 unchanged.
- [x] **rspec** 229/0/1 pending unchanged (no Rails changes in this PR).
- [x] `pnpm typecheck` / `pnpm lint` cached green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)