### PR TITLE
feat(api): extend menu-extraction schema + prompt with image bboxes (phase 4.11.2 structural)

### DIFF
--- a/apps/api/app/jobs/resolve_tags_job.rb
+++ b/apps/api/app/jobs/resolve_tags_job.rb
@@ -68,6 +68,11 @@ class ResolveTagsJob < ApplicationJob
           tags_payload:            Array(item["tags"]),
           unresolved_ingredients:  Array(item["unresolved_ingredients"]),
           unresolved_tags:         Array(item["unresolved_tags"]),
+          # Phase 4.11.2 — bbox is optional in the schema; nil is the
+          # signal "no inline photo for this dish." Phase 4.11.3's
+          # IngestionItem#promote! reads this column to decide whether
+          # to crop + attach.
+          image_bbox:              item["image_bbox"],
           decision:                "pending"
         )
       end

--- a/apps/api/app/services/ingestion/extract_menu_prompt.rb
+++ b/apps/api/app/services/ingestion/extract_menu_prompt.rb
@@ -30,7 +30,8 @@ module Ingestion
                     "size": "<size label, or null when there is only one price>",
                     "price_cents": <integer cents, or null if absent>
                   }
-                ]
+                ],
+                "image_bbox": { "x": 0.0, "y": 0.0, "w": 0.0, "h": 0.0 }
               }
             ]
           }
@@ -45,6 +46,18 @@ module Ingestion
         emit one element per price in the `prices` array.
       * `price_cents` is in CENTS. "$4.50" becomes 450.
       * Output JSON only — no markdown fences, no commentary.
+
+      Per-dish photos:
+      * Many menus include a small photo of an individual dish next to
+        its name + description. When you see one, return its bounding
+        box as `image_bbox: { "x": <left>, "y": <top>, "w": <width>,
+        "h": <height> }`. All four are fractions in 0..1 of the source
+        page: 0,0 = top-left corner, 1,1 = bottom-right corner.
+      * If an item has NO inline photo on the page, OMIT the
+        `image_bbox` field entirely. Don't return zero-sized or null
+        boxes — absence means "no photo."
+      * If a single page contains multiple images, prefer the one
+        physically closest to the item's name + description.
     MD
 
     USER_INSTRUCTIONS = "Extract every menu item from these images."

--- a/apps/api/app/services/ingestion/menu_extraction_schema.rb
+++ b/apps/api/app/services/ingestion/menu_extraction_schema.rb
@@ -53,6 +53,35 @@ module Ingestion
                         price_cents: { type: %w[integer null], minimum: 0 }
                       }
                     }
+                  },
+                  # Phase 4.11.2 — optional per-dish bounding box for the
+                  # cropper (Phase 4.11.1 + 4.11.3). Coordinates are
+                  # fractions of the source page so resolution-independent:
+                  # 0,0 = top-left, 1,1 = bottom-right; w + h are the
+                  # box's width + height as fractions. Items without an
+                  # inline photo on the source page should omit this
+                  # field entirely. The `oneOf` shape is draft-04-safe
+                  # (json-schema gem default): a union type at the top
+                  # level dilutes the sub-object rules, so we
+                  # explicitly enumerate "null" + "fully-typed object."
+                  # `exclusiveMinimum: true` (boolean form) goes with
+                  # `minimum: 0` for w/h since draft-04 doesn't support
+                  # the numeric `exclusiveMinimum` form.
+                  image_bbox: {
+                    oneOf: [
+                      { type: "null" },
+                      {
+                        type: "object",
+                        required: %w[x y w h],
+                        additionalProperties: false,
+                        properties: {
+                          x: { type: "number", minimum: 0, maximum: 1 },
+                          y: { type: "number", minimum: 0, maximum: 1 },
+                          w: { type: "number", minimum: 0, exclusiveMinimum: true, maximum: 1 },
+                          h: { type: "number", minimum: 0, exclusiveMinimum: true, maximum: 1 }
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/apps/api/spec/jobs/resolve_tags_job_spec.rb
+++ b/apps/api/spec/jobs/resolve_tags_job_spec.rb
@@ -123,4 +123,61 @@ RSpec.describe ResolveTagsJob, type: :job do
       expect(run.failure_message).to start_with("resolve_tags_api_error: 500")
     end
   end
+
+  # Phase 4.11.2 — when the extractor's payload included image_bbox
+  # (per-item bounding box for the inline dish photo), materialize
+  # must copy it onto the IngestionItem so Phase 4.11.3's promote!
+  # can crop + attach. Items without a bbox carry nil so the
+  # promote-time cropper skip kicks in cleanly.
+  describe "image_bbox from extraction" do
+    let(:staging_with_bbox) do
+      {
+        "sections" => [
+          { "name" => "Appetizers", "items" => [
+              { "name" => "Spring Rolls",
+                "description" => "Crispy veggie.",
+                "prices" => [{ "size" => nil, "price_cents" => 600 }],
+                "ingredients" => [],
+                "unresolved_ingredients" => [],
+                "image_bbox" => { "x" => 0.1, "y" => 0.2, "w" => 0.3, "h" => 0.25 } },
+              { "name" => "Tom Yum",
+                "description" => "Hot + sour soup.",
+                "prices" => [{ "size" => nil, "price_cents" => 800 }],
+                "ingredients" => [],
+                "unresolved_ingredients" => [] }
+            ] }
+        ]
+      }
+    end
+
+    let(:run_with_bbox) do
+      create(:ingestion_run,
+             restaurant: restaurant, status: "resolving",
+             staging:    staging_with_bbox,
+             state_history: { "extracting" => 5.minutes.ago.utc.iso8601,
+                              "resolving"  => Time.current.utc.iso8601 })
+    end
+
+    let(:empty_tag_response) do
+      { "items" => [
+        { "index" => 0, "resolved" => [], "unresolved" => [] },
+        { "index" => 1, "resolved" => [], "unresolved" => [] }
+      ] }
+    end
+
+    before do
+      allow_any_instance_of(AnthropicClient)
+        .to receive(:messages_create).and_return(empty_tag_response)
+    end
+
+    it "copies image_bbox onto the IngestionItem when present, leaves nil otherwise" do
+      described_class.perform_now(run_with_bbox.id)
+
+      with_photo    = IngestionItem.find_by(name: "Spring Rolls")
+      without_photo = IngestionItem.find_by(name: "Tom Yum")
+
+      expect(with_photo.image_bbox).to eq("x" => 0.1, "y" => 0.2, "w" => 0.3, "h" => 0.25)
+      expect(without_photo.image_bbox).to be_nil
+    end
+  end
 end

--- a/apps/api/spec/services/ingestion/menu_extraction_schema_spec.rb
+++ b/apps/api/spec/services/ingestion/menu_extraction_schema_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+require "json-schema"
+
+# Phase 4.11.2 — guards the structural schema change that lets
+# Anthropic vision return a per-dish bbox alongside the text fields.
+# The validator runs through AnthropicClient::ResponseParser at runtime,
+# but the rules belong to the schema constant — so this spec hits it
+# directly to keep failures pinpointed.
+RSpec.describe Ingestion::MenuExtractionSchema do
+  let(:schema) { described_class }
+
+  def validate(payload)
+    JSON::Validator.fully_validate(schema, payload)
+  end
+
+  let(:base_item) do
+    {
+      "name"        => "Spring Rolls",
+      "description" => "Crispy veggie rolls.",
+      "prices"      => [{ "size" => nil, "price_cents" => 600 }]
+    }
+  end
+
+  let(:base_payload) do
+    { "sections" => [{ "name" => "Appetizers", "items" => [base_item] }] }
+  end
+
+  it "accepts a payload with no image_bbox (text-only menu)" do
+    expect(validate(base_payload)).to be_empty
+  end
+
+  it "accepts a well-formed image_bbox" do
+    item = base_item.merge("image_bbox" => { "x" => 0.5, "y" => 0.1, "w" => 0.2, "h" => 0.15 })
+    payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+    expect(validate(payload)).to be_empty
+  end
+
+  it "accepts a null image_bbox (some models prefer null over omission)" do
+    item = base_item.merge("image_bbox" => nil)
+    payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+    expect(validate(payload)).to be_empty
+  end
+
+  it "rejects an image_bbox missing a key" do
+    item = base_item.merge("image_bbox" => { "x" => 0.5, "y" => 0.1, "w" => 0.2 })
+    payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+    errors = validate(payload)
+    expect(errors).not_to be_empty
+    expect(errors.join("\n")).to match(/required.*h|h.*required/i)
+  end
+
+  it "rejects an image_bbox with x out of [0,1]" do
+    item = base_item.merge("image_bbox" => { "x" => 1.5, "y" => 0.1, "w" => 0.2, "h" => 0.2 })
+    payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+    expect(validate(payload)).not_to be_empty
+  end
+
+  it "rejects an image_bbox with zero width (exclusiveMinimum)" do
+    item = base_item.merge("image_bbox" => { "x" => 0.1, "y" => 0.1, "w" => 0, "h" => 0.2 })
+    payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+    expect(validate(payload)).not_to be_empty
+  end
+
+  it "rejects an unknown property in image_bbox (additionalProperties: false)" do
+    item = base_item.merge(
+      "image_bbox" => { "x" => 0.1, "y" => 0.1, "w" => 0.2, "h" => 0.2, "rotation" => 5 }
+    )
+    payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+    expect(validate(payload)).not_to be_empty
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,9 +13,8 @@ the merge / review / status rules.
 
 **Phase 4.11** ⭐ Per-dish photo extraction (user-requested followup). Subplan: `docs/plans/phase-4.11-dish-photos.md`.
 
-1. **Phase 4.11.4 — Render dish photos on web + mobile restaurant pages** (`docs/plans/phase-4.11-dish-photos.md#4114--render-dish-photos-on-web--mobile-restaurant-pages`) — this PR
-2. **[BLOCKED] Phase 4.11.0 — Record live AnthropicClient cassette** (deferred Phase 2.3 work; **still blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that)
-3. **[BLOCKED] Phase 4.11.2 — Extend ExtractMenuJob to ask for + receive bboxes** (`docs/plans/phase-4.11-dish-photos.md#4112--extend-extractmenujob-to-ask-for--receive-bboxes`) — same Anthropic-cap dependency as 4.11.0
+1. **Phase 4.11.2 — Extend MenuExtractionSchema + prompt + materialize image_bbox (structural)** (`docs/plans/phase-4.11-dish-photos.md#4112--extend-extractmenujob-to-ask-for--receive-bboxes`) — this PR. Per the subplan's Stop clause, the structural part (schema+prompt+materialize+specs) ships now; live cassette recording follows when the Anthropic cap clears.
+2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the bbox prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that.
 
 After Phase 4.11 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way Phase 4 was drafted at the end of Phase 3.
 
@@ -63,6 +62,7 @@ After Phase 4.11 ships, the loop will draft `docs/plans/phase-5.md` (Durango lau
 - ✅ Phase 4.11 — subplan committed (#166)
 - ✅ Phase 4.11.1 — image_bbox column + DishPhotoCropper service (#167)
 - ✅ Phase 4.11.3 — IngestionItem promote attaches cropped dish photo (#168)
+- ✅ Phase 4.11.4 — render cropped dish photos on restaurant pages (#169)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,41 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 16:17 — tick #75. PR #169 (Phase 4.11.4 photo render)
+merged at 15:48 UTC with all CI green including title-lint (the
+lowercase-after-colon convention now baked in). Anthropic still
+capped until 2026-05-01 00:00 UTC (~7.5h away). Next-up was
+all-`[BLOCKED]` so I re-read the 4.11.2 subplan: its **Stop**
+clause explicitly says "if capped, push the schema + prompt + spec
+stub and skip the live re-record." Pivoted to **Phase 4.11.2
+structural** — everything except the live cassette recording.
+- `MenuExtractionSchema` gains optional per-item `image_bbox`
+  shaped as `oneOf: [null, {x, y, w, h}]`. Restructured from
+  `type: [object, null]` to `oneOf` because json-schema gem
+  defaults to draft-04 where union types dilute sub-object rules
+  (caught by the spec — first 2 cases failed until I switched).
+  Also `exclusiveMinimum: true` (boolean form) for w/h since
+  draft-04 doesn't support the numeric form. Items omit the field
+  entirely when no inline photo; null also accepted defensively.
+- `ExtractMenuPrompt::SYSTEM_INSTRUCTIONS` gets a "Per-dish
+  photos" paragraph: 0,0=top-left, 1,1=bottom-right, omit when no
+  inline photo, prefer the photo physically closest to the item
+  name when a page has multiple.
+- `ResolveTagsJob#materialize_ingestion_items!` copies
+  `item["image_bbox"]` (or nil) onto IngestionItem so 4.11.3's
+  promote! crops + attaches without further plumbing.
+- New spec `spec/services/ingestion/menu_extraction_schema_spec.rb`
+  (7 cases) + extended resolve_tags_job_spec covering bbox flow.
+Roadmap: ticked 4.11.4 (#169); reorganized Next-up so 4.11.2
+structural (this PR) is #1 and the combined 4.11.0 / 4.11.2
+cassette work is #2 (BLOCKED, single recording covers both since
+VCR body-matching auto-supersedes the older cassette). Local:
+rspec 337/0/1 pending (+8); pnpm typecheck + lint cached green.
+**Phase 4.11 status after this PR**: every line of consumer-side
+code is on master + the extractor is asking the model for bboxes;
+the only outstanding work is the live recording when the cap
+clears.
+
 2026-04-30 15:47 — tick #74. PR #168 (Phase 4.11.3 promote+serialize)
 merged at 15:24 UTC. **Anthropic still capped** until 2026-05-01
 00:00 UTC (~8.5h away) — 4.11.0 (cassette) + 4.11.2 (extract


### PR DESCRIPTION
## Why

Phase 4.11.2 from `docs/plans/phase-4.11-dish-photos.md` — the
producer side of per-dish photo extraction. The subplan's **Stop**
clause says: "needs `ANTHROPIC_API_KEY` recording. If capped, push
the schema + prompt + spec stub and skip the live re-record like
the Phase 2.3 cassette PR did." Anthropic remains capped until
2026-05-01 00:00 UTC (~7.5h from this PR), so this PR ships the
structural piece. The cassette recording follows when the cap
clears (combined Phase 4.11.0 / 4.11.2-cassette PR).

## What

- **Schema**: `MenuExtractionSchema` gains optional per-item
  `image_bbox` shaped as `oneOf: [null, {x, y, w, h}]`. All four
  coordinates are numbers in `0..1` (fractions of the source page);
  `w` and `h` use `exclusiveMinimum: true` to enforce positive
  size. `additionalProperties: false` on the bbox object so the
  model can't smuggle extra fields. Used `oneOf` rather than
  `type: [object, null]` because the json-schema gem defaults to
  draft-04 where union types dilute sub-object rules — the spec
  caught this.
- **Prompt**: `ExtractMenuPrompt::SYSTEM_INSTRUCTIONS` gets one
  paragraph: when an inline dish photo exists, return its
  normalized bbox (0,0 = top-left, 1,1 = bottom-right); omit the
  field entirely when no photo; if a page has multiple images,
  prefer the one physically closest to the item name.
- **Materialize**: `ResolveTagsJob#materialize_ingestion_items!`
  copies `item["image_bbox"]` (or nil) onto the new IngestionItem
  so Phase 4.11.3's `promote!` crops + attaches with no further
  plumbing.

## Tests

- New `spec/services/ingestion/menu_extraction_schema_spec.rb` —
  7 cases: text-only menu (no bbox), well-formed bbox, null bbox,
  missing key, x out of `[0,1]`, zero width, unknown property.
- Extended `spec/jobs/resolve_tags_job_spec.rb`: bbox-bearing
  extraction flows into `IngestionItem.image_bbox`; bbox-less
  items carry nil.
- Full rspec: 337/0/1 pending (+8 from baseline). pnpm typecheck +
  lint cached green (no JS changes).

## Notes — what's left for Phase 4.11

After this PR merges, Phase 4.11 is **structurally complete on
both sides** (extractor → schema → materialize → promote → crop →
attach → render). The only outstanding work is the **live
cassette recording** for end-to-end validation, which is one
combined PR for 4.11.0 + 4.11.2-cassette (VCR body-matching
auto-supersedes the older cassette). Blocked on the Anthropic cap
reset; will retry from the next loop tick after 2026-05-01 00:00
UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)