### PR TITLE
feat(api): IngestionItem promote attaches cropped dish photo (phase 4.11.3)

### DIFF
--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -25,7 +25,7 @@ module Api
       def index
         restaurant = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id])
         items      = restaurant.items.published
-                               .includes(menu_section: :menu)
+                               .includes(menu_section: :menu, photo_attachment: :blob)
                                .order(popularity: :desc, name: :asc)
                                .to_a
 
@@ -48,7 +48,8 @@ module Api
       end
 
       def show
-        item = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id]).items.published.find(params[:id])
+        item = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id])
+                          .items.published.includes(photo_attachment: :blob).find(params[:id])
         filter = build_filter
         render json: serialize_item(item, filter, build_label_lookup([item], filter), current_user_override_item_ids([item]), review_counts_for([item]))
       end
@@ -176,8 +177,19 @@ module Api
           status:              reasons.empty? ? "visible" : "hidden",
           reasons:             reasons,
           overridden_by_user:  override_ids.include?(item.id),
-          reviews_count:       review_counts.fetch(item.id, 0)
+          reviews_count:       review_counts.fetch(item.id, 0),
+          photo_url:           photo_url_for(item)
         }
+      end
+
+      # Phase 4.11.3 — same shape as ReviewsController#photo_url_for.
+      # Returns the signed blob URL, falling back to the request's base
+      # URL when PUBLIC_HOST isn't set (dev / CI). Production deploys
+      # set PUBLIC_HOST so URLs work for clients on a different origin.
+      def photo_url_for(item)
+        return nil unless item.photo.attached?
+        host = ENV["PUBLIC_HOST"].presence || request.base_url
+        Rails.application.routes.url_helpers.rails_blob_url(item.photo, host: host)
       end
 
       # Phase 4.4 — bulk-load review counts for the items in the

--- a/apps/api/app/models/ingestion_item.rb
+++ b/apps/api/app/models/ingestion_item.rb
@@ -59,8 +59,35 @@ class IngestionItem < ApplicationRecord
         )
       end
 
+      attach_dish_photo!(created)
+
       update!(item: created, decision: "accepted", decided_at: Time.current)
       created
     end
+  end
+
+  private
+
+  # Phase 4.11.3 — when Anthropic vision marked a per-dish photo on the
+  # source page (image_bbox jsonb populated by 4.11.2), crop it out and
+  # attach it to the new Item. Best-effort: a bad bbox or unreadable
+  # source blob logs + skips so promotion still succeeds. The bbox
+  # column stays null for items extracted by pre-4.11.2 cassettes; this
+  # method is a no-op for them.
+  def attach_dish_photo!(created_item)
+    return if image_bbox.blank?
+    source_blob = ingestion_run.inputs.blobs.first
+    return if source_blob.nil?
+
+    cropped = Ingestion::DishPhotoCropper.call(source: source_blob, bbox: image_bbox)
+    created_item.photo.attach(
+      io:           cropped.io,
+      filename:     "dish-#{created_item.id}.jpg",
+      content_type: cropped.content_type
+    )
+  rescue StandardError => e
+    Rails.logger.warn(
+      "IngestionItem##{id} promote! photo attach skipped: #{e.class} #{e.message}"
+    )
   end
 end

--- a/apps/api/app/models/item.rb
+++ b/apps/api/app/models/item.rb
@@ -2,6 +2,11 @@ class Item < ApplicationRecord
   STATUSES   = %w[draft published removed].freeze
   CONFIDENCE = %w[confirmed suggested inferred].freeze
 
+  # Phase 4.11.3 — same shape as Review#photo so the same upload paths
+  # and any future shared helpers (resize variants, etc.) work for both.
+  MAX_PHOTO_BYTES = 5 * 1024 * 1024
+  ALLOWED_PHOTO_TYPES = %w[image/jpeg image/jpg image/png image/heic image/heif image/webp].freeze
+
   belongs_to :restaurant
   belongs_to :menu_section, optional: true
   belongs_to :created_by_user, class_name: "User", optional: true
@@ -15,9 +20,13 @@ class Item < ApplicationRecord
   has_many :reviews,          dependent: :destroy
   has_many :user_item_overrides, dependent: :destroy
 
+  has_one_attached :photo
+
   validates :name, presence: true
   validates :status,     inclusion: { in: STATUSES }
   validates :confidence, inclusion: { in: CONFIDENCE }
+  validate  :photo_within_size_limit
+  validate  :photo_is_an_allowed_image_type
 
   scope :published, -> { where(status: "published") }
 
@@ -32,4 +41,18 @@ class Item < ApplicationRecord
     return all if avoid_ids.blank?
     where.not("tag_ids && ARRAY[?]::uuid[]", avoid_ids)
   }
+
+  private
+
+  def photo_within_size_limit
+    return unless photo.attached?
+    return if photo.byte_size <= MAX_PHOTO_BYTES
+    errors.add(:photo, "must be #{MAX_PHOTO_BYTES / 1.megabyte} MB or smaller")
+  end
+
+  def photo_is_an_allowed_image_type
+    return unless photo.attached?
+    return if ALLOWED_PHOTO_TYPES.include?(photo.content_type)
+    errors.add(:photo, "must be one of #{ALLOWED_PHOTO_TYPES.join(', ')}")
+  end
 end

--- a/apps/api/spec/models/ingestion_item_spec.rb
+++ b/apps/api/spec/models/ingestion_item_spec.rb
@@ -78,5 +78,57 @@ RSpec.describe IngestionItem, type: :model do
 
       expect { orphan_item.promote! }.to raise_error(/no restaurant/)
     end
+
+    # Phase 4.11.3 — when Anthropic vision marked a per-dish photo on
+    # the source page (image_bbox jsonb populated by 4.11.2), promote!
+    # crops it out and attaches it to the new Item. Must be best-effort
+    # so a single bad bbox doesn't block the whole verify queue.
+    describe "dish photo attachment" do
+      let(:menu_path) { Rails.root.join("spec/fixtures/menus/sample.jpg") }
+
+      before do
+        run.inputs.attach(
+          io:           File.open(menu_path, "rb"),
+          filename:     "menu.jpg",
+          content_type: "image/jpeg"
+        )
+      end
+
+      it "attaches a cropped photo when image_bbox is present" do
+        item.update!(image_bbox: { "x" => 0.4, "y" => 0.4, "w" => 0.2, "h" => 0.2 })
+
+        promoted = item.promote!
+
+        expect(promoted.photo).to be_attached
+        expect(promoted.photo.content_type).to eq("image/jpeg")
+        expect(promoted.photo.byte_size).to be > 0
+      end
+
+      it "leaves photo unattached when image_bbox is nil" do
+        promoted = item.promote!
+        expect(promoted.photo).not_to be_attached
+      end
+
+      it "swallows cropper errors so promotion still succeeds" do
+        # Bad bbox (x out of range) makes DishPhotoCropper raise. The
+        # rescue must keep promotion succeeding without an attachment.
+        item.update!(image_bbox: { "x" => 1.5, "y" => 0.1, "w" => 0.1, "h" => 0.1 })
+
+        expect(Rails.logger).to receive(:warn).with(/InvalidBboxError/)
+        expect { item.promote! }.not_to raise_error
+        expect(item.reload.item.photo).not_to be_attached
+        expect(item.decision).to eq("accepted")
+      end
+
+      it "leaves photo unattached when the run has no source blob" do
+        # Edge case: bbox set but inputs purged (operator cleanup, etc.).
+        # Should silently skip rather than blow up.
+        run.inputs.purge
+        item.update!(image_bbox: { "x" => 0.4, "y" => 0.4, "w" => 0.2, "h" => 0.2 })
+
+        promoted = item.promote!
+        expect(promoted.photo).not_to be_attached
+      end
+    end
   end
 end

--- a/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_spec.rb
@@ -357,4 +357,23 @@ RSpec.describe "GET /api/v1/restaurants/:id/items", type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe "photo_url payload (Phase 4.11.3)" do
+    it "echoes a signed blob URL for items with an attached photo" do
+      carne_taco.photo.attach(
+        io:           StringIO.new("\xff\xd8\xff\xe0fake-jpeg-bytes".b),
+        filename:     "carne.jpg",
+        content_type: "image/jpeg"
+      )
+
+      get "/api/v1/restaurants/#{restaurant.id}/items"
+
+      items = response.parsed_body["items"].index_by { |i| i["name"] }
+      expect(items["Carne Asada Taco"]["photo_url"]).to be_a(String)
+      expect(items["Carne Asada Taco"]["photo_url"]).to match(%r{/rails/active_storage/blobs/})
+      # Items without an attachment carry an explicit null so clients
+      # can pattern-match without an `in payload` check.
+      expect(items["Cheese Quesadilla"]["photo_url"]).to be_nil
+    end
+  end
 end

--- a/apps/mobile/__tests__/lib/restaurants.test.ts
+++ b/apps/mobile/__tests__/lib/restaurants.test.ts
@@ -122,6 +122,7 @@ describe('groupItemsBySection', () => {
       menu_section_name: null,
       status: 'visible',
       reasons: [],
+      photo_url: null,
       ...overrides,
     };
   }

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -58,6 +58,12 @@ export interface RestaurantItem extends FilterableItem {
   overridden_by_user?: boolean;
   /** Phase 4.4 — total review count, populated for both anon + auth. */
   reviews_count?: number;
+  /**
+   * Phase 4.11.3 — signed `rails_blob_url` for the dish photo cropped
+   * out of the source menu page. Null for items extracted before
+   * 4.11.2 / for menu items with no inline photo.
+   */
+  photo_url: string | null;
 }
 
 export interface FilterSummary {

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -54,6 +54,12 @@ export interface RestaurantItem extends FilterableItem {
   overridden_by_user?: boolean;
   /** Phase 4.4 — total review count, populated for both anon + auth. */
   reviews_count?: number;
+  /**
+   * Phase 4.11.3 — signed `rails_blob_url` for the dish photo cropped
+   * out of the source menu page. Null for items extracted before
+   * 4.11.2 / for menu items with no inline photo.
+   */
+  photo_url: string | null;
 }
 
 export interface FilterSummary {

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,32 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 15:21 — tick #73. PR #167 (Phase 4.11.1 cropper) merged at
+14:51 UTC. **Anthropic still capped** until 2026-05-01 00:00 UTC
+(~9h away) — skipped retry of the 4.11.0 cassette + 4.11.2 prompt
+work, pivoted to 4.11.3 (consumer-side promote/serialize) which has
+zero Anthropic dependency. Item gains `has_one_attached :photo`
+(reuses Phase 4.3's MAX_PHOTO_BYTES + ALLOWED_PHOTO_TYPES). Extended
+`IngestionItem#promote!` with a `attach_dish_photo!(created)` rescue
+block: when `image_bbox` is present, fetches the run's first source
+blob and crops via `Ingestion::DishPhotoCropper`, attaches the JPEG
+to the new Item.photo. Cropper failures (bad bbox, unreadable blob,
+no source) log + skip — promotion always succeeds so a single weird
+coordinate doesn't block the verify queue. Items endpoint serializer
+emits `photo_url` (signed `rails_blob_url` with PUBLIC_HOST/
+request.base_url fallback, mirrors Phase 4.3's review pattern);
+preloaded `photo_attachment: :blob` on both index + show to skip
+N+1. RestaurantItem TS types in web + mobile gain
+`photo_url: string | null`. Mobile factory updated with
+`photo_url: null` default. Tests: 5 new specs (4 promote behavior +
+1 serializer payload) — rspec 329/0/1 pending; pnpm typecheck +
+lint cached green; mobile + web vitest/jest green. Pre-4.11.2
+ingestions stay null on the bbox column so this is a no-op for
+them; once 4.11.2 lands, photos flow through with no further
+consumer changes. **Date fix**: prior tick #72 mis-stamped itself
+2026-05-01; actual UTC clock today is 2026-04-30 (PR #167 merge
+timestamp confirms).
+
 2026-05-01 14:30 — tick #72. PR #166 (Phase 4.11 plan + master fix) merged at 14:18 UTC.
 **Cassette PR (4.11.0) blocked again**: tried recording with the same
 sample.jpg, hit HTTP 400 "regain access on 2026-05-01 at 00:00 UTC"


### PR DESCRIPTION
## Why

Phase 4.11.3 from `docs/plans/phase-4.11-dish-photos.md`. Wires the
**consumer** side of per-dish photo extraction so when Anthropic
vision starts emitting bboxes (Phase 4.11.2, still cap-blocked), the
photos flow through promote → Item.photo → restaurant page with no
further changes.

This depends only on the cropper service shipped in #167, not on
Anthropic — `image_bbox` stays null for pre-4.11.2 ingestions and
`#promote!` quietly no-ops on the photo path for them.

## What

- **`Item`** gains `has_one_attached :photo` with the same 5MB +
  jpeg/png/heic/webp validations as `Review#photo` from Phase 4.3
  (constants live on the model so the rule is byte-identical).
- **`IngestionItem#promote!`** gets a `attach_dish_photo!(created)`
  helper: when `image_bbox` is present, it fetches the run's first
  source blob and crops via `Ingestion::DishPhotoCropper`, attaching
  the JPEG to the new `Item.photo`. Cropper failures (bad bbox,
  unreadable blob, no source attached) `Rails.logger.warn` + skip —
  promotion always succeeds so a single weird coordinate from the
  model doesn't block the verify queue.
- **Items endpoint serializer** emits `photo_url` on every item
  (signed `rails_blob_url`, falls back to `request.base_url` when
  `PUBLIC_HOST` isn't set — same helper pattern as `ReviewsController`).
  Preloaded `photo_attachment: :blob` on both `index` and `show` to
  avoid N+1.
- **`RestaurantItem`** TS types in web + mobile gain
  `photo_url: string | null`. Mobile factory updated with `photo_url:
  null` default so existing tests still typecheck.

## Test plan

- [x] `bundle exec rspec` — 329/0/1 pending (5 new specs: 4 promote
      branches + 1 serializer payload)
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm --filter @biteworthy/mobile test` — 15/15 (restaurants suite)
- [x] `pnpm --filter @biteworthy/web test` — 61/61

## Notes

- **No bbox in the wild yet.** Until Phase 4.11.2 (Anthropic-cap
  blocked) lands the prompt + schema change to extract bboxes,
  every new ingestion will continue to leave `image_bbox` null
  and this code is a no-op. That's intentional — we're shipping
  honest infrastructure without faking the producer.
- **Multi-page menus.** `image_bbox` doesn't yet carry a page index,
  so this PR uses `inputs.blobs.first` as the source. When 4.11.2
  ships, the bbox jsonb shape can be extended (e.g. `page` key) and
  `attach_dish_photo!` updated to pick the right blob; out of scope
  here.
- **`PUBLIC_HOST`.** Production deploys (now that bite-worthy.com is
  registered) should set this so URLs work for clients on a
  different origin. Dev / CI fall back to `request.base_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)