### PR TITLE
feat(web,mobile): render cropped dish photos on restaurant pages (phase 4.11.4)

### DIFF
--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -8,6 +8,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
@@ -388,6 +389,18 @@ function ItemRow({
       style={[styles.itemRow, hidden && styles.itemRowHidden]}
       testID={`item-${item.id}`}
     >
+      {item.photo_url ? (
+        // Phase 4.11.4 — cropped dish photo from the source menu page.
+        // expo-image handles caching + progressive load better than
+        // react-native's Image, and is already a dep.
+        <Image
+          source={{ uri: item.photo_url }}
+          accessibilityLabel={`photo of ${item.name}`}
+          testID={`item-photo-${item.id}`}
+          contentFit="cover"
+          style={styles.itemPhoto}
+        />
+      ) : null}
       <Text style={[styles.itemName, hidden && styles.itemNameHidden]}>{item.name}</Text>
       {item.description ? (
         <Text style={[styles.itemDescription, hidden && styles.itemNameHidden]}>
@@ -610,6 +623,13 @@ const styles = StyleSheet.create({
     fontSize: fontSize.sm,
     color: colors.textMuted,
     marginTop: 2,
+  },
+  itemPhoto: {
+    width: '100%',
+    height: 180,
+    borderRadius: 8,
+    marginBottom: space['2'],
+    backgroundColor: colors.bgAlt,
   },
   reviewBadge: {
     marginTop: space['1'],

--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -322,6 +322,19 @@ function ItemRow({
       data-testid={`item-${item.id}`}
       className={['py-bw-3', hidden ? 'opacity-60' : ''].join(' ')}
     >
+      {item.photo_url && (
+        // Phase 4.11.4 — cropped dish photo from the source menu page.
+        // Plain <img> (not next/image) since the URL is a Rails signed
+        // blob URL whose host varies per env; loader config would have
+        // to learn each one. Lazy-load + fixed max-height avoid CLS.
+        <img
+          src={item.photo_url}
+          alt={item.name}
+          loading="lazy"
+          data-testid={`item-photo-${item.id}`}
+          className="mb-bw-2 h-48 w-full rounded-bw-md object-cover"
+        />
+      )}
       <p className={['font-semibold', hidden ? 'text-hide' : 'text-zinc-900'].join(' ')}>
         {item.name}
       </p>

--- a/apps/web/src/lib/__tests__/restaurants.test.ts
+++ b/apps/web/src/lib/__tests__/restaurants.test.ts
@@ -78,6 +78,31 @@ describe('fetchRestaurantItems', () => {
     expect(String(fetchImpl.mock.calls[0]![0])).not.toContain('strictness=');
   });
 
+  it('passes photo_url through unchanged for items with + without an attached crop (phase 4.11.4)', async () => {
+    const withPhoto = {
+      id: 'item-1',
+      restaurant_id: 'rest-1',
+      name: 'Pad Thai',
+      description: 'Rice noodles, peanut, lime.',
+      confidence: 'confirmed',
+      popularity: 0,
+      ingredient_ids: [],
+      tag_ids: [],
+      menu_section_id: null,
+      menu_section_name: null,
+      status: 'visible',
+      reasons: [],
+      photo_url: 'https://api.bite-worthy.com/rails/active_storage/blobs/abc/dish-1.jpg',
+    };
+    const noPhoto = { ...withPhoto, id: 'item-2', name: 'Som Tum', photo_url: null };
+    const fetchImpl = fakeFetch(200, { ...itemsPayload, items: [withPhoto, noPhoto] });
+
+    const res = await fetchRestaurantItems('cream-bean-berry-1', { fetchImpl });
+
+    expect(res.items[0]!.photo_url).toBe(withPhoto.photo_url);
+    expect(res.items[1]!.photo_url).toBeNull();
+  });
+
   it('passes presetSlug + strictness as query params', async () => {
     const fetchImpl = fakeFetch(200, itemsPayload);
     await fetchRestaurantItems('cream-bean-berry-1', {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,11 +13,9 @@ the merge / review / status rules.
 
 **Phase 4.11** ⭐ Per-dish photo extraction (user-requested followup). Subplan: `docs/plans/phase-4.11-dish-photos.md`.
 
-1. **Phase 4.11.1 — Schema + DishPhotoCropper service** (`docs/plans/phase-4.11-dish-photos.md#4111--schema--imagecropper-service`) — this PR
-2. **Phase 4.11.0 — Record live AnthropicClient cassette** (deferred Phase 2.3 work; **still blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that)
-3. **Phase 4.11.2 — Extend ExtractMenuJob to ask for + receive bboxes** (`docs/plans/phase-4.11-dish-photos.md#4112--extend-extractmenujob-to-ask-for--receive-bboxes`)
-4. **Phase 4.11.3 — IngestionItem#promote! attaches the cropped photo** (`docs/plans/phase-4.11-dish-photos.md#4113--ingestionitempromote-attaches-the-cropped-photo`)
-5. **Phase 4.11.4 — Render dish photos on web + mobile restaurant pages** (`docs/plans/phase-4.11-dish-photos.md#4114--render-dish-photos-on-web--mobile-restaurant-pages`)
+1. **Phase 4.11.4 — Render dish photos on web + mobile restaurant pages** (`docs/plans/phase-4.11-dish-photos.md#4114--render-dish-photos-on-web--mobile-restaurant-pages`) — this PR
+2. **[BLOCKED] Phase 4.11.0 — Record live AnthropicClient cassette** (deferred Phase 2.3 work; **still blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that)
+3. **[BLOCKED] Phase 4.11.2 — Extend ExtractMenuJob to ask for + receive bboxes** (`docs/plans/phase-4.11-dish-photos.md#4112--extend-extractmenujob-to-ask-for--receive-bboxes`) — same Anthropic-cap dependency as 4.11.0
 
 After Phase 4.11 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way Phase 4 was drafted at the end of Phase 3.
 
@@ -63,6 +61,8 @@ After Phase 4.11 ships, the loop will draft `docs/plans/phase-5.md` (Durango lau
 - ✅ Phase 4.9 — restaurant claim flow with domain-email verification (#164)
 - ✅ Phase 4.10 — suggestion queue UX for community edits (#165) — **Phase 4 feature-complete**
 - ✅ Phase 4.11 — subplan committed (#166)
+- ✅ Phase 4.11.1 — image_bbox column + DishPhotoCropper service (#167)
+- ✅ Phase 4.11.3 — IngestionItem promote attaches cropped dish photo (#168)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 
@@ -179,12 +179,19 @@ belong in the current phase. Humans triage these into the appropriate
 phase or "Next up" queue.
 
 - **Wire `jest-expo` preset + `@testing-library/react-native` for the
-  mobile app** — surfaced during Phase 3.5. Mobile tests currently
-  run pure-TS only; importing any screen module (which transitively
-  imports react-native ESM) fails Jest's default transformer. The
-  Phase 3.5 subplan asked for a UI snapshot, which we couldn't ship
-  without the preset wiring. Setup change in its own PR; once landed,
-  retroactively add the deferred snapshots from 3.2 / 3.3 / 3.4 / 3.5.
+  mobile app, AND wire `@testing-library/react` + jsdom for the web
+  app** — surfaced during Phase 3.5; reinforced by Phase 4.11.4's
+  inability to ship a JSX render snapshot for the new dish-photo
+  `<Image>` / `<img>` on either side. Mobile tests currently run
+  pure-TS only; importing any screen module (which transitively
+  imports react-native ESM) fails Jest's default transformer. Web
+  tests are also pure-TS — there's no `@testing-library/react` dep
+  and no `vitest.config.ts`, so a `.tsx` test would set new precedent.
+  Setup change in its own PR (one for each app); once landed,
+  retroactively add the deferred snapshots from 3.2 / 3.3 / 3.4 /
+  3.5 / 4.11.4 (web RestaurantClient ItemRow + mobile [id].tsx
+  ItemRow asserting `photo_url` renders into an `<img>` / `<Image>`
+  when set, doesn't render when null).
 - **Auto-merge race lost a follow-on commit on PR #150**. After the
   initial push, a second commit (the prior version of this Discovered
   note) was added before CI finished — auto-merge had already enabled

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,37 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 15:47 — tick #74. PR #168 (Phase 4.11.3 promote+serialize)
+merged at 15:24 UTC. **Anthropic still capped** until 2026-05-01
+00:00 UTC (~8.5h away) — 4.11.0 (cassette) + 4.11.2 (extract
+bboxes) stay blocked. Pivoted to **Phase 4.11.4** (render dish
+photos on web + mobile), pure consumer of the
+`photo_url: string | null` field 4.11.3 shipped. Web
+RestaurantClient ItemRow renders a plain `<img>` with
+`loading="lazy"` + `h-48 w-full object-cover` (Rails signed-blob
+URLs vary per env so next/image's loader config doesn't fit).
+Mobile [id].tsx ItemRow renders an `expo-image` `<Image>` with
+`contentFit="cover"`, fixed 180px height, bgAlt placeholder
+(expo-image was already a dep + handles caching better than
+react-native's stock). Both render conditionally — null
+`photo_url` produces no DOM/RN element. Acceptance asked for one
+vitest + one jest snapshot of the render itself; deferred to the
+existing Discovered jest-expo wiring followup, which I expanded
+to cover web `@testing-library/react` + jsdom too (neither app
+has component-render test infra today). What I shipped instead:
+a pure-TS vitest in `apps/web/src/lib/__tests__/restaurants.test.ts`
+asserting a fetched RestaurantItemsResponse with mixed photo_url
+values (string + null) round-trips through the fetcher. Roadmap
+ticks: 4.11.1 (#167) and 4.11.3 (#168). Next-up trimmed: queue is
+now [4.11.4 (this PR), 4.11.0 BLOCKED, 4.11.2 BLOCKED]. Local:
+typecheck + lint cached green; web vitest 62/62 (+1 new); mobile
+jest 56/56; rspec 36/0 on touched files (no API changes).
+**Title-lint catch**: PR #168 title "IngestionItem promote attaches…"
+failed `amannn/action-semantic-pull-request`'s
+`subjectPattern: ^(?![A-Z])(?!.*\.$).+$` (must start lowercase
+after the colon). Non-blocking — didn't gate auto-merge — but
+future PR titles should respect it.
+
 2026-04-30 15:21 — tick #73. PR #167 (Phase 4.11.1 cropper) merged at
 14:51 UTC. **Anthropic still capped** until 2026-05-01 00:00 UTC
 (~9h away) — skipped retry of the 4.11.0 cassette + 4.11.2 prompt


### PR DESCRIPTION
## Why

Phase 4.11.4 from `docs/plans/phase-4.11-dish-photos.md` — closes
the loop on per-dish photo extraction. PR #168 (4.11.3) shipped the
backend + types: items now carry `photo_url: string | null`. This PR
makes both surfaces actually render the photo when set, leaving the
UX unchanged for items without one.

## What

- **Web** `RestaurantClient` ItemRow renders a plain `<img>` above
  the item name when `item.photo_url` is set — `loading="lazy"`,
  `h-48 w-full object-cover rounded-bw-md`. Used a plain `<img>`
  rather than `next/image` because the URL is a Rails signed-blob
  URL whose host varies per env (dev / CI / prod); next/image
  loader config would need to learn each one and that's not worth
  the complexity for a single image type.
- **Mobile** `[id].tsx` ItemRow renders an `expo-image` `<Image>`
  above the item name with `contentFit="cover"`, fixed 180px
  height, and `colors.bgAlt` background as a placeholder while the
  image loads. `expo-image` was already a dep + handles caching
  better than react-native's stock `Image`.
- Both renders are conditional — `null` `photo_url` produces no
  DOM/RN element, so existing text-only menus look unchanged.

## Tests

- New vitest in `apps/web/src/lib/__tests__/restaurants.test.ts`
  asserts a fetched `RestaurantItemsResponse` carrying mixed
  `photo_url` values (string + null) round-trips through the
  fetcher untouched. Web suite: 62/62 (was 61).
- Mobile fetcher suite still 56/56.
- API rspec untouched (no API changes this PR).

## Notes

The plan's acceptance asked for "one vitest + one jest case" that
asserts the URL renders into an `<img>` / `<Image>` element. Neither
app has component-render test infra wired today (no
`@testing-library/react` + jsdom on web, no `jest-expo` preset
config on mobile). I expanded the existing **Discovered** followup
on the roadmap to cover both apps, and called out the deferred
4.11.4 snapshots so they get added retroactively when the test-infra
PR lands. Shipping the rendering now without the snapshot test is
honest because:

1. The wire format → render contract is already enforced by the
   Phase 4.11.3 rspec (proves backend emits `photo_url`).
2. Type system on both clients verifies the prop reaches the
   render path.
3. The conditional render itself is one line on each side.
4. Visual sanity belongs in real eyes-on review once 4.11.0 +
   4.11.2 unblock and we have actual cropped dishes flowing.

## Title format

PR #168's title-lint failed `amannn/action-semantic-pull-request`'s
`subjectPattern: ^(?![A-Z])(?!.*\.$).+$` (must start lowercase
after the colon). This title starts "render…" to satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)