### PR TITLE
feat(api,web,mobile): public user profile pages (phase 4.7)

### DIFF
--- a/apps/api/app/controllers/api/v1/users_controller.rb
+++ b/apps/api/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,70 @@
+module Api
+  module V1
+    # Phase 4.7 — public user profile lookup by handle.
+    #
+    # GET /api/v1/users/:handle returns a small *public* payload —
+    # display_name, handle, member_since, recent (visible) reviews
+    # and a count of restaurants they've reviewed at. Sensitive
+    # fields (email, dietary profile, overrides, jti, sign_in
+    # timestamps) are intentionally absent.
+    #
+    # Anonymous access is intentional — the page is meant to be
+    # linkable. Authenticated callers see the same payload; nothing
+    # changes based on identity (Phase 4.8 history stays on the
+    # private /api/v1/profile/history endpoint).
+    class UsersController < BaseController
+      skip_before_action :authenticate_user!, only: [:show]
+
+      RECENT_REVIEW_LIMIT = 10
+
+      def show
+        user = User.find_by!(handle: params[:handle])
+        recent_reviews = user.reviews.visible
+                            .includes(item: :restaurant, photo_attachment: :blob)
+                            .order(created_at: :desc)
+                            .limit(RECENT_REVIEW_LIMIT)
+
+        # One COUNT DISTINCT — much cheaper than loading restaurants.
+        # Hidden reviews are excluded so the public stat stays accurate.
+        restaurants_reviewed_count = user.reviews.visible.joins(:item).distinct.count("items.restaurant_id")
+
+        render json: {
+          handle:                     user.handle,
+          display_name:               user.display_name,
+          member_since:               user.created_at,
+          reviews_count:              user.reviews.visible.count,
+          restaurants_reviewed_count: restaurants_reviewed_count,
+          recent_reviews:             recent_reviews.map { |r| serialize_review(r) }
+        }
+      end
+
+      private
+
+      def serialize_review(review)
+        item = review.item
+        {
+          id:           review.id,
+          item: {
+            id:   item.id,
+            name: item.name,
+            restaurant: {
+              id:   item.restaurant_id,
+              slug: item.restaurant.slug,
+              name: item.restaurant.name
+            }
+          },
+          rating:     review.rating,
+          body:       review.body,
+          photo_url:  photo_url_for(review),
+          created_at: review.created_at
+        }
+      end
+
+      def photo_url_for(review)
+        return nil unless review.photo.attached?
+        host = ENV["PUBLIC_HOST"].presence || request.base_url
+        Rails.application.routes.url_helpers.rails_blob_url(review.photo, host: host)
+      end
+    end
+  end
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -66,6 +66,10 @@ Rails.application.routes.draw do
         resources :reviews, only: [:index, :create]
       end
       resources :reviews, only: [:update, :destroy]
+      # Phase 4.7 — public profile by handle. Constraint allows
+      # underscores + digits + ASCII letters (matches User#handle
+      # validation).
+      get "/users/:handle", to: "users#show", as: :user, constraints: { handle: /[A-Za-z0-9_]{3,30}/ }
       resources :ingestion_runs, only: [:create, :show] do
         resources :items, only: [:index, :update], controller: "ingestion_items"
       end

--- a/apps/api/spec/requests/api/v1/users_spec.rb
+++ b/apps/api/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/users/:handle", type: :request do
+  let(:user)       { create(:user, handle: "diner_jane", display_name: "Diner Jane") }
+  let(:restaurant) { create(:restaurant, :published, name: "Ninis Taqueria") }
+  let(:item)       { create(:item, :published, restaurant: restaurant, name: "Pollo Taco") }
+
+  it "returns the public payload — anonymously" do
+    create(:review, user: user, item: item, rating: 5, body: "Great.")
+
+    get "/api/v1/users/#{user.handle}"
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+
+    expect(body).to include(
+      "handle"       => "diner_jane",
+      "display_name" => "Diner Jane",
+      "reviews_count" => 1,
+      "restaurants_reviewed_count" => 1
+    )
+    expect(body["member_since"]).to be_present
+    expect(body["recent_reviews"].length).to eq(1)
+
+    review = body["recent_reviews"].first
+    expect(review).to include("rating" => 5, "body" => "Great.")
+    expect(review["item"]).to include(
+      "id"   => item.id,
+      "name" => "Pollo Taco"
+    )
+    expect(review["item"]["restaurant"]).to include(
+      "slug" => restaurant.slug,
+      "name" => "Ninis Taqueria"
+    )
+  end
+
+  it "never leaks sensitive fields (no email, no dietary profile, no jti)" do
+    create(:review, user: user, item: item, rating: 5)
+
+    get "/api/v1/users/#{user.handle}"
+
+    body = response.parsed_body
+    expect(body.keys).to contain_exactly(
+      "handle", "display_name", "member_since",
+      "reviews_count", "restaurants_reviewed_count", "recent_reviews"
+    )
+    serialized = response.body
+    [user.email, user.jti].each do |secret|
+      expect(serialized).not_to include(secret), "leaked #{secret}"
+    end
+  end
+
+  it "excludes hidden reviews from the count + recent list" do
+    visible = create(:review, user: user, item: item, rating: 5, body: "Loved it.")
+    hidden  = create(:review, user: user, item: create(:item, :published, restaurant: restaurant), rating: 1, body: "spam at https://x/")
+    hidden.hide!(reason: "spam")
+
+    get "/api/v1/users/#{user.handle}"
+
+    body = response.parsed_body
+    expect(body["reviews_count"]).to eq(1)
+    expect(body["restaurants_reviewed_count"]).to eq(1)
+    expect(body["recent_reviews"].map { |r| r["id"] }).to eq([visible.id])
+  end
+
+  it "caps recent_reviews at 10 (newest first)" do
+    12.times do |i|
+      r = create(:item, :published, restaurant: restaurant, name: "Item #{i}")
+      create(:review, user: user, item: r, rating: 5, created_at: i.days.ago)
+    end
+
+    get "/api/v1/users/#{user.handle}"
+
+    body = response.parsed_body
+    expect(body["recent_reviews"].length).to eq(10)
+    expect(body["reviews_count"]).to eq(12)
+  end
+
+  it "404s on an unknown handle" do
+    get "/api/v1/users/no-such-handle"
+    expect(response).to have_http_status(:not_found)
+  end
+end

--- a/apps/mobile/__tests__/lib/users.test.ts
+++ b/apps/mobile/__tests__/lib/users.test.ts
@@ -1,0 +1,49 @@
+import {
+  fetchPublicUserProfile,
+  UserProfileFetchError,
+  type PublicUserProfile,
+} from '../../lib/api/users';
+
+const samplePayload: PublicUserProfile = {
+  handle: 'diner_jane',
+  display_name: 'Diner Jane',
+  member_since: '2026-04-01T00:00:00Z',
+  reviews_count: 3,
+  restaurants_reviewed_count: 2,
+  recent_reviews: [],
+};
+
+type FetchCall = Parameters<typeof fetch>;
+type FetchMock = jest.Mock<Promise<Response>, FetchCall>;
+
+function fakeFetch(status: number, body: unknown): FetchMock {
+  return jest.fn(async (..._args: FetchCall) =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Response,
+  ) as FetchMock;
+}
+
+describe('fetchPublicUserProfile (mobile)', () => {
+  it('GETs the public user endpoint and returns the parsed payload', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    const out = await fetchPublicUserProfile('diner_jane', { fetchImpl });
+    expect(out).toEqual(samplePayload);
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain('/api/v1/users/diner_jane');
+  });
+
+  it('returns null on 404 (mirrors the web client semantics)', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'not found' });
+    const out = await fetchPublicUserProfile('ghost', { fetchImpl });
+    expect(out).toBeNull();
+  });
+
+  it('throws UserProfileFetchError on other non-2xx', async () => {
+    const fetchImpl = fakeFetch(500, { error: 'boom' });
+    await expect(fetchPublicUserProfile('diner_jane', { fetchImpl })).rejects.toBeInstanceOf(
+      UserProfileFetchError,
+    );
+  });
+});

--- a/apps/mobile/app/users/[handle].tsx
+++ b/apps/mobile/app/users/[handle].tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import {
+  fetchPublicUserProfile,
+  type PublicUserProfile,
+  type UserReview,
+} from '../../lib/api/users';
+
+/**
+ * Phase 4.7 — public user profile screen (mobile mirror of /u/[handle]).
+ * Anonymous endpoint; no auth required to view.
+ */
+export default function UserProfileScreen() {
+  const params = useLocalSearchParams<{ handle: string }>();
+  const handle = String(params.handle ?? '');
+
+  const [profile, setProfile] = useState<PublicUserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!handle) return;
+    let cancelled = false;
+    setLoading(true);
+    setNotFound(false);
+    setError(null);
+    fetchPublicUserProfile(handle)
+      .then((p) => {
+        if (cancelled) return;
+        if (p === null) setNotFound(true);
+        else setProfile(p);
+      })
+      .catch((e) => {
+        if (!cancelled) setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [handle]);
+
+  if (!handle) return <Center text="Missing handle." />;
+  if (loading) return <CenterSpinner />;
+  if (notFound) return <Center text={`No diner @${handle} found.`} />;
+  if (error) return <Center text={`Could not load profile — ${error}`} />;
+  if (!profile) return null;
+
+  const memberSince = new Date(profile.member_since).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+  });
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.eyebrow}>Diner</Text>
+      <Text style={styles.headline}>{profile.display_name ?? `@${profile.handle}`}</Text>
+      <Text style={styles.muted}>@{profile.handle} · Member since {memberSince}</Text>
+
+      <View style={styles.statsRow}>
+        <Stat label="Reviews" value={profile.reviews_count} />
+        <Stat label="Restaurants" value={profile.restaurants_reviewed_count} />
+      </View>
+
+      <Text style={styles.sectionTitle}>Recent reviews</Text>
+      {profile.recent_reviews.length === 0 ? (
+        <Text style={styles.empty}>No reviews yet.</Text>
+      ) : (
+        profile.recent_reviews.map((r) => <ReviewRow key={r.id} review={r} />)
+      )}
+    </ScrollView>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <View style={styles.stat}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+function ReviewRow({ review }: { review: UserReview }) {
+  return (
+    <Pressable
+      accessibilityLabel={`open-item-${review.item.id}`}
+      onPress={() =>
+        router.push({
+          pathname: '/items/[id]',
+          params: { id: review.item.id, itemName: review.item.name },
+        })
+      }
+      style={styles.reviewRow}
+      testID={`review-${review.id}`}
+    >
+      <Text style={styles.reviewMeta}>
+        <Text style={styles.reviewStars}>{'★'.repeat(review.rating)}{'☆'.repeat(5 - review.rating)}</Text>
+        {' on '}
+        <Text style={styles.reviewItem}>{review.item.name}</Text>
+        <Text style={styles.reviewWhere}> at {review.item.restaurant.name}</Text>
+      </Text>
+      {review.body ? <Text style={styles.reviewBody}>{review.body}</Text> : null}
+      {review.photo_url ? (
+        <Image source={{ uri: review.photo_url }} style={styles.reviewPhoto} accessibilityLabel="review-photo" />
+      ) : null}
+    </Pressable>
+  );
+}
+
+function Center({ text }: { text: string }) {
+  return (
+    <View style={styles.center}>
+      <Text style={styles.body}>{text}</Text>
+    </View>
+  );
+}
+
+function CenterSpinner() {
+  return (
+    <View style={styles.center} testID="profile-loading">
+      <ActivityIndicator size="large" color={colors.bite} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bg },
+  content: { paddingTop: 60, paddingHorizontal: space['6'], paddingBottom: space['12'], gap: space['3'] },
+  center: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: space['6'],
+  },
+  eyebrow: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  headline: { fontSize: fontSize['2xl'], fontWeight: '700', color: colors.text },
+  muted: { fontSize: fontSize.sm, color: colors.textMuted },
+  body: { fontSize: fontSize.base, color: colors.text },
+  empty: { color: colors.textMuted, fontSize: fontSize.base, paddingVertical: space['4'], textAlign: 'center' },
+  statsRow: { flexDirection: 'row', gap: space['3'], marginTop: space['3'] },
+  stat: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: space['3'],
+    paddingVertical: space['2'],
+  },
+  statLabel: { color: colors.textMuted, fontSize: fontSize.xs, textTransform: 'uppercase', letterSpacing: 1 },
+  statValue: { color: colors.text, fontSize: fontSize.xl, fontWeight: '700', marginTop: 4 },
+  sectionTitle: { fontSize: fontSize.lg, fontWeight: '700', color: colors.text, marginTop: space['4'] },
+  reviewRow: { paddingVertical: space['3'], borderBottomWidth: 1, borderBottomColor: colors.border },
+  reviewMeta: { fontSize: fontSize.sm, color: colors.text },
+  reviewStars: { color: colors.bite, fontWeight: '700' },
+  reviewItem: { fontWeight: '700', color: colors.text },
+  reviewWhere: { color: colors.textMuted },
+  reviewBody: { fontSize: fontSize.base, color: colors.text, marginTop: 4 },
+  reviewPhoto: { marginTop: space['2'], width: '100%', height: 180, borderRadius: 12, backgroundColor: colors.bgAlt },
+});

--- a/apps/mobile/lib/api/users.ts
+++ b/apps/mobile/lib/api/users.ts
@@ -1,0 +1,55 @@
+/**
+ * Phase 4.7 — public user profile fetcher (mobile).
+ *
+ * Anonymous endpoint, no JWT needed. Mirrors apps/web/src/lib/users.ts.
+ */
+const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export interface UserReviewItem {
+  id: string;
+  name: string;
+  restaurant: { id: string; slug: string; name: string };
+}
+
+export interface UserReview {
+  id: string;
+  item: UserReviewItem;
+  rating: number;
+  body: string | null;
+  photo_url: string | null;
+  created_at: string;
+}
+
+export interface PublicUserProfile {
+  handle: string;
+  display_name: string | null;
+  member_since: string;
+  reviews_count: number;
+  restaurants_reviewed_count: number;
+  recent_reviews: UserReview[];
+}
+
+export class UserProfileFetchError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'UserProfileFetchError';
+  }
+}
+
+export interface FetchOptions {
+  fetchImpl?: typeof fetch;
+}
+
+export async function fetchPublicUserProfile(
+  handle: string,
+  opts: FetchOptions = {},
+): Promise<PublicUserProfile | null> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/users/${encodeURIComponent(handle)}`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new UserProfileFetchError(res.status, `fetchPublicUserProfile ${handle} failed: ${res.status}`);
+  return (await res.json()) as PublicUserProfile;
+}

--- a/apps/web/src/app/u/[handle]/page.tsx
+++ b/apps/web/src/app/u/[handle]/page.tsx
@@ -1,0 +1,96 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { fetchPublicUserProfile, type UserReview } from '../../../lib/users';
+
+/**
+ * Phase 4.7 — public user profile at `/u/<handle>`.
+ *
+ * Server-rendered for SEO and so external links (e.g. shared review
+ * cards) work even when the recipient isn't signed in. The endpoint
+ * returns a public-only payload (no email, no dietary profile).
+ *
+ * Future Phase 4.X tabs (history, claimed restaurants) hang off the
+ * same handle.
+ */
+type Params = { handle: string };
+
+export default async function UserProfilePage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { handle } = await params;
+  const profile = await fetchPublicUserProfile(handle);
+  if (!profile) notFound();
+
+  const memberSince = new Date(profile.member_since).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+  });
+
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 py-bw-12">
+      <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">Diner</p>
+      <h1 className="mt-bw-2 text-bw-3xl font-bold">
+        {profile.display_name ?? `@${profile.handle}`}
+      </h1>
+      <p className="mt-1 text-bw-sm text-zinc-500">@{profile.handle} · Member since {memberSince}</p>
+
+      <dl className="mt-bw-4 grid grid-cols-2 gap-bw-3 sm:grid-cols-3">
+        <Stat label="Reviews" value={profile.reviews_count} />
+        <Stat label="Restaurants reviewed" value={profile.restaurants_reviewed_count} />
+      </dl>
+
+      <h2 className="mt-bw-6 text-bw-lg font-bold">Recent reviews</h2>
+      <ul className="mt-bw-3 divide-y divide-zinc-100">
+        {profile.recent_reviews.map((r) => (
+          <ReviewRow key={r.id} review={r} />
+        ))}
+        {profile.recent_reviews.length === 0 && (
+          <li className="py-bw-6 text-center text-bw-sm text-zinc-500">
+            No reviews yet.
+          </li>
+        )}
+      </ul>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-bw-md border border-zinc-200 px-bw-3 py-bw-2">
+      <dt className="text-bw-xs uppercase tracking-wider text-zinc-500">{label}</dt>
+      <dd className="mt-1 text-bw-xl font-bold text-zinc-900">{value}</dd>
+    </div>
+  );
+}
+
+function ReviewRow({ review }: { review: UserReview }) {
+  return (
+    <li className="py-bw-3" data-testid={`review-${review.id}`}>
+      <p className="text-bw-sm font-semibold text-zinc-700">
+        <span className="text-bite">
+          {'★'.repeat(review.rating)}
+          <span className="text-zinc-300">{'☆'.repeat(5 - review.rating)}</span>
+        </span>{' '}
+        on{' '}
+        <Link
+          href={`/restaurants/${encodeURIComponent(review.item.restaurant.slug)}/items/${encodeURIComponent(review.item.id)}`}
+          className="font-bold text-zinc-900 hover:text-bite-dark"
+        >
+          {review.item.name}
+        </Link>{' '}
+        <span className="text-zinc-500">at {review.item.restaurant.name}</span>
+      </p>
+      {review.body && <p className="mt-1 text-bw-base text-zinc-700">{review.body}</p>}
+      {review.photo_url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={review.photo_url}
+          alt="Reviewer's photo"
+          className="mt-bw-2 max-h-64 w-full rounded-bw-md object-cover"
+        />
+      )}
+    </li>
+  );
+}

--- a/apps/web/src/lib/__tests__/users.test.ts
+++ b/apps/web/src/lib/__tests__/users.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchPublicUserProfile, type PublicUserProfile } from '../users';
+
+const samplePayload: PublicUserProfile = {
+  handle: 'diner_jane',
+  display_name: 'Diner Jane',
+  member_since: '2026-04-01T00:00:00Z',
+  reviews_count: 3,
+  restaurants_reviewed_count: 2,
+  recent_reviews: [],
+};
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'NOT FOUND',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+describe('fetchPublicUserProfile', () => {
+  it('GETs /api/v1/users/:handle and returns the parsed payload', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    const out = await fetchPublicUserProfile('diner_jane', { fetchImpl });
+    expect(out).toEqual(samplePayload);
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain('/api/v1/users/diner_jane');
+  });
+
+  it('returns null on 404 (so SSR can call notFound())', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'not found' });
+    const out = await fetchPublicUserProfile('ghost', { fetchImpl });
+    expect(out).toBeNull();
+  });
+
+  it('throws on other non-2xx', async () => {
+    const fetchImpl = fakeFetch(500, { error: 'boom' });
+    await expect(fetchPublicUserProfile('diner_jane', { fetchImpl })).rejects.toThrow(/500/);
+  });
+
+  it('URL-encodes handles that contain reserved chars (defense-in-depth)', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    await fetchPublicUserProfile('a/b', { fetchImpl });
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain('/api/v1/users/a%2Fb');
+  });
+});

--- a/apps/web/src/lib/users.ts
+++ b/apps/web/src/lib/users.ts
@@ -1,0 +1,52 @@
+/**
+ * Phase 4.7 — public user profile fetcher.
+ *
+ * Anonymous endpoint (no auth header), so this is safe to call from
+ * SSR pages without `getServerJwt`.
+ */
+import { api, type ApiOptions } from './api';
+
+export interface UserReviewItem {
+  id: string;
+  name: string;
+  restaurant: { id: string; slug: string; name: string };
+}
+
+export interface UserReview {
+  id: string;
+  item: UserReviewItem;
+  rating: number;
+  body: string | null;
+  photo_url: string | null;
+  created_at: string;
+}
+
+export interface PublicUserProfile {
+  handle: string;
+  display_name: string | null;
+  member_since: string;
+  reviews_count: number;
+  restaurants_reviewed_count: number;
+  recent_reviews: UserReview[];
+}
+
+export class UserProfileNotFoundError extends Error {
+  constructor(handle: string) {
+    super(`User profile not found: ${handle}`);
+    this.name = 'UserProfileNotFoundError';
+  }
+}
+
+export async function fetchPublicUserProfile(
+  handle: string,
+  opts: ApiOptions = {},
+): Promise<PublicUserProfile | null> {
+  try {
+    return await api<PublicUserProfile>(`/users/${encodeURIComponent(handle)}`, opts);
+  } catch (e) {
+    // The api() helper throws on non-2xx with a message containing
+    // the status. Surface 404 as null so SSR can call notFound().
+    if ((e as Error).message.includes('404')) return null;
+    throw e;
+  }
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,15 +13,12 @@ the merge / review / status rules.
 
 **Phase 4** ⭐ Reviews + accounts. Subplan: `docs/plans/phase-4.md`.
 
-1. **Phase 4.6 — Review moderation queue (Avo)** (`docs/plans/phase-4.md#46`) — this PR
-3. **Phase 4.3 — Review API + photo attachment** (`docs/plans/phase-4.md#43`)
-4. **Phase 4.4 — Mobile review UX** (`docs/plans/phase-4.md#44`)
-5. **Phase 4.5 — Web review UX** (`docs/plans/phase-4.md#45`)
-6. **Phase 4.6 — Review moderation queue (Avo)** (`docs/plans/phase-4.md#46`)
-7. **Phase 4.7 — User profile pages** (`docs/plans/phase-4.md#47`)
-8. **Phase 4.8 — "My filtered menus" history** (`docs/plans/phase-4.md#48`)
-9. **Phase 4.9 — Restaurant claim flow (domain-email verification)** (`docs/plans/phase-4.md#49`)
-10. **Phase 4.10 — Suggestion queue UX (community edits)** (`docs/plans/phase-4.md#410`)
+1. **Phase 4.7 — User profile pages** (`docs/plans/phase-4.md#47`) — this PR
+2. **Phase 4.8 — "My filtered menus" history** (`docs/plans/phase-4.md#48`)
+3. **Phase 4.9 — Restaurant claim flow (domain-email verification)** (`docs/plans/phase-4.md#49`)
+4. **Phase 4.10 — Suggestion queue UX (community edits)** (`docs/plans/phase-4.md#410`)
+
+After Phase 4 ships, the loop will draft `docs/plans/phase-4.11-dish-photos.md` (per-dish photo extraction from menu pages — user-requested followup) before moving to Phase 5.
 
 ### Done
 
@@ -59,6 +56,7 @@ the merge / review / status rules.
 - ✅ Phase 4.3 — review API + photo attachment (#158)
 - ✅ Phase 4.4 — mobile review UX (#159)
 - ✅ Phase 4.5 — web review UX (#160)
+- ✅ Phase 4.6 — review moderation queue (#161)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,36 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 12:00 — tick #67. PR #161 (Phase 4.6) merged at 11:49 UTC.
+**Cassette PR blocked**: started the cassette work (planned for this
+tick at user request), converted IMG_6973.HEIC → JPEG, dropped at
+spec/fixtures/menus/sample.jpg, replaced the skip block with a real
+VCR.use_cassette around ExtractMenuJob.perform_now. Recording
+attempt failed with HTTP 400: "You have reached your specified API
+usage limits. You will regain access on 2026-05-01 at 00:00 UTC."
+Per playbook §7 (secrets the loop doesn't have / blocked), rolled
+back the local edits + reported to user; can retry after the cap
+resets. Pivoted to Phase 4.7 — user profile pages — since it has
+no Anthropic dependency. New `GET /api/v1/users/:handle` returns
+the public payload (handle, display_name, member_since,
+reviews_count, restaurants_reviewed_count, recent_reviews[10]
+with item + restaurant context). Sensitive fields explicitly
+excluded; one rspec asserts the response keys are exactly the
+allowed set AND that user.email + user.jti don't appear anywhere
+in the response body. Hidden reviews drop out via the same
+.visible scope from 4.6. Web: server-rendered `/u/[handle]/page.tsx`
+with stat cards + recent-reviews list linking to
+/restaurants/<slug>/items/<id>. Mobile: `/users/[handle].tsx`
+mirror with the same structure; review rows push to /items/[id]
+via the typed router.push. Tests: 5 rspec (public payload, no
+PII leak, hidden-review exclusion, 10-cap newest-first, 404 on
+unknown handle); 4 vitest for the web client; 3 jest for the
+mobile client. Roadmap: cleaned up duplicated Next-up entries
+(stale items from earlier ticks), added a note that Phase 4.11
+dish-photo subplan drafts after Phase 4.10. Local: rspec 254/0/1
+pending; web vitest 45/45; mobile jest 53/53; pnpm typecheck/lint
+cached green.
+
 2026-05-01 11:30 — tick #66. PR #160 (Phase 4.5) merged at 11:18 UTC.
 Picked up Phase 4.6 — review moderation queue. New migration adds
 `hidden_at` + `hidden_reason` + `flagged_at` columns to reviews


### PR DESCRIPTION
## Summary

Phase 4.7 ships the `/u/<handle>` profile pages on web + mobile. Public, anonymous, server-rendered for SEO. Subplan: `docs/plans/phase-4.md#47`.

### API
- New `GET /api/v1/users/:handle`. Public payload only — `handle`, `display_name`, `member_since`, `reviews_count`, `restaurants_reviewed_count`, `recent_reviews[10]` with item + restaurant context.
- **No PII**: email, profile, overrides, jti, sign-in timestamps are intentionally absent. A spec asserts the response keys are exactly the allowed set AND that `user.email` + `user.jti` strings don't appear anywhere in the response body.
- Hidden reviews drop out via the `.visible` scope from Phase 4.6.
- Route constraint matches `User#handle` validation (3–30 chars, ASCII letters / digits / underscores).

### Web
- `/u/[handle]/page.tsx` — server-rendered with stat cards + recent-reviews list. Each review links to `/restaurants/<slug>/items/<id>`.
- `apps/web/src/lib/users.ts` — anonymous fetcher; returns `null` on 404 so SSR can call `notFound()`.

### Mobile
- `/users/[handle].tsx` mirror screen. Review rows push to `/items/[id]` via the typed `router.push`.
- `apps/mobile/lib/api/users.ts` — same null-on-404 semantics.

## Heads-up on this tick's scope

This tick was originally planned as the **cassette PR** for `ExtractMenuJob` (per the user's prior redirect). Recording attempt hit the Anthropic API daily cap:

> "You have reached your specified API usage limits. You will regain access on 2026-05-01 at 00:00 UTC."

Per playbook §7 (blocked on a missing secret / external availability), I rolled back the local cassette work and pivoted here so the tick produced something. Will retry the cassette PR once the cap resets — single rspec invocation, then commit the cassette YAML.

## Out of scope
- Edit-my-review UI on the profile page — the user only sees their own reviews; the edit affordance can land with Phase 4.X if needed.
- Following / followers — explicitly out of v1.
- Profile edit (display name / handle) — defer until we have a user-settings page.
- UI render test — same `jest-expo` / `@testing-library/react` Discovered followup.

## Test plan
- [x] **rspec** 254/0/1 pending — 5 new (public payload, no-PII-leak, hidden-review exclusion, 10-cap newest-first, 404 unknown handle).
- [x] **Web vitest** 45/45 (4 new for the API client).
- [x] **Mobile jest** 53/53 (3 new for the mobile API client).
- [x] `pnpm typecheck` / `pnpm lint` cached green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)