### PR TITLE
docs: phase 5 subplan + queue (loop plan-update PR)

### DIFF
--- a/docs/plans/phase-5.md
+++ b/docs/plans/phase-5.md
@@ -1,0 +1,188 @@
+# Phase 5 — Launch (subplan)
+
+Phase 1 → 4 + 4.11 turned the codebase into a working product running on a developer laptop. Phase 5 turns it into something a real person in Durango can open on a Friday night and use to pick where to eat. The work splits into three buckets:
+
+1. **Production deploys** — API, web, mobile bundles all need a real public home plus the storage / email / blob infra they were stubbing in dev.
+2. **Public-facing surface** — marketing landing, SEO city pages, press kit. Today the web app's `/` is "hello"; nobody can find the product.
+3. **Seed data + launch motion** — 30 real Durango restaurants ingested, store submissions, instrumentation, outreach.
+
+**Demo at the end (the real one):** a real user in Durango opens bite-worthy.com on Friday at 6pm, picks "Celiac + tree-nut allergy", taps the nearest of 30 seeded restaurants, sees only the dishes that are safe, walks in and orders.
+
+## Stop conditions specific to Phase 5
+
+This phase has the most external-dependency surface of any phase so far. The loop's discipline is to ship the *wiring* and flag what needs a human credential or signature.
+
+- **Anthropic production billing** — the daily-cap reset that's blocked Phase 4.11.0 / 4.11.2-cassette is the same surface that limits a 30-restaurant ingest. The loop should NOT mass-ingest until a human confirms the project tier supports the run cost (~$10–15 for 30 menus at the Phase 2.9 dashboard's measured rates).
+- **SMTP credentials** — the Phase 4 stop condition still applies. Phase 5.2 picks a provider (recommend SES or Postmark), wires the env vars, ships an `bin/rails email:smoke` task. Live-send needs a human to drop creds in `.env.production`.
+- **S3 / R2 bucket** — Phase 2 + 4 deferred this. Phase 5.3 wires it; bucket creation + IAM + CORS need a human.
+- **App Store / Play Store team accounts** — Apple Developer Program ($99/yr) + Google Play Console ($25 one-time) need a human signature. EAS submit can drive the upload once credentials exist.
+- **Apple review timeline** — typically 1–7 days. Not blocking the loop but a real launch dependency. Submit early.
+- **Real menu PDFs / URLs for 30 Durango restaurants** — research task, not a coding task. The loop ships the batch-ingest tooling + a `seeds.csv` template; populating it is human work. (`docs/seeds/durango.csv.example` will list the columns.)
+- **DNS for bite-worthy.com** — domain is registered. Once the API host (5.1) + web host (5.4) are picked, DNS records need a human in the registrar.
+- **Privacy policy + terms** — App Store requires both. Phase 5.9 ships standard templates filled with BiteWorthy specifics; a human should have a lawyer skim before submission.
+
+## Tasks (one PR each)
+
+### 5.1 — Production API deploy: Fly.io + Postgres + Solid Queue
+
+**Branch**: `claude/phase-5.1-api-deploy`
+
+The Rails API needs a real public home so the mobile + web apps can hit something other than `localhost:3000`.
+
+- Pick Fly.io (Rails-friendly defaults, Solid Queue worker process is straightforward, predictable bill). Alternatives: Render, Railway. Decision recorded in a new `docs/adr/0002-production-hosting.md`.
+- `fly.toml` at `apps/api/`. Two processes: `web` (puma) + `worker` (`bin/jobs`). Postgres via `fly postgres create` (start with the cheapest dev tier; rotate to a real plan when seed data is in).
+- Required env: `RAILS_MASTER_KEY`, `DATABASE_URL`, `PUBLIC_HOST=https://api.bite-worthy.com`, `ANTHROPIC_API_KEY`, the omniauth + devise secrets from Phase 1.2. ADR documents the source of each.
+- Smoke task: `bin/rails biteworthy:production:smoke` hits `/up`, posts a no-op IngestionRun, fetches it back. Run it from CI on every deploy.
+- DNS: `api.bite-worthy.com` CNAME to the Fly app. Documented but human-applied (see Stop conditions).
+
+**Specs**: smoke task spec; existing rspec stays unchanged (same env shape).
+
+**Acceptance**: `curl https://api.bite-worthy.com/up` returns 200 from a fresh checkout.
+
+### 5.2 — SMTP wiring (real email for reviews + claims + password resets)
+
+**Branch**: `claude/phase-5.2-smtp`
+
+Phase 4.3 / 4.6 / 4.9 all stubbed mailers with `:test` adapter. Production needs real delivery.
+
+- Pick Postmark (best deliverability for transactional, generous free tier). Alternatives: SES (cheaper at scale but more wiring), SendGrid. Decision in ADR.
+- `config/environments/production.rb` switches `action_mailer.delivery_method = :smtp` with creds from `SMTP_*` env vars.
+- All existing mailer templates render-tested against a real Postmark sandbox. Layout pulled from `_legacy/` if anything reusable; otherwise plain text + minimal HTML.
+- `bin/rails email:smoke` task that posts one of each kind (review confirmation, claim verification, password reset) to a configurable address and reports the Postmark message-id.
+
+**Specs**: ActionMailer test envs prove the templates render with the expected variables; live-send is a manual smoke per Stop conditions.
+
+**Acceptance**: a human runs `email:smoke EMAIL=skylar@…` and receives all three.
+
+### 5.3 — ActiveStorage S3 / R2 (review + dish photos in production)
+
+**Branch**: `claude/phase-5.3-blob-storage`
+
+Phase 2 + 4 + 4.11 all noted that local-disk ActiveStorage is fine in dev/CI but production needs real object storage. This is that PR.
+
+- Pick Cloudflare R2 (S3-compatible, no egress charges — meaningful for image-heavy traffic). Falls back to AWS S3 with no code changes if the human prefers. Decision in ADR.
+- `config/storage.yml` gains `:r2` (and keeps `:amazon` for the fallback). `production.rb` flips `active_storage.service = :r2`.
+- Required env: `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_ENDPOINT`. Documented in `.env.example`.
+- One small change to `ReviewsController#photo_url_for` + the equivalent in `ItemsController` (Phase 4.11.3): the signed URL now points at R2's public endpoint rather than `request.base_url`. PUBLIC_HOST env var still drives the production host.
+- Backfill task: `bin/rails biteworthy:storage:backfill` re-uploads any local-disk attachments to R2 (no-op if already on R2). Idempotent.
+
+**Specs**: ActiveStorage URL helpers in test mode unchanged; the only new spec is the backfill task's idempotence on already-migrated blobs.
+
+**Acceptance**: a review photo posted via mobile in production survives a server restart and renders on the web restaurant page.
+
+### 5.4 — Production web deploy: Vercel + bite-worthy.com
+
+**Branch**: `claude/phase-5.4-web-deploy`
+
+- Pick Vercel (Next.js native, free tier handles a Durango-scale beta). Alternative: Cloudflare Pages. ADR.
+- `apps/web/vercel.json` if any custom routing is needed; default Next.js detection should suffice.
+- Env: `NEXT_PUBLIC_API_BASE=https://api.bite-worthy.com`. Cookie domain set to `.bite-worthy.com` so the JWT cookie from Phase 4.1 works across `www` + `app` if we add a subdomain later.
+- DNS: `bite-worthy.com` apex to Vercel + `www.bite-worthy.com` CNAME. Human-applied per Stop conditions.
+- `robots.txt` allows everything; `sitemap.xml` generated from `app/sitemap.ts` covers `/`, `/durango/[diet]` (5.6), and the seeded restaurant pages.
+
+**Specs**: vitest for the sitemap generator; smoke that the `/up` proxy from web → API resolves.
+
+**Acceptance**: `https://bite-worthy.com` resolves to the marketing landing and the SSR restaurant pages work.
+
+### 5.5 — Marketing landing page at `/`
+
+**Branch**: `claude/phase-5.5-landing`
+
+The current root is a leftover "hello" page. Replaces it with a real first impression.
+
+- Hero: "See only the dishes you can eat." Subhead explains the dietary filter in one sentence. CTA buttons: "Get the iOS app", "Get the Android app", "Try the web app" (deeplinks to App Store / Play Store / `/restaurants`).
+- Three-up feature explainer: scan menu → pick filter → see safe dishes. Each with a screenshot from a real seeded restaurant page.
+- Footer: privacy, terms, press, GitHub link, Durango focus statement.
+- Pure SSR — no client islands needed. Tailwind-only. Reuses `@biteworthy/ui-tokens` colors so the brand stays consistent with the apps.
+- Open Graph + Twitter card meta tags so shared links look right.
+
+**Specs**: vitest for the meta-tag composition (deterministic strings). Visual review on a deployed preview.
+
+### 5.6 — SEO landing pages: `/durango/[diet]`
+
+**Branch**: `claude/phase-5.6-city-diet-pages`
+
+Parameterized routes that index well for "celiac restaurants Durango", "vegan Durango", etc. — the actual queries Durango folks already type.
+
+- Route: `app/durango/[diet]/page.tsx`. `[diet]` is a slug from `DietaryProfile`; 404 if unknown.
+- SSR fetches the 30 seeded restaurants, applies the preset's filter on the server, ranks by `(visible_count desc, name asc)`. Each row shows: restaurant name + neighborhood + count of visible items + a "see menu" deep link.
+- Per-page meta: `<title>Vegan restaurants in Durango — BiteWorthy</title>`, og:image generated server-side (a static template with the diet name overlaid; can be hand-polished later).
+- `sitemap.ts` enumerates one URL per active dietary preset.
+
+**Specs**: vitest for the ranking + filtering logic; request-spec smoke for the 30-restaurant payload.
+
+**Acceptance**: Google's mobile-friendly tester gives `/durango/gluten-free` a passing grade after deploy.
+
+### 5.7 — Seed 30 Durango restaurants via the ingestion pipeline
+
+**Branch**: `claude/phase-5.7-durango-seed`
+
+Operator-driven batch ingest. The pipeline already works (Phase 2 + 4.11); this PR adds the workflow for running it 30 times from a CSV.
+
+- New `docs/seeds/durango.csv.example`: columns `name`, `address`, `phone`, `website`, `menu_source` (URL or local PDF path), `neighborhood`. Real seeding lives in a private repo + uses an unchecked `durango.csv`.
+- `bin/rails biteworthy:seed:durango FILE=durango.csv`: each row creates a `Restaurant`, kicks off an `IngestionRun` (URL or PDF entrypoint per Phase 2.8), polls until staged-or-failed, prints a status line. Reuses Phase 2.9's cost dashboard for the per-run accounting.
+- New Avo dashboard tile: "Durango seed run" — running totals of staged / published / failed across the batch.
+- The run does NOT auto-publish — the 80%-accepted threshold from Phase 2.5 still gates publication via the swipe-verify queue. A human still verifies each menu before it goes live.
+
+**Specs**: rake task spec with a small CSV fixture (3 fake restaurants, fully mocked Anthropic); Avo tile spec.
+
+**Acceptance**: running the task against the real CSV ends with 30 staged runs in `/admin/dashboard`, all under the projected $15 budget.
+
+### 5.8 — PostHog funnel wiring (real instrumentation)
+
+**Branch**: `claude/phase-5.8-posthog`
+
+Phase 3 + 4 emitted placeholder `track(...)` events; this lights them up.
+
+- Picks PostHog Cloud (generous free tier for a launch; self-host later if volume warrants). ADR notes the trade-off vs Plausible / Mixpanel.
+- New `lib/track.ts` (web) + `lib/track.ts` (mobile): thin wrapper around `posthog-js` / `posthog-react-native`. `track(eventName, props)` no-ops in dev unless `POSTHOG_KEY` is set; honors `Do-Not-Track` and the in-app analytics toggle (new on `/profile/settings`).
+- Funnel events instrumented end-to-end: `app_open`, `profile_set`, `menu_filtered`, `restaurant_tap`, `filter_changed`, `review_posted`, `share_link_copied`, `restaurant_claimed`, `suggestion_submitted`. Each has a stable name + a documented payload schema in `docs/analytics.md`.
+- Server-side: `RecordRestaurantVisitJob` (Phase 4.8) doubles as the source of `restaurant_tap` for authenticated users so the funnel stays right even when JS analytics is blocked.
+
+**Specs**: unit tests for the wrapper (DNT respected, settings toggle respected, payload shape stable); fake `posthog` client.
+
+**Acceptance**: a real beta tester completes the full funnel; PostHog dashboard shows the conversion at each step.
+
+### 5.9 — Mobile app store submission (TestFlight + Play Store)
+
+**Branch**: `claude/phase-5.9-app-stores`
+
+- App icon + splash assets generated from `@biteworthy/ui-tokens` colors. Output to `apps/mobile/assets/` at the sizes Expo's `app.json` expects.
+- App Store + Play Store metadata in `apps/mobile/store-listing/`: name, subtitle, description, keywords, screenshots (5+ per device class). Screenshots scripted via `expo-router` test routes that drive the seeded restaurants from 5.7.
+- Privacy policy + terms — boilerplate templates in `apps/web/src/app/{privacy,terms}/page.tsx` (linked from the marketing landing 5.5 + the App Store submission). Filled with BiteWorthy-specific data flows; a human + lawyer should final-review.
+- EAS config: `eas.json` with `production` profile pointed at the App Store + Play Store build channels. `eas submit --platform=all` driven from CI on tag.
+- Initial submission is for **TestFlight beta** + **Internal Testing track**, NOT public release. Public release is gated on ~50 internal-tester sessions clean.
+
+**Specs**: pure-TS test for the screenshot-driver routes (URL composition); no end-to-end EAS test (that's a paid build).
+
+**Acceptance**: a beta link from TestFlight reaches at least 5 testers; one full week with no crash reports clears the path to public release.
+
+### 5.10 — Press kit + outreach (Durango launch)
+
+**Branch**: `claude/phase-5.10-press`
+
+- `/press` page on web: logo lockup (PNG + SVG), screenshots, a 50-word + 200-word product blurb, founder bio + photo, contact email, recent app store links.
+- Email templates in `docs/outreach/` for Durango press: Durango Telegraph, Durango Herald, La Plata Mountaineer, Local KSUT FM. One template per outlet shaped to their beat (Telegraph: dining; Herald: tech; KSUT: human-interest).
+- Soft-launch waitlist on the marketing landing (5.5): email-only form, stores in a new `waitlist_signups` table, sends a "you're on the list" confirmation via the 5.2 SMTP wiring. Emails get an "early access" blast 48h before public release.
+- Launch-day social posts staged in `docs/outreach/launch-day.md` (Twitter/X, Bluesky, Instagram, LinkedIn). Hashtag plan: `#Durango`, `#GlutenFree`, etc.
+
+**Specs**: request spec for the waitlist endpoint; vitest for the email-validation helper.
+
+**Acceptance**: at least three Durango outlets confirm they'll cover launch; the press page passes Lighthouse 95+ on mobile.
+
+## Cross-cutting
+
+- **OpenAPI codegen** — every new endpoint (`GET /api/v1/durango/restaurants`, the waitlist post) regenerates `packages/api-types/src/generated.ts` per the Phase 1.6 pipeline.
+- **Cost dashboard** — Phase 2.9's `/admin/dashboard` already tracks per-run Anthropic spend. Phase 5.7 + 5.8 add a "production health" tab: deploy status (5.1 / 5.4 healthchecks), error rate from PostHog, weekly active filter sessions.
+- **Discovered followups** — the existing `jest-expo` + `@testing-library/react` items remain in the queue. Phase 5.5 / 5.6 / 5.10 will add to that list if more JSX-render coverage gaps appear; the loop should keep these as standalone PRs rather than bundling.
+- **Auto-merge race** — the prior Discovered note about PR #150 stays open. Phase 5 has shorter PR cycles (deploys + content), so the race is more likely; consider gating auto-merge on a manual `ready-to-merge` label after the final push if a second occurrence happens.
+
+## Out of scope for Phase 5 (explicit)
+
+- **Stripe / payments** — no monetization in v1. Premium tier is a Phase 6+ conversation.
+- **Push notifications** — Phase 4 explicitly out-of-scoped this. Same here.
+- **Reservations / delivery integrations** — out per `docs/roadmap.md`.
+- **Cities outside Durango** — Phase 6+ gates expansion on the Durango funnel hitting a target conversion rate.
+- **Native iOS / Android codebase split** — Phase 0 ADR already ruled this out.
+- **Restaurant photo galleries** — `has_one_attached :photo` (Phase 4.11.3) ships one photo per dish; multi-photo galleries are Phase 6+.
+- **Social graph / feed / gamification** — explicitly NOT in v1 per the roadmap's NOT-doing list.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,12 +11,20 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
-**Phase 4.11** ⭐ Per-dish photo extraction (user-requested followup). Subplan: `docs/plans/phase-4.11-dish-photos.md`.
+**Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md` — committed this PR. Awaiting human review of the plan before items auto-run.
 
-1. **Phase 4.11.2 — Extend MenuExtractionSchema + prompt + materialize image_bbox (structural)** (`docs/plans/phase-4.11-dish-photos.md#4112--extend-extractmenujob-to-ask-for--receive-bboxes`) — this PR. Per the subplan's Stop clause, the structural part (schema+prompt+materialize+specs) ships now; live cassette recording follows when the Anthropic cap clears.
-2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the bbox prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that.
-
-After Phase 4.11 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way Phase 4 was drafted at the end of Phase 3.
+1. **Phase 5 subplan committed** — this PR. No code, just `docs/plans/phase-5.md` + Next-up reorder. **Phase 4.11 is structurally complete** (every line of consumer + producer code is on master); only the live cassette recording remains, which is now item #2 below.
+2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7 mass-ingests Durango menus.
+3. **Phase 5.1 — production API deploy (Fly.io + Postgres + Solid Queue)** (`docs/plans/phase-5.md#51--production-api-deploy-flyio--postgres--solid-queue`). Foundation for everything below.
+4. **Phase 5.2 — SMTP wiring** (`docs/plans/phase-5.md#52--smtp-wiring-real-email-for-reviews--claims--password-resets`). Closes the long-deferred email gap from Phase 4.
+5. **Phase 5.3 — ActiveStorage S3 / R2** (`docs/plans/phase-5.md#53--activestorage-s3--r2-review--dish-photos-in-production`). Closes the long-deferred blob-storage gap from Phase 2 + 4.
+6. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`).
+7. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
+8. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
+9. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
+10. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+11. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+12. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
 
@@ -63,6 +71,7 @@ After Phase 4.11 ships, the loop will draft `docs/plans/phase-5.md` (Durango lau
 - ✅ Phase 4.11.1 — image_bbox column + DishPhotoCropper service (#167)
 - ✅ Phase 4.11.3 — IngestionItem promote attaches cropped dish photo (#168)
 - ✅ Phase 4.11.4 — render cropped dish photos on restaurant pages (#169)
+- ✅ Phase 4.11.2 — extend menu-extraction schema + prompt with image bboxes (#170) — **Phase 4.11 structurally complete; live cassette recording is the only remaining task**
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,36 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 16:46 — tick #76. PR #170 (Phase 4.11.2 structural)
+merged at 16:18 UTC. Anthropic still capped (~7h to reset);
+Next-up was a single `[BLOCKED]` cassette item. Per the
+roadmap's stated cadence ("After Phase 4.11 ships, the loop
+will draft `docs/plans/phase-5.md` (Durango launch) the same way
+Phase 4 was drafted at the end of Phase 3"), and given Phase 4.11
+is **structurally complete** (every line of consumer + producer
+code on master after #170; cassette is the only outstanding
+work), this tick mirrors PR #155 — a plan-only PR drafting
+Phase 5. Decomposed Phase 5 into 10 tasks across three buckets:
+production deploys (5.1 Fly.io API, 5.2 SMTP Postmark, 5.3 R2
+ActiveStorage, 5.4 Vercel web on bite-worthy.com), public
+surface (5.5 marketing landing replacing /, 5.6 SEO
+/durango/[diet] pages), and seed + launch motion (5.7
+30-restaurant batch ingest from CSV, 5.8 PostHog funnel wiring
+real, 5.9 TestFlight + Play Internal app submission, 5.10 press
+kit + Durango outreach + waitlist). Stop conditions enumerated:
+Anthropic billing tier, SMTP creds, R2 bucket + IAM, App Store
++ Play Store team accounts, real Durango menu CSV (research
+task), DNS for bite-worthy.com, lawyer-skim of privacy/terms.
+Cross-cutting: OpenAPI codegen on every endpoint PR; existing
+Discovered followups (jest-expo + web RTL wiring; auto-merge
+race) carry over. Roadmap: ticked 4.11.2 (#170) + flagged Phase
+4.11 structurally complete; replaced Next-up with the Phase 5
+batch plus the holdover BLOCKED cassette PR. Local: pnpm
+typecheck + lint full-turbo cached green; no code changes.
+**Plan PR awaiting human review** — subsequent ticks will pick
+from the new queue (5.1 first once a human approves the plan;
+cassette retry once the cap clears at 2026-05-01 00:00 UTC).
+
 2026-04-30 16:17 — tick #75. PR #169 (Phase 4.11.4 photo render)
 merged at 15:48 UTC with all CI green including title-lint (the
 lowercase-after-colon convention now baked in). Anthropic still


### PR DESCRIPTION
## Summary

**Phase 4.11 is structurally complete** (every line of consumer +
producer code on master after #170; only the live cassette
recording remains, gated on the Anthropic cap reset at 2026-05-01
00:00 UTC). Per the roadmap's stated cadence ("After Phase 4.11
ships, the loop will draft `docs/plans/phase-5.md` (Durango
launch) the same way Phase 4 was drafted at the end of Phase 3"),
this is the plan-update PR for Phase 5. **No code, just planning
docs**, awaiting human review before items auto-run.

### Phase 5 — Launch (Durango)
Decomposed into 10 PR-sized tasks across three buckets:

**Production deploys**
1. **5.1** — API on Fly.io + Postgres + Solid Queue worker + `api.bite-worthy.com`.
2. **5.2** — SMTP via Postmark (closes the Phase 4 email gap).
3. **5.3** — ActiveStorage on Cloudflare R2 (closes the Phase 2 + 4 + 4.11 blob-storage gap).
4. **5.4** — Web on Vercel + `bite-worthy.com` apex/www.

**Public surface**
5. **5.5** — Marketing landing page replaces the current "hello" at `/`.
6. **5.6** — SEO `/durango/[diet]` pages parameterized by DietaryProfile slugs.

**Seed + launch motion**
7. **5.7** — Batch ingest 30 Durango restaurants from a CSV via the existing pipeline.
8. **5.8** — PostHog funnel wiring (replaces the placeholder events Phase 3 + 4 emitted).
9. **5.9** — Mobile app store submission: TestFlight + Play Internal (NOT public release).
10. **5.10** — Press kit page + Durango-press outreach templates + soft-launch waitlist.

### Stop conditions called out

This phase has the most external-dependency surface of any phase so far. The loop ships the wiring; humans drop credentials.

- **Anthropic billing tier** — same daily-cap surface that's blocking the cassette PR limits the 30-restaurant ingest.
- **SMTP creds** (Postmark or SES) — env-var task for a human after 5.2 ships the wiring.
- **S3 / R2 bucket** + IAM + CORS — human credential task for 5.3.
- **App Store + Play Store team accounts** — Apple Developer Program ($99/yr) + Google Play Console ($25 one-time).
- **Real Durango menu PDFs / URLs** — research task; the loop ships a CSV template + batch tool, populating it is human work.
- **DNS for bite-worthy.com** — domain registered (per user); records need configuring once 5.1 + 5.4 hosts are picked.
- **Privacy policy + terms** — App Store requires; 5.9 ships templates that a lawyer should skim.

### Cross-cutting

- OpenAPI codegen on every endpoint PR (Phase 1.6 pipeline).
- Existing **Discovered** followups carry over: jest-expo + web `@testing-library/react` wiring (blocks UI snapshots); the PR #150 auto-merge race (more likely to recur in Phase 5's shorter PR cycles).
- Phase 5 has a much higher external-dependency surface than prior phases — the loop's discipline is to ship wiring + flag what needs a human signature.

### roadmap.md changes
- Ticks Phase 4.11.2 (#170) and flags Phase 4.11 **structurally complete**.
- Replaces the Next-up queue with the Phase 5 batch plus the holdover BLOCKED cassette PR (which is no longer a launch blocker — only a gate before 5.7's mass ingest).

### What's NOT in Phase 5 (explicit)
Stripe / payments; push notifications; reservations / delivery integrations; cities outside Durango; native iOS / Android codebase split; restaurant photo galleries (multiple photos per dish); social graph / feed / gamification.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint`: green (full turbo cache, docs-only PR).
- [x] No code changes; rspec / vitest / jest unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)