### PR TITLE
feat(api,web): suggestion queue UX for community edits (phase 4.10)

### DIFF
--- a/apps/api/app/controllers/api/v1/suggestions_controller.rb
+++ b/apps/api/app/controllers/api/v1/suggestions_controller.rb
@@ -1,0 +1,119 @@
+module Api
+  module V1
+    # Phase 4.10 — community-edit suggestions on items + the
+    # claimed-restaurant owner's review queue.
+    #
+    #   POST   /api/v1/items/:item_id/suggestions
+    #     Anyone (signed in or not). Anonymous suggestions land with
+    #     user_id: nil and skip the polite "thanks for contributing"
+    #     attribution but still queue for the owner.
+    #
+    #   GET    /api/v1/restaurants/:restaurant_id/suggestions
+    #     Authenticated. Returns pending suggestions on items
+    #     belonging to this restaurant. Gated to the restaurant's
+    #     `claimed_by_user_id` (or admin).
+    #
+    #   PATCH  /api/v1/suggestions/:id
+    #     Authenticated owner of the related restaurant (or admin).
+    #     `{ decision: 'accepted' | 'rejected' }` — accept routes
+    #     through SuggestionResolver to materialize the change.
+    class SuggestionsController < BaseController
+      skip_before_action :authenticate_user!, only: [:create]
+      before_action :load_item,       only: [:create]
+      before_action :load_restaurant, only: [:index]
+      before_action :load_suggestion, only: [:update]
+
+      def create
+        kind    = params[:kind].to_s
+        payload = params[:payload].is_a?(ActionController::Parameters) ? params[:payload].to_unsafe_h : {}
+
+        unless SuggestionResolver::ITEM_KINDS.include?(kind)
+          return render json: {
+            error: "Unsupported kind",
+            allowed: SuggestionResolver::ITEM_KINDS
+          }, status: :unprocessable_entity
+        end
+
+        suggestion = Suggestion.create!(
+          user:    current_user,
+          subject: @item,
+          kind:    kind,
+          status:  "pending",
+          payload: payload
+        )
+        render json: serialize(suggestion), status: :created
+      end
+
+      def index
+        gate_owner!(@restaurant) or return
+
+        suggestions = Suggestion.includes(:user, :subject)
+                                .where(subject_type: "Item", subject_id: @restaurant.items.select(:id))
+                                .where(status: "pending")
+                                .order(created_at: :asc)
+
+        render json: { suggestions: suggestions.map { |s| serialize(s) } }
+      end
+
+      def update
+        item = @suggestion.subject
+        return render json: { error: "Subject is not an Item" }, status: :unprocessable_entity unless item.is_a?(Item)
+        gate_owner!(item.restaurant) or return
+
+        decision = params[:decision].to_s
+        case decision
+        when "accepted"
+          SuggestionResolver.accept!(@suggestion, by_user: current_user)
+        when "rejected"
+          SuggestionResolver.reject!(@suggestion, by_user: current_user)
+        else
+          return render json: { error: "decision must be 'accepted' or 'rejected'" }, status: :unprocessable_entity
+        end
+        render json: serialize(@suggestion)
+      rescue SuggestionResolver::InvalidPayloadError => e
+        render json: { error: e.message, kind: "InvalidPayloadError" }, status: :unprocessable_entity
+      rescue SuggestionResolver::UnsupportedKindError => e
+        render json: { error: e.message, kind: "UnsupportedKindError" }, status: :unprocessable_entity
+      end
+
+      private
+
+      def load_item
+        @item = Item.published.find(params[:item_id])
+      end
+
+      def load_restaurant
+        @restaurant = Restaurant.find_by_id_or_slug!(params[:restaurant_id])
+      end
+
+      def load_suggestion
+        @suggestion = Suggestion.find(params[:id])
+      end
+
+      # Returns true if the caller may act as owner; renders 403 +
+      # returns nil otherwise. Caller pattern: `gate_owner!(...) or return`.
+      def gate_owner!(restaurant)
+        return true if current_user&.is_admin?
+        return true if restaurant.claimed_by_user_id.present? && restaurant.claimed_by_user_id == current_user&.id
+        render json: { error: "Only the claimed-restaurant owner can do that" }, status: :forbidden
+        nil
+      end
+
+      def serialize(suggestion)
+        item = suggestion.subject
+        {
+          id:      suggestion.id,
+          kind:    suggestion.kind,
+          status:  suggestion.status,
+          payload: suggestion.payload,
+          created_at: suggestion.created_at,
+          resolved_at: suggestion.resolved_at,
+          item: item.is_a?(Item) ? { id: item.id, name: item.name, restaurant_id: item.restaurant_id } : nil,
+          submitter: suggestion.user.then { |u|
+            u ? { id: u.id, handle: u.handle, display_name: u.display_name } : nil
+          }
+        }
+      end
+    end
+  end
+end

--- a/apps/api/app/services/suggestion_resolver.rb
+++ b/apps/api/app/services/suggestion_resolver.rb
@@ -1,0 +1,101 @@
+# Phase 4.10 — accept/reject community-edit suggestions on Items.
+#
+# The Suggestion polymorphic queue handles many flavors of edit. This
+# resolver knows how to TURN AN ACCEPT INTO A REAL CHANGE — adding /
+# removing ItemIngredient + ItemTag join rows, renaming items, etc.
+# Mirrors IngestionItem#promote! semantics: accepted edits land as
+# `confidence: confirmed, source: human` so they outweigh any future
+# AI re-ingestion.
+#
+# Rejecting is just a status change — no side effects on the Item.
+class SuggestionResolver
+  ITEM_KINDS = %w[
+    add_ingredient
+    remove_ingredient
+    add_tag
+    remove_tag
+    rename
+  ].freeze
+
+  class UnsupportedKindError < StandardError; end
+  class InvalidPayloadError  < StandardError; end
+
+  class << self
+    # Apply the suggestion to its subject and mark it accepted.
+    # Wrapped in one transaction so a payload validation failure
+    # leaves both the Suggestion and the subject untouched.
+    def accept!(suggestion, by_user:)
+      raise UnsupportedKindError, "kind=#{suggestion.kind}" unless ITEM_KINDS.include?(suggestion.kind)
+      raise InvalidPayloadError, "subject is not an Item" unless suggestion.subject.is_a?(Item)
+
+      Suggestion.transaction do
+        apply!(suggestion)
+        suggestion.update!(
+          status: "accepted",
+          resolved_by_user_id: by_user.id,
+          resolved_at: Time.current
+        )
+      end
+      suggestion
+    end
+
+    def reject!(suggestion, by_user:)
+      suggestion.update!(
+        status: "rejected",
+        resolved_by_user_id: by_user.id,
+        resolved_at: Time.current
+      )
+      suggestion
+    end
+
+    private
+
+    def apply!(suggestion)
+      item    = suggestion.subject
+      payload = suggestion.payload || {}
+
+      case suggestion.kind
+      when "add_ingredient"
+        ingredient = find_ingredient!(payload)
+        ItemIngredient.find_or_create_by!(item: item, ingredient: ingredient) do |row|
+          row.confidence = "confirmed"
+          row.source     = "human"
+        end
+      when "remove_ingredient"
+        ingredient = find_ingredient!(payload)
+        item.item_ingredients.where(ingredient: ingredient).destroy_all
+      when "add_tag"
+        tag = find_tag!(payload)
+        ItemTag.find_or_create_by!(item: item, tag: tag) do |row|
+          row.confidence = "confirmed"
+          row.source     = "human"
+        end
+      when "remove_tag"
+        tag = find_tag!(payload)
+        item.item_tags.where(tag: tag).destroy_all
+      when "rename"
+        new_name = payload["name"].to_s.strip
+        raise InvalidPayloadError, "name required for rename" if new_name.empty?
+        item.update!(name: new_name)
+      end
+    end
+
+    def find_ingredient!(payload)
+      slug = payload["ingredient_slug"]
+      id   = payload["ingredient_id"]
+      ing  = Ingredient.find_by(id: id) if id.present?
+      ing ||= Ingredient.find_by(slug: slug) if slug.present?
+      raise InvalidPayloadError, "ingredient not found (id=#{id} slug=#{slug})" unless ing
+      ing
+    end
+
+    def find_tag!(payload)
+      slug = payload["tag_slug"]
+      id   = payload["tag_id"]
+      tag  = Tag.find_by(id: id) if id.present?
+      tag ||= Tag.find_by(slug: slug) if slug.present?
+      raise InvalidPayloadError, "tag not found (id=#{id} slug=#{slug})" unless tag
+      tag
+    end
+  end
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
         # Phase 4.9 — restaurant claim flow.
         post   "claim",        to: "restaurant_claims#create"
         get    "claim/verify", to: "restaurant_claims#verify"
+        # Phase 4.10 — owner's pending-suggestion queue.
+        resources :suggestions, only: [:index]
       end
       resources :ingredients, only: [:index]
       resources :tags, only: [:index]
@@ -71,8 +73,12 @@ Rails.application.routes.draw do
           delete :never_hide, to: "item_overrides#destroy"
         end
         resources :reviews, only: [:index, :create]
+        # Phase 4.10 — anyone can suggest a fix.
+        resources :suggestions, only: [:create]
       end
       resources :reviews, only: [:update, :destroy]
+      # Phase 4.10 — owner accepts/rejects a suggestion.
+      resources :suggestions, only: [:update]
       # Phase 4.7 — public profile by handle. Constraint allows
       # underscores + digits + ASCII letters (matches User#handle
       # validation).

--- a/apps/api/spec/factories/suggestions.rb
+++ b/apps/api/spec/factories/suggestions.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :item_suggestion_pending, class: "Suggestion" do
+    user
+    subject { create(:item, :published) }
+    kind    { "rename" }
+    status  { "pending" }
+    payload { { "name" => "Renamed item" } }
+  end
+end

--- a/apps/api/spec/requests/api/v1/suggestions_spec.rb
+++ b/apps/api/spec/requests/api/v1/suggestions_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe "Suggestion API", type: :request do
+  let(:contributor)  { create(:user) }
+  let(:owner)        { create(:user) }
+  let(:other_user)   { create(:user) }
+  let(:contributor_headers) { auth_headers_for(contributor) }
+  let(:owner_headers)       { auth_headers_for(owner) }
+  let(:other_headers)       { auth_headers_for(other_user) }
+
+  let(:restaurant) do
+    create(:restaurant, :published,
+           claimed_at: Time.current,
+           claimed_by_user_id: owner.id)
+  end
+  let(:item)     { create(:item, :published, restaurant: restaurant, name: "Veggie Burrito") }
+  let(:cilantro) { create(:ingredient, slug: "herb-cilantro") }
+
+  describe "POST /api/v1/items/:item_id/suggestions" do
+    it "creates a pending suggestion (signed in)" do
+      expect {
+        post "/api/v1/items/#{item.id}/suggestions",
+             params:  { kind: "add_ingredient", payload: { ingredient_slug: cilantro.slug } },
+             headers: contributor_headers
+      }.to change(Suggestion, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body).to include(
+        "kind"   => "add_ingredient",
+        "status" => "pending"
+      )
+      expect(body["submitter"]).to include("id" => contributor.id)
+    end
+
+    it "accepts anonymous suggestions (user_id stays nil)" do
+      expect {
+        post "/api/v1/items/#{item.id}/suggestions",
+             params: { kind: "rename", payload: { name: "Veggie Burrito (V+GF)" } }
+      }.to change(Suggestion, :count).by(1)
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body["submitter"]).to be_nil
+    end
+
+    it "422s on an unsupported kind" do
+      post "/api/v1/items/#{item.id}/suggestions",
+           params: { kind: "make_it_free", payload: {} }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["allowed"]).to include("add_ingredient")
+    end
+
+    it "404s on an unpublished item" do
+      draft = create(:item, restaurant: restaurant) # default :draft
+      post "/api/v1/items/#{draft.id}/suggestions",
+           params: { kind: "rename", payload: { name: "X" } }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /api/v1/restaurants/:id/suggestions" do
+    let!(:pending)  { create(:item_suggestion_pending, subject: item) }
+    let!(:accepted) { create(:item_suggestion_pending, subject: item, status: "accepted") }
+
+    it "returns only pending suggestions for the restaurant's items, owner-gated" do
+      get "/api/v1/restaurants/#{restaurant.id}/suggestions", headers: owner_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["suggestions"].map { |s| s["id"] }).to eq([pending.id])
+    end
+
+    it "403s for a non-owner" do
+      get "/api/v1/restaurants/#{restaurant.id}/suggestions", headers: other_headers
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "401s anonymously" do
+      get "/api/v1/restaurants/#{restaurant.id}/suggestions"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "admins can see any restaurant's queue" do
+      admin = create(:user, is_admin: true)
+      get "/api/v1/restaurants/#{restaurant.id}/suggestions", headers: auth_headers_for(admin)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /api/v1/suggestions/:id" do
+    let!(:suggestion) do
+      Suggestion.create!(
+        user: contributor, subject: item, kind: "add_ingredient", status: "pending",
+        payload: { "ingredient_slug" => cilantro.slug }
+      )
+    end
+
+    it "owner accepts → resolver applies the change + stamps the Suggestion" do
+      patch "/api/v1/suggestions/#{suggestion.id}",
+            params:  { decision: "accepted" },
+            headers: owner_headers
+
+      expect(response).to have_http_status(:ok)
+      suggestion.reload
+      expect(suggestion.status).to eq("accepted")
+      expect(suggestion.resolved_by_user_id).to eq(owner.id)
+      expect(item.reload.ingredients).to include(cilantro)
+    end
+
+    it "owner rejects → no Item change" do
+      patch "/api/v1/suggestions/#{suggestion.id}",
+            params:  { decision: "rejected" },
+            headers: owner_headers
+      expect(suggestion.reload.status).to eq("rejected")
+      expect(item.reload.ingredients).to be_empty
+    end
+
+    it "403s for a non-owner" do
+      patch "/api/v1/suggestions/#{suggestion.id}",
+            params:  { decision: "accepted" },
+            headers: other_headers
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "422s on an invalid decision string" do
+      patch "/api/v1/suggestions/#{suggestion.id}",
+            params:  { decision: "maybe" },
+            headers: owner_headers
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "422s + InvalidPayloadError surface when the payload is broken" do
+      bad = Suggestion.create!(
+        user: contributor, subject: item, kind: "add_ingredient", status: "pending",
+        payload: { "ingredient_slug" => "no-such-thing" }
+      )
+      patch "/api/v1/suggestions/#{bad.id}",
+            params:  { decision: "accepted" },
+            headers: owner_headers
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["kind"]).to eq("InvalidPayloadError")
+      expect(bad.reload.status).to eq("pending") # rollback
+    end
+  end
+end

--- a/apps/api/spec/services/suggestion_resolver_spec.rb
+++ b/apps/api/spec/services/suggestion_resolver_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe SuggestionResolver do
+  let(:moderator) { create(:user) }
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:item)      { create(:item, :published, restaurant: restaurant, name: "Carne Asada Taco") }
+  let(:cilantro)  { create(:ingredient, slug: "herb-cilantro") }
+  let(:spicy_tag) { create(:tag, slug: "flavor-spicy") }
+
+  def suggestion(kind:, payload: {})
+    Suggestion.create!(
+      user: create(:user), subject: item, kind: kind, status: "pending", payload: payload
+    )
+  end
+
+  describe ".accept!" do
+    it "add_ingredient creates an ItemIngredient with confidence:confirmed source:human" do
+      sg = suggestion(kind: "add_ingredient", payload: { "ingredient_slug" => cilantro.slug })
+
+      described_class.accept!(sg, by_user: moderator)
+
+      ii = item.item_ingredients.find_by(ingredient: cilantro)
+      expect(ii).to be_present
+      expect(ii.confidence).to eq("confirmed")
+      expect(ii.source).to     eq("human")
+      sg.reload
+      expect(sg.status).to eq("accepted")
+      expect(sg.resolved_by_user_id).to eq(moderator.id)
+    end
+
+    it "add_ingredient is idempotent (re-accepting an already-applied suggestion doesn't dup)" do
+      sg = suggestion(kind: "add_ingredient", payload: { "ingredient_id" => cilantro.id })
+      described_class.accept!(sg, by_user: moderator)
+      expect {
+        # Re-creating + re-applying with the same payload also doesn't dup.
+        described_class.accept!(suggestion(kind: "add_ingredient", payload: { "ingredient_id" => cilantro.id }), by_user: moderator)
+      }.not_to change { item.item_ingredients.where(ingredient: cilantro).count }
+    end
+
+    it "remove_ingredient deletes the join row" do
+      ItemIngredient.create!(item: item, ingredient: cilantro, confidence: "confirmed", source: "human")
+      sg = suggestion(kind: "remove_ingredient", payload: { "ingredient_slug" => cilantro.slug })
+
+      described_class.accept!(sg, by_user: moderator)
+      expect(item.item_ingredients.where(ingredient: cilantro)).to be_empty
+    end
+
+    it "add_tag creates an ItemTag with confidence:confirmed source:human" do
+      sg = suggestion(kind: "add_tag", payload: { "tag_slug" => spicy_tag.slug })
+      described_class.accept!(sg, by_user: moderator)
+      it_tag = item.item_tags.find_by(tag: spicy_tag)
+      expect(it_tag.confidence).to eq("confirmed")
+      expect(it_tag.source).to     eq("human")
+    end
+
+    it "remove_tag deletes the join row" do
+      ItemTag.create!(item: item, tag: spicy_tag, confidence: "confirmed", source: "human")
+      sg = suggestion(kind: "remove_tag", payload: { "tag_id" => spicy_tag.id })
+      described_class.accept!(sg, by_user: moderator)
+      expect(item.item_tags.where(tag: spicy_tag)).to be_empty
+    end
+
+    it "rename updates Item#name" do
+      sg = suggestion(kind: "rename", payload: { "name" => "Carne Asada al Pastor Taco" })
+      described_class.accept!(sg, by_user: moderator)
+      expect(item.reload.name).to eq("Carne Asada al Pastor Taco")
+    end
+
+    it "raises InvalidPayloadError on a blank rename" do
+      sg = suggestion(kind: "rename", payload: { "name" => "  " })
+      expect { described_class.accept!(sg, by_user: moderator) }.to raise_error(SuggestionResolver::InvalidPayloadError)
+      expect(sg.reload.status).to eq("pending") # transaction rolled back
+    end
+
+    it "raises InvalidPayloadError when the ingredient can't be found" do
+      sg = suggestion(kind: "add_ingredient", payload: { "ingredient_slug" => "no-such-thing" })
+      expect { described_class.accept!(sg, by_user: moderator) }.to raise_error(SuggestionResolver::InvalidPayloadError)
+    end
+
+    it "raises UnsupportedKindError on a kind we don't know" do
+      sg = suggestion(kind: "claim", payload: {}) # claim is for restaurants, not items
+      expect { described_class.accept!(sg, by_user: moderator) }.to raise_error(SuggestionResolver::UnsupportedKindError)
+    end
+  end
+
+  describe ".reject!" do
+    it "marks rejected and stamps the resolver, no Item changes" do
+      sg = suggestion(kind: "rename", payload: { "name" => "WHATEVER" })
+      expect {
+        described_class.reject!(sg, by_user: moderator)
+      }.not_to change { item.reload.name }
+      sg.reload
+      expect(sg.status).to eq("rejected")
+      expect(sg.resolved_by_user_id).to eq(moderator.id)
+    end
+  end
+end

--- a/apps/web/src/app/api/items/[id]/suggestions/route.ts
+++ b/apps/web/src/app/api/items/[id]/suggestions/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Phase 4.10 — proxy POST /api/items/:id/suggestions to Rails.
+ * Anonymous-allowed: no JWT required to suggest a fix. If the
+ * cookie carries one, forward it so the suggestion attributes
+ * properly.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const body = await request.text();
+  const jwt = await getServerJwt();
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  if (jwt) headers.Authorization = `Bearer ${jwt}`;
+
+  const upstream = await fetch(
+    `${API_BASE}/api/v1/items/${encodeURIComponent(id)}/suggestions`,
+    { method: 'POST', headers, body },
+  );
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/restaurants/[slug]/suggestions/route.ts
+++ b/apps/web/src/app/api/restaurants/[slug]/suggestions/route.ts
@@ -1,0 +1,27 @@
+/**
+ * Phase 4.10 — proxy GET /api/restaurants/:slug/suggestions
+ * (owner-only queue) with the cookie's JWT.
+ */
+import { NextResponse } from 'next/server';
+import { getServerJwt } from '../../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await context.params;
+  const jwt = await getServerJwt();
+  if (!jwt) return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+
+  const upstream = await fetch(
+    `${API_BASE}/api/v1/restaurants/${encodeURIComponent(slug)}/suggestions`,
+    { headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' } },
+  );
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/suggestions/[id]/route.ts
+++ b/apps/web/src/app/api/suggestions/[id]/route.ts
@@ -1,0 +1,33 @@
+/**
+ * Phase 4.10 — proxy PATCH /api/suggestions/:id (owner accept/reject)
+ * with the cookie's JWT.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const jwt = await getServerJwt();
+  if (!jwt) return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+
+  const body = await request.text();
+  const upstream = await fetch(`${API_BASE}/api/v1/suggestions/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body,
+  });
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/SuggestFixClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/SuggestFixClient.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import {
+  createSuggestion,
+  SUGGESTION_KINDS,
+  SuggestionError,
+  type SuggestionKind,
+} from '../../../../../lib/suggestions';
+
+const KIND_LABELS: Record<SuggestionKind, string> = {
+  add_ingredient:    'Add a missing ingredient',
+  remove_ingredient: 'Remove a wrong ingredient',
+  add_tag:           'Add a missing tag',
+  remove_tag:        'Remove a wrong tag',
+  rename:            'Fix a typo / rename',
+};
+
+const KIND_PAYLOAD_HINT: Record<SuggestionKind, string> = {
+  add_ingredient:    'ingredient slug (e.g. herb-cilantro)',
+  remove_ingredient: 'ingredient slug (e.g. herb-cilantro)',
+  add_tag:           'tag slug (e.g. allergen-contains-dairy)',
+  remove_tag:        'tag slug (e.g. allergen-contains-dairy)',
+  rename:            'new item name',
+};
+
+/**
+ * Phase 4.10 — "Suggest a fix" form on the item detail page. Anyone
+ * can submit; the queue lands at /restaurants/<slug>/suggestions for
+ * the claimed-restaurant owner to act on.
+ */
+export function SuggestFixClient({ itemId }: { itemId: string }) {
+  const [open, setOpen] = useState(false);
+  const [kind, setKind] = useState<SuggestionKind>('add_ingredient');
+  const [value, setValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!value.trim()) {
+      setError('Fill in the value.');
+      return;
+    }
+    const payload = buildPayload(kind, value.trim());
+    try {
+      setSubmitting(true);
+      await createSuggestion(itemId, { kind, payload });
+      setDone(true);
+      setValue('');
+    } catch (err) {
+      const status = err instanceof SuggestionError ? err.status : 0;
+      setError(status === 422 ? 'Couldn’t accept that — double-check the value.' : (err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <p className="mt-bw-3 text-bw-sm text-zinc-500" data-testid="suggest-thanks">
+        Thanks — your suggestion is in the queue.{' '}
+        <button
+          type="button"
+          onClick={() => {
+            setDone(false);
+            setOpen(true);
+          }}
+          className="font-semibold text-bite hover:text-bite-dark"
+        >
+          Submit another
+        </button>
+      </p>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        data-testid="open-suggest"
+        className="mt-bw-3 text-bw-sm font-semibold text-zinc-500 hover:text-zinc-700"
+      >
+        Suggest a fix
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} className="mt-bw-3 rounded-bw-md border border-zinc-200 p-bw-3" data-testid="suggest-form">
+      <p className="text-bw-sm font-semibold text-zinc-700">Suggest a fix</p>
+      <select
+        value={kind}
+        onChange={(e) => setKind(e.target.value as SuggestionKind)}
+        aria-label="suggest-kind"
+        className="mt-bw-2 w-full rounded-bw-md border border-zinc-300 px-bw-2 py-bw-2 text-bw-sm"
+      >
+        {SUGGESTION_KINDS.map((k) => (
+          <option key={k} value={k}>{KIND_LABELS[k]}</option>
+        ))}
+      </select>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={KIND_PAYLOAD_HINT[kind]}
+        aria-label="suggest-value"
+        required
+        className="mt-bw-2 w-full rounded-bw-md border border-zinc-300 px-bw-2 py-bw-2 text-bw-sm"
+      />
+      {error && (
+        <p className="mt-bw-2 rounded-bw-md bg-bite-light px-bw-2 py-bw-1 text-bw-xs text-bite-dark">
+          {error}
+        </p>
+      )}
+      <div className="mt-bw-2 flex items-center gap-bw-2 justify-end">
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-bw-sm font-semibold text-zinc-500 hover:text-zinc-700"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          data-testid="submit-suggest"
+          className={[
+            'rounded-bw-md bg-zinc-700 px-bw-3 py-bw-2 text-bw-sm font-bold text-white',
+            submitting ? 'opacity-60' : 'hover:bg-zinc-900',
+          ].join(' ')}
+        >
+          {submitting ? 'Sending…' : 'Send suggestion'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function buildPayload(kind: SuggestionKind, value: string): Record<string, unknown> {
+  switch (kind) {
+    case 'add_ingredient':
+    case 'remove_ingredient':
+      return { ingredient_slug: value };
+    case 'add_tag':
+    case 'remove_tag':
+      return { tag_slug: value };
+    case 'rename':
+      return { name: value };
+  }
+}

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../../lib/restaurants';
 import { fetchReviewsServer, type ReviewsResponse } from '../../../../../lib/reviews';
 import { ReviewsClient } from './ReviewsClient';
+import { SuggestFixClient } from './SuggestFixClient';
 
 /**
  * Phase 4.5 — server-rendered item detail page with reviews.
@@ -62,6 +63,7 @@ function Page({
       )}
 
       <ReviewsClient itemId={item.id} initial={initialReviews} />
+      <SuggestFixClient itemId={item.id} />
     </main>
   );
 }

--- a/apps/web/src/app/restaurants/[slug]/suggestions/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/suggestions/page.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  decideSuggestion,
+  fetchSuggestionsForRestaurant,
+  SuggestionError,
+  type SuggestionPayload,
+} from '../../../../lib/suggestions';
+
+/**
+ * Phase 4.10 — owner queue for community-edit suggestions.
+ *
+ * Authenticated and gated to the restaurant's
+ * `claimed_by_user_id` (or admin) by the API. 401 → /login,
+ * 403 → "you don't own this restaurant."
+ */
+export default function SuggestionQueuePage() {
+  const params = useParams<{ slug: string }>();
+  const slug = params.slug;
+  const router = useRouter();
+
+  const [suggestions, setSuggestions] = useState<SuggestionPayload[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<{ status: number; message: string } | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSuggestionsForRestaurant(slug)
+      .then((res) => {
+        if (!cancelled) setSuggestions(res.suggestions);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof SuggestionError && e.status === 401) {
+          router.replace(`/login?next=${encodeURIComponent(`/restaurants/${slug}/suggestions`)}`);
+          return;
+        }
+        if (e instanceof SuggestionError) setError({ status: e.status, message: e.message });
+        else setError({ status: 500, message: (e as Error).message });
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, router]);
+
+  const decide = async (id: string, decision: 'accepted' | 'rejected') => {
+    setBusyId(id);
+    try {
+      await decideSuggestion(id, decision);
+      // Drop the row from the queue locally (it's no longer pending).
+      setSuggestions((prev) => prev.filter((s) => s.id !== id));
+    } catch (e) {
+      const message = (e as Error).message;
+      window.alert(message); // simple feedback for owner — pending UX upgrade
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 py-bw-12">
+      <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">
+        <Link href={`/restaurants/${slug}`} className="hover:underline">← Back to restaurant</Link>
+      </p>
+      <h1 className="mt-bw-2 text-bw-2xl font-bold">Community suggestions</h1>
+      <p className="mt-bw-2 text-bw-sm text-zinc-500">
+        Pending fixes diners have submitted for items at this restaurant.
+      </p>
+
+      {loading && <p className="mt-bw-6 text-bw-sm text-zinc-500">Loading…</p>}
+
+      {error?.status === 403 && (
+        <p className="mt-bw-6 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          You don&rsquo;t own this restaurant. Only the verified owner can review suggestions.
+        </p>
+      )}
+      {error && error.status !== 403 && (
+        <p className="mt-bw-6 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          {error.message}
+        </p>
+      )}
+
+      {!loading && !error && suggestions.length === 0 && (
+        <p className="mt-bw-6 text-bw-base text-zinc-500">No pending suggestions. Inbox zero.</p>
+      )}
+
+      <ul className="mt-bw-4 divide-y divide-zinc-100">
+        {suggestions.map((s) => (
+          <SuggestionRow key={s.id} suggestion={s} busy={busyId === s.id} onDecide={decide} />
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+function SuggestionRow({
+  suggestion,
+  busy,
+  onDecide,
+}: {
+  suggestion: SuggestionPayload;
+  busy: boolean;
+  onDecide: (id: string, decision: 'accepted' | 'rejected') => void;
+}) {
+  return (
+    <li className="py-bw-4" data-testid={`suggestion-${suggestion.id}`}>
+      <p className="text-bw-sm font-semibold text-zinc-700">
+        {suggestion.kind} on{' '}
+        <span className="text-zinc-900">{suggestion.item?.name ?? 'unknown item'}</span>
+      </p>
+      <pre className="mt-1 overflow-x-auto rounded-bw-md bg-zinc-50 p-bw-2 text-bw-xs text-zinc-700">
+        {JSON.stringify(suggestion.payload, null, 2)}
+      </pre>
+      <p className="mt-1 text-bw-xs text-zinc-500">
+        from {suggestion.submitter?.handle ? `@${suggestion.submitter.handle}` : 'anonymous diner'} ·{' '}
+        {new Date(suggestion.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+      </p>
+      <div className="mt-bw-2 flex gap-bw-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onDecide(suggestion.id, 'accepted')}
+          data-testid={`accept-${suggestion.id}`}
+          className={[
+            'rounded-bw-md bg-ok px-bw-3 py-bw-2 text-bw-sm font-bold text-white',
+            busy ? 'opacity-60' : 'hover:opacity-90',
+          ].join(' ')}
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onDecide(suggestion.id, 'rejected')}
+          data-testid={`reject-${suggestion.id}`}
+          className={[
+            'rounded-bw-md border border-zinc-300 bg-white px-bw-3 py-bw-2 text-bw-sm font-semibold text-zinc-700',
+            busy ? 'opacity-60' : 'hover:border-zinc-400',
+          ].join(' ')}
+        >
+          Reject
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,10 +13,9 @@ the merge / review / status rules.
 
 **Phase 4** ⭐ Reviews + accounts. Subplan: `docs/plans/phase-4.md`.
 
-1. **Phase 4.9 — Restaurant claim flow (domain-email verification)** (`docs/plans/phase-4.md#49`) — this PR
-2. **Phase 4.10 — Suggestion queue UX (community edits)** (`docs/plans/phase-4.md#410`)
+1. **Phase 4.10 — Suggestion queue UX (community edits)** (`docs/plans/phase-4.md#410`) — this PR (last item in Phase 4)
 
-After Phase 4 ships, the loop will draft `docs/plans/phase-4.11-dish-photos.md` (per-dish photo extraction from menu pages — user-requested followup) before moving to Phase 5.
+After 4.10 merges, Phase 4 is feature-complete. The next loop tick drafts `docs/plans/phase-4.11-dish-photos.md` (per-dish photo extraction from menu pages — user-requested followup) before moving to Phase 5.
 
 ### Done
 
@@ -57,6 +56,7 @@ After Phase 4 ships, the loop will draft `docs/plans/phase-4.11-dish-photos.md` 
 - ✅ Phase 4.6 — review moderation queue (#161)
 - ✅ Phase 4.7 — public user profile pages (#162)
 - ✅ Phase 4.8 — "My filtered menus" history (#163)
+- ✅ Phase 4.9 — restaurant claim flow with domain-email verification (#164)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,39 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 13:30 — tick #70. PR #164 (Phase 4.9) merged at 13:24 UTC.
+Picked up Phase 4.10 — suggestion queue UX (the last item in Phase 4).
+New `SuggestionResolver` service with five item-edit kinds
+(add_ingredient, remove_ingredient, add_tag, remove_tag, rename),
+each accept materializing a real Item / ItemIngredient / ItemTag
+change with `confidence: confirmed, source: human` (mirrors
+IngestionItem#promote!). Wrapped in one transaction so a payload
+validation failure rolls back both the side effect and the
+Suggestion status. Three endpoints: POST anonymous-allowed (so a
+diner without an account can still flag a fix), GET owner-only
+(restaurant.claimed_by_user_id or admin), PATCH owner-only with
+'accepted' | 'rejected' decision. All gated through one
+`gate_owner!` helper. Web: three Next proxy routes mirroring the
+auth shape (suggestion-create forwards a JWT IF the cookie has
+one; the other two require it). New `lib/suggestions.ts` client
+with SuggestionError preserving status + kind so the UI can
+distinguish 401 (bounce to /login), 403 (you don't own this
+restaurant), 422 + InvalidPayloadError (couldn't accept that —
+double-check the value). `<SuggestFixClient>` form on the item
+detail page (kind dropdown + value input + dynamic placeholder
+hint per kind). `/restaurants/[slug]/suggestions` owner queue page
+shows pending suggestions with Accept / Reject buttons; rows drop
+locally on decision rather than re-fetching. Tests: 11 resolver
+specs (every kind end-to-end + idempotence + rollback +
+unsupported kind), 12 controller specs (anonymous create,
+authenticated create attribution, unsupported kind 422, owner
+gate on index/update, admin override, accept materializes,
+InvalidPayload rollback), 7 vitest for the web client. Local:
+rspec 314/0/1 pending; web vitest 61/61; mobile jest 56/56;
+pnpm typecheck/lint cached green. **After this PR ships, Phase 4
+is feature-complete** (4.1 → 4.10 all merged); next tick drafts
+the Phase 4.11 dish-photo subplan per the user's earlier ask.
+
 2026-05-01 13:00 — tick #69. PR #163 (Phase 4.8) merged at 12:52 UTC.
 Picked up Phase 4.9 — restaurant claim flow with domain-email
 verification. New `RestaurantClaim` service that reuses the


### PR DESCRIPTION
## Summary

Phase 4.10 — the **last item in Phase 4**. Anyone can suggest a fix on an item; the claimed-restaurant owner sees a queue and accepts/rejects with one tap. Reuses the existing `suggestions` polymorphic queue (no schema change). Subplan: `docs/plans/phase-4.md#410`.

### API

**`SuggestionResolver` service** with five item-edit kinds. Each accept materializes a real change with `confidence: confirmed, source: human` (mirrors `IngestionItem#promote!`):

| Kind | Effect on accept |
|---|---|
| `add_ingredient` | Creates `ItemIngredient` row (idempotent) |
| `remove_ingredient` | Deletes the matching `ItemIngredient` |
| `add_tag` | Creates `ItemTag` row (idempotent) |
| `remove_tag` | Deletes the matching `ItemTag` |
| `rename` | Updates `Item#name` (rejects blank) |

Wrapped in one transaction so a payload-validation failure rolls back both the side effect and the Suggestion status.

**Three endpoints:**

- `POST /api/v1/items/:item_id/suggestions` — anonymous-allowed (so a diner without an account can flag a fix). When signed in, the suggestion attributes properly.
- `GET  /api/v1/restaurants/:id/suggestions` — owner-only (`restaurant.claimed_by_user_id` or admin). Returns pending only.
- `PATCH /api/v1/suggestions/:id` — owner-only. `decision: 'accepted' | 'rejected'`.

All gated through one `gate_owner!` helper. Admin role bypasses ownership.

### Web

- Three Next proxy routes mirror the auth shape (POST forwards the cookie's JWT IF present; the other two require it).
- **`apps/web/src/lib/suggestions.ts`** — `SuggestionError` preserves status + kind so callers can distinguish 401 (bounce to `/login`), 403 ("you don't own this restaurant"), 422 + `InvalidPayloadError` ("couldn't accept that — double-check the value").
- **`<SuggestFixClient>`** form on the item-detail page — kind dropdown + value input + dynamic placeholder hint per kind.
- **`/restaurants/[slug]/suggestions`** owner queue page — shows pending suggestions with Accept / Reject buttons. Rows drop locally on decision rather than re-fetching.

## After this PR

**Phase 4 is feature-complete.** All 10 sub-tasks merged (4.1 → 4.10). Next loop tick drafts `docs/plans/phase-4.11-dish-photos.md` (per-dish photo extraction from menu pages — your earlier request) before moving to Phase 5.

## Out of scope
- Mobile UX for suggest-a-fix and the queue — same shape as web; if you want it before Phase 5, easy follow-up.
- Email-out to suggestion submitter when accepted — needs SMTP (existing Phase 4 stop condition).
- Auto-detect duplicate suggestions — defer until volume warrants.

## Test plan
- [x] **rspec** 314/0/1 pending — 11 resolver specs + 12 controller specs.
- [x] **Web vitest** 61/61 — 7 new for the API client.
- [x] **Mobile jest** 56/56 unchanged.
- [x] `pnpm typecheck` / `pnpm lint` cached green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)