### PR TITLE
feat(api,web,mobile): "My filtered menus" history (phase 4.8)

### DIFF
--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -35,6 +35,11 @@ module Api
         review_counts = review_counts_for(items)
         rendered      = items.map { |item| serialize_item(item, filter, labels, override_ids, review_counts) }
 
+        # Phase 4.8 — record an authenticated user's visit to this
+        # restaurant for the History tab. Best-effort, async, never
+        # blocks the response.
+        record_visit_for_history(restaurant, rendered) if current_user
+
         render json: {
           restaurant_id: restaurant.id,
           filter: filter_summary(filter),
@@ -184,6 +189,22 @@ module Api
         ids = items.map(&:id)
         return {} if ids.empty?
         Review.visible.where(item_id: ids).group(:item_id).count
+      end
+
+      # Phase 4.8 — fire-and-forget enqueue. Never raises into the
+      # request even if SolidQueue is briefly unhealthy.
+      def record_visit_for_history(restaurant, rendered_items)
+        visible_count = rendered_items.count { |i| i[:status] == "visible" }
+        hidden_count  = rendered_items.size - visible_count
+        RecordRestaurantVisitJob.perform_later(
+          current_user.id,
+          restaurant.id,
+          visible_count,
+          hidden_count,
+          Date.current.iso8601
+        )
+      rescue StandardError => e
+        Rails.logger.warn("RecordRestaurantVisitJob enqueue failed: #{e.class} #{e.message}")
       end
 
       # Phase 4.2 — bulk-load the authenticated user's "never hide"

--- a/apps/api/app/controllers/api/v1/profile_history_controller.rb
+++ b/apps/api/app/controllers/api/v1/profile_history_controller.rb
@@ -1,0 +1,52 @@
+module Api
+  module V1
+    # Phase 4.8 — GET /api/v1/profile/history.
+    #
+    # The user's recent restaurant visits, newest-first. One row per
+    # (user, restaurant, day) — see RecordRestaurantVisitJob. Each
+    # entry carries the visible/hidden item counts AT VIEW TIME (the
+    # last visit of that day), so a user can see "what I saw" without
+    # re-running the filter against current data.
+    #
+    # Authenticated only — this is private history.
+    class ProfileHistoryController < BaseController
+      DEFAULT_LIMIT = 30
+      MAX_LIMIT     = 100
+
+      def index
+        limit  = (params[:limit].presence  || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
+        offset = (params[:offset].presence || 0).to_i.clamp(0, 10_000)
+
+        scope = current_user.restaurant_visits
+                            .newest_first
+                            .includes(restaurant: :city)
+                            .offset(offset)
+                            .limit(limit)
+
+        render json: {
+          visits: scope.map { |v| serialize(v) },
+          total:  current_user.restaurant_visits.count
+        }
+      end
+
+      private
+
+      def serialize(visit)
+        r = visit.restaurant
+        {
+          id:                  visit.id,
+          viewed_on:           visit.viewed_on,
+          updated_at:          visit.updated_at,
+          items_visible_count: visit.items_visible_count,
+          items_hidden_count:  visit.items_hidden_count,
+          restaurant: {
+            id:   r.id,
+            slug: r.slug,
+            name: r.name,
+            city: { slug: r.city.slug, name: r.city.name, region: r.city.region }
+          }
+        }
+      end
+    end
+  end
+end

--- a/apps/api/app/jobs/record_restaurant_visit_job.rb
+++ b/apps/api/app/jobs/record_restaurant_visit_job.rb
@@ -1,0 +1,37 @@
+# Phase 4.8 — record a "user opened this restaurant today" row.
+#
+# Enqueued (best-effort, fire-and-forget) by the items endpoint when
+# an authenticated user fetches a restaurant's menu. The job upserts
+# one row per (user, restaurant, day) — the unique index in the
+# migration makes that race-safe.
+#
+# Counts reflect the LAST visit of the day (overwrite, not sum). Fine
+# for the use case ("see what I saw"). The history list reads from
+# this table; nothing else does.
+#
+# Failure semantics: this is best-effort telemetry. If the enqueue
+# fails or the job raises, swallow it — we never want to leak a
+# request error because we couldn't record a visit.
+class RecordRestaurantVisitJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id, restaurant_id, items_visible_count, items_hidden_count, viewed_on_iso = nil)
+    viewed_on = viewed_on_iso ? Date.iso8601(viewed_on_iso) : Date.current
+
+    visit = RestaurantVisit.find_or_initialize_by(
+      user_id: user_id,
+      restaurant_id: restaurant_id,
+      viewed_on: viewed_on
+    )
+    visit.items_visible_count = items_visible_count
+    visit.items_hidden_count  = items_hidden_count
+    visit.save!
+  rescue ActiveRecord::RecordNotUnique
+    # Lost the upsert race with another worker — retry once and let
+    # find_or_initialize_by find the row this time.
+    retry
+  rescue ActiveRecord::InvalidForeignKey
+    # User or restaurant deleted between request + job execution.
+    # Best-effort: drop silently.
+  end
+end

--- a/apps/api/app/models/restaurant_visit.rb
+++ b/apps/api/app/models/restaurant_visit.rb
@@ -1,0 +1,13 @@
+class RestaurantVisit < ApplicationRecord
+  # Phase 4.8 — "My filtered menus" history.
+  # One row per (user, restaurant, day). RecordRestaurantVisitJob
+  # upserts; the controller never touches this table directly.
+
+  belongs_to :user
+  belongs_to :restaurant
+
+  validates :viewed_on, presence: true
+  validates :user_id, uniqueness: { scope: [:restaurant_id, :viewed_on] }
+
+  scope :newest_first, -> { order(updated_at: :desc) }
+end

--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   has_many :suggestions, dependent: :nullify
   has_many :user_item_overrides, dependent: :destroy
   has_many :overridden_items, through: :user_item_overrides, source: :item
+  has_many :restaurant_visits, dependent: :destroy
 
   validates :handle, presence: true, uniqueness: true,
                      format: { with: /\A[a-z0-9_]{3,30}\z/i }

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -50,7 +50,11 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resource :profile, only: [:show, :update]
+      resource :profile, only: [:show, :update] do
+        # Phase 4.8 — "My filtered menus" history (recent restaurant
+        # visits with the visible/hidden item counts at view time).
+        get :history, to: "profile_history#index"
+      end
       resources :cities, only: [:index, :show]
       resources :restaurants, only: [:index, :show] do
         resources :items, only: [:index, :show]

--- a/apps/api/db/migrate/20260430124229_create_restaurant_visits.rb
+++ b/apps/api/db/migrate/20260430124229_create_restaurant_visits.rb
@@ -1,0 +1,30 @@
+class CreateRestaurantVisits < ActiveRecord::Migration[8.1]
+  # Phase 4.8 — "My filtered menus" history.
+  #
+  # One row per (user, restaurant, day). The unique index makes the
+  # visit-recording job an upsert with no race-condition risk — a
+  # user reloading the same restaurant five times in a day produces
+  # a single row with the latest counts.
+  #
+  # Counts are denormalized so the History list renders without
+  # touching items/reviews (cheap, bounded query). They reflect the
+  # LAST visit's state per day, not an average — fine for the use
+  # case ("see what I saw").
+  def change
+    create_table :restaurant_visits, id: :uuid do |t|
+      t.references :user,       type: :uuid, null: false, foreign_key: true
+      t.references :restaurant, type: :uuid, null: false, foreign_key: true
+      t.date       :viewed_on,  null: false
+      t.integer    :items_visible_count, null: false, default: 0
+      t.integer    :items_hidden_count,  null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :restaurant_visits, [:user_id, :restaurant_id, :viewed_on], unique: true,
+              name: "idx_restaurant_visits_user_restaurant_day"
+    # History list reads "the user's recent visits" — a per-user index
+    # over updated_at lets us page newest-first without a sort.
+    add_index :restaurant_visits, [:user_id, :updated_at], order: { updated_at: :desc },
+              name: "idx_restaurant_visits_user_recent"
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_114231) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_124229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -260,6 +260,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_114231) do
     t.index ["restaurant_id"], name: "index_menus_on_restaurant_id"
   end
 
+  create_table "restaurant_visits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "items_hidden_count", default: 0, null: false
+    t.integer "items_visible_count", default: 0, null: false
+    t.uuid "restaurant_id", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.date "viewed_on", null: false
+    t.index ["restaurant_id"], name: "index_restaurant_visits_on_restaurant_id"
+    t.index ["user_id", "restaurant_id", "viewed_on"], name: "idx_restaurant_visits_user_restaurant_day", unique: true
+    t.index ["user_id", "updated_at"], name: "idx_restaurant_visits_user_recent", order: { updated_at: :desc }
+    t.index ["user_id"], name: "index_restaurant_visits_on_user_id"
+  end
+
   create_table "restaurants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "about"
     t.uuid "city_id", null: false
@@ -408,6 +422,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_114231) do
   add_foreign_key "items", "users", column: "created_by_user_id"
   add_foreign_key "menu_sections", "menus"
   add_foreign_key "menus", "restaurants"
+  add_foreign_key "restaurant_visits", "restaurants"
+  add_foreign_key "restaurant_visits", "users"
   add_foreign_key "restaurants", "cities"
   add_foreign_key "restaurants", "users", column: "claimed_by_user_id"
   add_foreign_key "reviews", "items"

--- a/apps/api/spec/factories/restaurant_visits.rb
+++ b/apps/api/spec/factories/restaurant_visits.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :restaurant_visit do
+    user
+    restaurant
+    viewed_on { Date.current }
+    items_visible_count { 5 }
+    items_hidden_count  { 2 }
+  end
+end

--- a/apps/api/spec/jobs/record_restaurant_visit_job_spec.rb
+++ b/apps/api/spec/jobs/record_restaurant_visit_job_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe RecordRestaurantVisitJob, type: :job do
+  let(:user)       { create(:user) }
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:today)      { Date.current.iso8601 }
+
+  it "creates a visit row with the given counts" do
+    expect {
+      described_class.perform_now(user.id, restaurant.id, 5, 2, today)
+    }.to change(RestaurantVisit, :count).by(1)
+
+    visit = RestaurantVisit.last
+    expect(visit.user_id).to eq(user.id)
+    expect(visit.restaurant_id).to eq(restaurant.id)
+    expect(visit.viewed_on).to eq(Date.current)
+    expect(visit.items_visible_count).to eq(5)
+    expect(visit.items_hidden_count).to eq(2)
+  end
+
+  it "upserts the same (user, restaurant, day) instead of duplicating" do
+    described_class.perform_now(user.id, restaurant.id, 5, 2, today)
+    expect {
+      described_class.perform_now(user.id, restaurant.id, 7, 1, today)
+    }.not_to change(RestaurantVisit, :count)
+
+    visit = RestaurantVisit.last
+    expect(visit.items_visible_count).to eq(7) # latest counts win
+    expect(visit.items_hidden_count).to eq(1)
+  end
+
+  it "creates separate rows for the same restaurant on different days" do
+    yesterday = (Date.current - 1).iso8601
+    described_class.perform_now(user.id, restaurant.id, 1, 0, yesterday)
+    expect {
+      described_class.perform_now(user.id, restaurant.id, 2, 0, today)
+    }.to change(RestaurantVisit, :count).by(1)
+  end
+
+  it "swallows InvalidForeignKey when the restaurant was deleted between request + perform" do
+    bogus_id = SecureRandom.uuid
+    expect {
+      described_class.perform_now(user.id, bogus_id, 1, 0, today)
+    }.not_to raise_error
+    expect(RestaurantVisit.count).to eq(0)
+  end
+
+  it "defaults viewed_on to today when no iso string is supplied" do
+    described_class.perform_now(user.id, restaurant.id, 3, 1)
+    expect(RestaurantVisit.last.viewed_on).to eq(Date.current)
+  end
+end

--- a/apps/api/spec/requests/api/v1/profile_history_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_history_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/profile/history", type: :request do
+  let(:user)    { create(:user) }
+  let(:headers) { auth_headers_for(user) }
+
+  let(:durango)        { create(:city, slug: "durango") }
+  let(:r1)             { create(:restaurant, :published, city: durango, name: "Ninis Taqueria") }
+  let(:r2)             { create(:restaurant, :published, city: durango, name: "Cream Bean Berry") }
+
+  it "401s anonymously" do
+    get "/api/v1/profile/history"
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns visits newest-first with restaurant + city + counts" do
+    create(:restaurant_visit, user: user, restaurant: r1, viewed_on: 2.days.ago.to_date,
+           items_visible_count: 3, items_hidden_count: 1, updated_at: 2.days.ago)
+    create(:restaurant_visit, user: user, restaurant: r2, viewed_on: 1.day.ago.to_date,
+           items_visible_count: 8, items_hidden_count: 0, updated_at: 1.day.ago)
+
+    get "/api/v1/profile/history", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+    expect(body["total"]).to eq(2)
+    names = body["visits"].map { |v| v["restaurant"]["name"] }
+    expect(names).to eq(["Cream Bean Berry", "Ninis Taqueria"])
+
+    first = body["visits"].first
+    expect(first).to include(
+      "items_visible_count" => 8,
+      "items_hidden_count"  => 0
+    )
+    expect(first["restaurant"]).to include(
+      "slug" => r2.slug,
+      "name" => "Cream Bean Berry"
+    )
+    expect(first["restaurant"]["city"]).to include(
+      "slug" => "durango", "name" => "Durango", "region" => "CO"
+    )
+  end
+
+  it "respects limit + offset" do
+    3.times do |i|
+      create(:restaurant_visit, user: user, restaurant: r1,
+             viewed_on: i.days.ago.to_date, updated_at: i.days.ago)
+    end
+
+    get "/api/v1/profile/history?limit=1&offset=1", headers: headers
+    expect(response.parsed_body["visits"].length).to eq(1)
+    expect(response.parsed_body["total"]).to eq(3)
+  end
+
+  it "scopes to the current user (no leak across users)" do
+    create(:restaurant_visit, user: user, restaurant: r1)
+    create(:restaurant_visit, user: create(:user), restaurant: r2)
+
+    get "/api/v1/profile/history", headers: headers
+    expect(response.parsed_body["total"]).to eq(1)
+  end
+end

--- a/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
@@ -318,6 +318,33 @@ RSpec.describe "GET /api/v1/restaurants/:id/items", type: :request do
     end
   end
 
+  describe "history-recording side effect (Phase 4.8)" do
+    let(:visitor) { create(:user) }
+    let(:visitor_headers) { auth_headers_for(visitor) }
+
+    it "enqueues RecordRestaurantVisitJob with visible/hidden counts when authenticated" do
+      expect(RecordRestaurantVisitJob).to receive(:perform_later).with(
+        visitor.id, restaurant.id, kind_of(Integer), kind_of(Integer), kind_of(String)
+      )
+
+      get "/api/v1/restaurants/#{restaurant.id}/items", headers: visitor_headers
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does NOT enqueue for anonymous callers" do
+      expect(RecordRestaurantVisitJob).not_to receive(:perform_later)
+      get "/api/v1/restaurants/#{restaurant.id}/items"
+    end
+
+    it "swallows enqueue failures so the response still 200s" do
+      allow(RecordRestaurantVisitJob).to receive(:perform_later)
+        .and_raise(RuntimeError, "queue down")
+
+      get "/api/v1/restaurants/#{restaurant.id}/items", headers: visitor_headers
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "404 cases" do
     it "404s on a non-existent restaurant" do
       get "/api/v1/restaurants/00000000-0000-0000-0000-000000000000/items"

--- a/apps/mobile/__tests__/lib/history.test.ts
+++ b/apps/mobile/__tests__/lib/history.test.ts
@@ -1,0 +1,63 @@
+import {
+  fetchHistory,
+  HistoryError,
+  type HistoryResponse,
+} from '../../lib/api/history';
+
+const samplePayload: HistoryResponse = {
+  total: 1,
+  visits: [
+    {
+      id: 'v1',
+      viewed_on: '2026-04-30',
+      updated_at: '2026-04-30T12:00:00Z',
+      items_visible_count: 5,
+      items_hidden_count: 1,
+      restaurant: {
+        id: 'rest-1',
+        slug: 'cream-bean-berry-1',
+        name: 'Cream, Bean & Berry',
+        city: { slug: 'durango', name: 'Durango', region: 'CO' },
+      },
+    },
+  ],
+};
+
+type FetchCall = Parameters<typeof fetch>;
+type FetchMock = jest.Mock<Promise<Response>, FetchCall>;
+
+function fakeFetch(status: number, body: unknown): FetchMock {
+  return jest.fn(async (..._args: FetchCall) =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Response,
+  ) as FetchMock;
+}
+
+describe('fetchHistory (mobile)', () => {
+  it('GETs the API endpoint with Bearer JWT', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    const out = await fetchHistory('jjj.www.ttt', { fetchImpl });
+    expect(out.total).toBe(1);
+
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toContain('/api/v1/profile/history');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jjj.www.ttt');
+  });
+
+  it('passes limit + offset query params when supplied', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    await fetchHistory('jwt', { fetchImpl, limit: 10, offset: 20 });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('limit=10');
+    expect(url).toContain('offset=20');
+  });
+
+  it('throws HistoryError on 401 so the screen can bounce to /login', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'unauth' });
+    await expect(fetchHistory('bad', { fetchImpl })).rejects.toBeInstanceOf(HistoryError);
+  });
+});

--- a/apps/mobile/app/history.tsx
+++ b/apps/mobile/app/history.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { router } from 'expo-router';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import {
+  fetchHistory,
+  HistoryError,
+  type HistoryVisit,
+} from '../lib/api/history';
+import { getJwt } from '../lib/auth';
+
+/**
+ * Phase 4.8 — "My filtered menus" history (mobile).
+ *
+ * Authenticated. Bounces to /login if the keychain has no JWT or
+ * the API returns 401.
+ */
+export default function HistoryScreen() {
+  const [visits, setVisits] = useState<HistoryVisit[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const jwt = await getJwt();
+      if (!jwt) {
+        router.replace('/login?next=%2Fhistory');
+        return;
+      }
+      try {
+        const res = await fetchHistory(jwt);
+        if (cancelled) return;
+        setVisits(res.visits);
+        setTotal(res.total);
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof HistoryError && e.status === 401) {
+          router.replace('/login?next=%2Fhistory');
+          return;
+        }
+        setError((e as Error).message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.center} testID="history-loading">
+        <ActivityIndicator size="large" color={colors.bite} />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.eyebrow}>My history</Text>
+      <Text style={styles.headline}>Recent menus you've filtered</Text>
+      <Text style={styles.summary}>
+        {total === 0 ? "You haven't browsed any restaurants yet." : `${total} visit${total === 1 ? '' : 's'} on record.`}
+      </Text>
+
+      {error && <Text style={styles.error}>{error}</Text>}
+
+      {visits.map((v) => (
+        <VisitRow key={v.id} visit={v} />
+      ))}
+    </ScrollView>
+  );
+}
+
+function VisitRow({ visit }: { visit: HistoryVisit }) {
+  const when = new Date(visit.viewed_on).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+  return (
+    <Pressable
+      accessibilityLabel={`open-restaurant-${visit.restaurant.id}`}
+      onPress={() =>
+        router.push({
+          pathname: '/restaurants/[id]',
+          params: { id: visit.restaurant.id },
+        })
+      }
+      style={styles.row}
+      testID={`visit-${visit.id}`}
+    >
+      <Text style={styles.rowName}>{visit.restaurant.name}</Text>
+      <Text style={styles.rowMeta}>
+        {when} · {visit.restaurant.city.name}, {visit.restaurant.city.region}
+      </Text>
+      <Text style={styles.rowSummary}>
+        Saw <Text style={styles.bold}>{visit.items_visible_count}</Text> item
+        {visit.items_visible_count === 1 ? '' : 's'}
+        {visit.items_hidden_count > 0 ? `, hiding ${visit.items_hidden_count}.` : '.'}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bg },
+  content: { paddingTop: 60, paddingHorizontal: space['6'], paddingBottom: space['12'], gap: space['3'] },
+  center: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: space['6'],
+  },
+  eyebrow: {
+    color: colors.bite,
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  headline: { fontSize: fontSize['2xl'], fontWeight: '700', color: colors.text },
+  summary: { fontSize: fontSize.base, color: colors.text },
+  error: {
+    backgroundColor: colors.biteLight,
+    color: colors.biteDark,
+    padding: space['3'],
+    borderRadius: 8,
+    fontSize: fontSize.sm,
+  },
+  row: { paddingVertical: space['3'], borderBottomWidth: 1, borderBottomColor: colors.border },
+  rowName: { fontSize: fontSize.lg, fontWeight: '700', color: colors.text },
+  rowMeta: { marginTop: 2, fontSize: fontSize.sm, color: colors.textMuted },
+  rowSummary: { marginTop: 4, fontSize: fontSize.sm, color: colors.text },
+  bold: { fontWeight: '700' },
+});

--- a/apps/mobile/lib/api/history.ts
+++ b/apps/mobile/lib/api/history.ts
@@ -1,0 +1,64 @@
+/**
+ * Phase 4.8 — fetch the authenticated user's recent restaurant visits.
+ * Mirrors apps/web/src/lib/history.ts; mobile uses the JWT directly
+ * via the keychain (no Next proxy on mobile).
+ */
+const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export interface HistoryRestaurantCity {
+  slug: string;
+  name: string;
+  region: string;
+}
+
+export interface HistoryRestaurant {
+  id: string;
+  slug: string;
+  name: string;
+  city: HistoryRestaurantCity;
+}
+
+export interface HistoryVisit {
+  id: string;
+  viewed_on: string;
+  updated_at: string;
+  items_visible_count: number;
+  items_hidden_count: number;
+  restaurant: HistoryRestaurant;
+}
+
+export interface HistoryResponse {
+  visits: HistoryVisit[];
+  total: number;
+}
+
+export class HistoryError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HistoryError';
+  }
+}
+
+export interface FetchHistoryOptions {
+  limit?: number;
+  offset?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export async function fetchHistory(
+  jwt: string,
+  opts: FetchHistoryOptions = {},
+): Promise<HistoryResponse> {
+  const { fetchImpl = fetch, limit, offset } = opts;
+  const url = new URL(`${API_BASE}/api/v1/profile/history`);
+  if (typeof limit === 'number') url.searchParams.set('limit', String(limit));
+  if (typeof offset === 'number') url.searchParams.set('offset', String(offset));
+  const res = await fetchImpl(url.toString(), {
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+  });
+  if (!res.ok) throw new HistoryError(res.status, `fetchHistory failed: ${res.status}`);
+  return (await res.json()) as HistoryResponse;
+}

--- a/apps/web/src/app/api/profile/history/route.ts
+++ b/apps/web/src/app/api/profile/history/route.ts
@@ -1,0 +1,24 @@
+/**
+ * Phase 4.8 — proxy GET /api/profile/history to Rails with the
+ * bw_session cookie's JWT.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function GET(request: NextRequest) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+  const search = request.nextUrl.search ?? '';
+  const upstream = await fetch(`${API_BASE}/api/v1/profile/history${search}`, {
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+  });
+  const body = await upstream.text();
+  return new NextResponse(body, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/history/page.tsx
+++ b/apps/web/src/app/history/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  fetchHistory,
+  HistoryError,
+  type HistoryVisit,
+} from '../../lib/history';
+
+/**
+ * Phase 4.8 — "My filtered menus" history.
+ *
+ * Authenticated. Renders the user's recent restaurant visits with
+ * the visible/hidden item counts AT VIEW TIME, so the user can see
+ * exactly what the filter was hiding when they last looked.
+ *
+ * 401 → bounce to /login. The proxy reads the bw_session cookie
+ * server-side; the client just hits /api/profile/history with
+ * credentials.
+ */
+export default function HistoryPage() {
+  const router = useRouter();
+
+  const [visits, setVisits] = useState<HistoryVisit[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchHistory()
+      .then((res) => {
+        if (cancelled) return;
+        setVisits(res.visits);
+        setTotal(res.total);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof HistoryError && e.status === 401) {
+          router.replace('/login?next=%2Fhistory');
+          return;
+        }
+        setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 py-bw-12">
+      <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">My history</p>
+      <h1 className="mt-bw-2 text-bw-3xl font-bold">Recent menus you've filtered</h1>
+      <p className="mt-bw-2 text-bw-base text-zinc-700">
+        {total === 0 && !loading
+          ? "You haven't browsed any restaurants yet."
+          : `${total} visit${total === 1 ? '' : 's'} on record.`}
+      </p>
+
+      {loading && <p className="mt-bw-6 text-bw-sm text-zinc-500">Loading…</p>}
+      {error && (
+        <p className="mt-bw-6 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          {error}
+        </p>
+      )}
+
+      <ul className="mt-bw-6 divide-y divide-zinc-100">
+        {visits.map((v) => (
+          <VisitRow key={v.id} visit={v} />
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+function VisitRow({ visit }: { visit: HistoryVisit }) {
+  const when = new Date(visit.viewed_on).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+  return (
+    <li className="py-bw-3" data-testid={`visit-${visit.id}`}>
+      <Link
+        href={`/restaurants/${encodeURIComponent(visit.restaurant.slug)}`}
+        className="font-bold text-zinc-900 hover:text-bite-dark"
+      >
+        {visit.restaurant.name}
+      </Link>
+      <p className="mt-1 text-bw-sm text-zinc-500">
+        {when} · {visit.restaurant.city.name}, {visit.restaurant.city.region}
+      </p>
+      <p className="mt-1 text-bw-sm text-zinc-700">
+        Saw <span className="font-bold">{visit.items_visible_count}</span> item
+        {visit.items_visible_count === 1 ? '' : 's'}
+        {visit.items_hidden_count > 0
+          ? `, hiding ${visit.items_hidden_count}.`
+          : '.'}
+      </p>
+    </li>
+  );
+}

--- a/apps/web/src/lib/__tests__/history.test.ts
+++ b/apps/web/src/lib/__tests__/history.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchHistory, HistoryError, type HistoryResponse } from '../history';
+
+const samplePayload: HistoryResponse = {
+  total: 1,
+  visits: [
+    {
+      id: 'v1',
+      viewed_on: '2026-04-30',
+      updated_at: '2026-04-30T12:00:00Z',
+      items_visible_count: 5,
+      items_hidden_count: 1,
+      restaurant: {
+        id: 'rest-1',
+        slug: 'cream-bean-berry-1',
+        name: 'Cream, Bean & Berry',
+        city: { slug: 'durango', name: 'Durango', region: 'CO' },
+      },
+    },
+  ],
+};
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'ERR',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+describe('fetchHistory', () => {
+  it('GETs the Next proxy at /api/profile/history with credentials', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    const out = await fetchHistory({ fetchImpl });
+    expect(out.total).toBe(1);
+
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/profile/history');
+    expect(init.credentials).toBe('same-origin');
+  });
+
+  it('passes limit + offset query params when supplied', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    await fetchHistory({ fetchImpl, limit: 10, offset: 20 });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('limit=10');
+    expect(url).toContain('offset=20');
+  });
+
+  it('throws HistoryError preserving status (for 401 → /login redirects)', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'Not signed in' });
+    await expect(fetchHistory({ fetchImpl })).rejects.toMatchObject({
+      name: 'HistoryError',
+      status: 401,
+    });
+  });
+});

--- a/apps/web/src/lib/history.ts
+++ b/apps/web/src/lib/history.ts
@@ -1,0 +1,59 @@
+/**
+ * Phase 4.8 — fetch the authenticated user's recent restaurant
+ * visits via the Next proxy at /api/profile/history. The proxy
+ * injects the bw_session cookie's JWT.
+ */
+
+export interface HistoryRestaurantCity {
+  slug: string;
+  name: string;
+  region: string;
+}
+
+export interface HistoryRestaurant {
+  id: string;
+  slug: string;
+  name: string;
+  city: HistoryRestaurantCity;
+}
+
+export interface HistoryVisit {
+  id: string;
+  viewed_on: string;
+  updated_at: string;
+  items_visible_count: number;
+  items_hidden_count: number;
+  restaurant: HistoryRestaurant;
+}
+
+export interface HistoryResponse {
+  visits: HistoryVisit[];
+  total: number;
+}
+
+export class HistoryError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HistoryError';
+  }
+}
+
+export interface FetchHistoryOptions {
+  limit?: number;
+  offset?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export async function fetchHistory(opts: FetchHistoryOptions = {}): Promise<HistoryResponse> {
+  const { fetchImpl = fetch, limit, offset } = opts;
+  const url = new URL('/api/profile/history', 'http://placeholder');
+  if (typeof limit === 'number') url.searchParams.set('limit', String(limit));
+  if (typeof offset === 'number') url.searchParams.set('offset', String(offset));
+  const path = `${url.pathname}${url.search}`;
+  const res = await fetchImpl(path, { credentials: 'same-origin' });
+  if (!res.ok) throw new HistoryError(res.status, `fetchHistory failed: ${res.status}`);
+  return (await res.json()) as HistoryResponse;
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,10 +13,9 @@ the merge / review / status rules.
 
 **Phase 4** ⭐ Reviews + accounts. Subplan: `docs/plans/phase-4.md`.
 
-1. **Phase 4.7 — User profile pages** (`docs/plans/phase-4.md#47`) — this PR
-2. **Phase 4.8 — "My filtered menus" history** (`docs/plans/phase-4.md#48`)
-3. **Phase 4.9 — Restaurant claim flow (domain-email verification)** (`docs/plans/phase-4.md#49`)
-4. **Phase 4.10 — Suggestion queue UX (community edits)** (`docs/plans/phase-4.md#410`)
+1. **Phase 4.8 — "My filtered menus" history** (`docs/plans/phase-4.md#48`) — this PR
+2. **Phase 4.9 — Restaurant claim flow (domain-email verification)** (`docs/plans/phase-4.md#49`)
+3. **Phase 4.10 — Suggestion queue UX (community edits)** (`docs/plans/phase-4.md#410`)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-4.11-dish-photos.md` (per-dish photo extraction from menu pages — user-requested followup) before moving to Phase 5.
 
@@ -57,6 +56,7 @@ After Phase 4 ships, the loop will draft `docs/plans/phase-4.11-dish-photos.md` 
 - ✅ Phase 4.4 — mobile review UX (#159)
 - ✅ Phase 4.5 — web review UX (#160)
 - ✅ Phase 4.6 — review moderation queue (#161)
+- ✅ Phase 4.7 — public user profile pages (#162)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,32 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 12:30 — tick #68. PR #162 (Phase 4.7) merged at 12:23 UTC.
+Picked up Phase 4.8 — "My filtered menus" history. New
+`restaurant_visits` table (user_id, restaurant_id, viewed_on,
+items_visible_count, items_hidden_count) with composite unique
+index on (user_id, restaurant_id, viewed_on) so the upsert is
+race-safe — a user reloading the same restaurant five times in
+a day produces a single row with the latest counts. Counts are
+denormalized so the History list renders without touching items
+or reviews. New `RecordRestaurantVisitJob` that
+`find_or_initialize_by` + saves; rescues InvalidForeignKey
+silently (best-effort) and retries RecordNotUnique once.
+ItemsController#index now enqueues the job when current_user is
+present, swallowing any enqueue exception so the response always
+200s. New `GET /api/v1/profile/history` returns paginated visits
+newest-first with restaurant + city info; auth-only. Web: Next
+proxy at `/api/profile/history` + client-side `/history` page
+that bounces 401 → /login. Mobile: `/history.tsx` mirror that
+reads JWT from keychain and bounces to /login if absent or 401.
+Tests: 5 job specs (create, idempotent upsert, separate days,
+swallowed FK error, default viewed_on); 4 controller specs (auth
+gate, newest-first ordering with city, limit/offset, no cross-user
+leak); 3 items-endpoint specs (enqueue with auth, no enqueue
+anonymous, swallow enqueue failure); 3 vitest + 3 jest for the
+JS clients. Local: rspec 266/0/1 pending; web vitest 48/48;
+mobile jest 56/56; pnpm typecheck/lint cached green.
+
 2026-05-01 12:00 — tick #67. PR #161 (Phase 4.6) merged at 11:49 UTC.
 **Cassette PR blocked**: started the cassette work (planned for this
 tick at user request), converted IMG_6973.HEIC → JPEG, dropped at


### PR DESCRIPTION
## Summary

Phase 4.8 records each authenticated user's restaurant visits (one row per user/restaurant/day) and surfaces them as a History page on web + mobile. Visit counts are captured AT VIEW TIME so the user can see what the filter was hiding the last time they looked. Subplan: `docs/plans/phase-4.md#48`.

### Schema
- New `restaurant_visits` table — `user_id`, `restaurant_id`, `viewed_on (date)`, `items_visible_count`, `items_hidden_count`.
- Composite **unique index on `(user_id, restaurant_id, viewed_on)`** so the upsert is race-safe — five reloads in a day produce one row with the latest counts.
- `(user_id, updated_at DESC)` index for the "most recent visits" query.

### Background job
- **`RecordRestaurantVisitJob`** — `find_or_initialize_by` + `save!`. Rescues `InvalidForeignKey` silently (best-effort telemetry) and retries `RecordNotUnique` once.

### API
- **`ItemsController#index`** enqueues the job when `current_user` is present, swallowing any enqueue exception so the response always 200s.
- **New `GET /api/v1/profile/history`** (auth-only) — paginated visits newest-first with restaurant + city info; `limit` defaults to 30, max 100.

### Web
- Next proxy at `/api/profile/history` reads the `bw_session` cookie and forwards the JWT.
- `/history` client page bounces 401 → `/login?next=/history`.

### Mobile
- `/history.tsx` mirror reads JWT from the keychain and bounces to `/login` if absent or 401.

## Out of scope
- Filter-by-restaurant or filter-by-date — defer until users ask for it.
- Surfacing what's CHANGED since last visit ("3 new items match your filter") — interesting future enhancement, but needs more thought on how often to re-run the filter.
- Aggregate analytics dashboard — admin tooling, not a user feature.

## Test plan
- [x] **rspec** 266/0/1 pending — 5 job + 4 history-endpoint + 3 items-endpoint side-effect specs.
- [x] **Web vitest** 48/48 — 3 new for the history client.
- [x] **Mobile jest** 56/56 — 3 new for the mobile history client.
- [x] `pnpm typecheck` / `pnpm lint` cached green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)