### PR TITLE
feat(api): production deploy wiring (fly.toml + Dockerfile + smoke task) (phase 5.1)

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,31 @@
+# Phase 5.1 — keep the production image lean + secret-free.
+# Anything touched here also affects `fly deploy` upload size.
+
+# Local secrets / state
+.env
+.env.*
+!.env.example
+
+# Logs + temp
+log/
+tmp/
+storage/
+
+# VCS + editor cruft
+.git/
+.gitignore
+.DS_Store
+**/.DS_Store
+
+# Test artifacts
+spec/
+.rspec
+coverage/
+
+# Local Postgres / Solid Queue dump dirs (if ever created)
+db/data/
+db/storage/
+
+# Documentation — built into the image is wasteful; CI publishes elsewhere.
+README.md
+docs/

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -50,3 +50,26 @@ ANTHROPIC_API_KEY=
 # Used by Devise for password-reset emails. The mailer itself isn't
 # wired in until Phase 4; this is documented now so .env stays canonical.
 DEVISE_MAILER_FROM=info@bite-worthy.com
+
+# --- Production deploy (Phase 5.1) ------------------------------------------
+# Set in `fly secrets`, not in any local .env. Documented here so the
+# canonical list lives in one place.
+#
+# PUBLIC_HOST is the public origin clients see. Used by the Phase 4.3
+# review photo URL helper + the Phase 4.11.3 dish photo URL helper to
+# build signed blob URLs that resolve from a different origin (web
+# client on bite-worthy.com calling api.bite-worthy.com). Falls back
+# to request.base_url in dev/CI.
+PUBLIC_HOST=
+
+# Solid Queue gets its own VM in fly.toml; never embed in puma in prod.
+# Local dev can still flip this to true to skip running `bin/jobs` in
+# a second terminal.
+SOLID_QUEUE_IN_PUMA=false
+
+# Rails 8 production ENV — fly.toml sets these in [env] for the
+# deployed app. Listed here so a human bringing up a self-hosted
+# clone has the canonical set.
+# RAILS_LOG_TO_STDOUT=true
+# RAILS_SERVE_STATIC_FILES=true
+# RAILS_MASTER_KEY=  # contents of config/master.key, set via `fly secrets set`

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1
+# Phase 5.1 — production image for Fly.io.
+#
+# Multi-stage:
+#   1. `base`  — common ENV + WORKDIR; the smallest layer both later
+#                stages share. ruby:3.3.6-slim matches .ruby-version.
+#   2. `build` — installs OS build deps + gems + bootsnap precompiles.
+#                Throws away apt caches / .git so the final image is
+#                lean.
+#   3. `final` — runtime deps only (libpq, libvips for image_processing,
+#                imagemagick for Phase 4.11.1's DishPhotoCropper),
+#                copies the bundled gems + app from `build`, runs as
+#                a non-root rails:1000 user.
+#
+# Both fly.toml processes (`app` = puma, `worker` = solid_queue:start)
+# share this image — the entrypoint just dispatches on argv.
+
+ARG RUBY_VERSION=3.3.6
+FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
+
+WORKDIR /rails
+
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development:test"
+
+# --- build stage -------------------------------------------------------------
+FROM base AS build
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+        build-essential \
+        git \
+        libpq-dev \
+        libyaml-dev \
+        pkg-config \
+        curl
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
+    bundle exec bootsnap precompile --gemfile
+
+COPY . .
+
+# Precompile bootsnap cache for app + lib (faster cold boots on Fly).
+RUN bundle exec bootsnap precompile app/ lib/
+
+# --- final stage -------------------------------------------------------------
+FROM base
+
+# Runtime-only OS deps. libvips + imagemagick are both used by
+# image_processing (review photos + Phase 4.11 dish photos); libpq for
+# Postgres; libjemalloc2 trims puma's RSS by ~30%.
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        libjemalloc2 \
+        libpq5 \
+        libvips42 \
+        imagemagick \
+        postgresql-client && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --from=build /rails /rails
+
+RUN groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+    chown -R rails:rails db log tmp
+USER 1000:1000
+
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+
+EXPOSE 3000
+CMD ["./bin/rails", "server"]

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -42,3 +42,42 @@ bundle exec rspec
 | API controllers | `app/controllers/api/v1/` |
 | Ingestion services (Anthropic) | `app/services/ingestion/` |
 | Background jobs | `app/jobs/` |
+
+## Production deploy (Phase 5.1)
+
+Hosted on Fly.io. Decision + trade-offs in `docs/adr/0002-production-hosting.md`.
+
+**One-time bootstrap (human):**
+
+```bash
+cd apps/api
+fly auth login
+fly launch --no-deploy --copy-config --name biteworthy-api
+fly postgres create --name biteworthy-pg --region den --vm-size shared-cpu-1x
+fly postgres attach biteworthy-pg
+fly secrets set \
+    RAILS_MASTER_KEY=$(cat config/master.key) \
+    DEVISE_JWT_SECRET_KEY=$(bin/rails secret) \
+    ANTHROPIC_API_KEY=... \
+    ADMIN_USERNAME=... ADMIN_PASSWORD=...
+fly deploy
+fly certs add api.bite-worthy.com   # after CNAME points at biteworthy-api.fly.dev
+```
+
+**Every deploy (automated post-Phase-5.4 CI; today: manual):**
+
+```bash
+fly deploy
+bin/rails biteworthy:production:smoke HOST=https://api.bite-worthy.com EXIT_CODE=1
+```
+
+The smoke task is read-only — safe to run repeatedly. It hits `/up` plus a real items query and prints one timing line per check; exits non-zero when `EXIT_CODE=1` is set so CI can fail the deploy if the smoke fails.
+
+**Where things live (deploy edition):**
+
+| Concern | Path |
+|---|---|
+| Container image | `Dockerfile` + `.dockerignore` + `bin/docker-entrypoint` |
+| Fly app config | `fly.toml` |
+| Smoke task | `lib/tasks/production.rake` (wraps `app/services/biteworthy/production_smoke.rb`) |
+| Production env defaults | `[env]` block in `fly.toml`; secrets via `fly secrets` |

--- a/apps/api/app/services/biteworthy/production_smoke.rb
+++ b/apps/api/app/services/biteworthy/production_smoke.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require "json"
+require "benchmark"
+
+# Phase 5.1 — production smoke runner.
+#
+# Hits the deployed API on three reads in sequence, prints a one-line
+# summary per check, returns true iff every check passed. Wrapped by
+# the `biteworthy:production:smoke` rake task with HOST + ENV defaults.
+#
+# The runner stays read-only on purpose — Phase 5.7's seed task is
+# the right place to exercise IngestionRun creation against prod, so
+# this can run from CI on every deploy without polluting the DB.
+module Biteworthy
+  class ProductionSmoke
+    CheckResult = Struct.new(:name, :ok, :status, :elapsed_ms, :detail, keyword_init: true)
+
+    def initialize(host:, logger:, http_client: Net::HTTP)
+      @host        = host.chomp("/")
+      @logger      = logger
+      @http_client = http_client
+    end
+
+    def run
+      results = []
+      results << check_up
+      results << check_items_query
+
+      log_summary(results)
+      results.all?(&:ok)
+    end
+
+    private
+
+    def check_up
+      timed("GET /up") do
+        response = get("/up")
+        ok       = response.is_a?(Net::HTTPSuccess)
+        [ok, response.code, ok ? "alive" : "expected 2xx, got #{response.code}"]
+      end
+    end
+
+    def check_items_query
+      restaurant = Restaurant.published.order(:created_at).first
+
+      return CheckResult.new(
+        name:      "GET /api/v1/restaurants/:slug/items",
+        ok:        true,
+        status:    "skipped",
+        elapsed_ms: 0,
+        detail:    "no published restaurant in DB; Phase 5.7's seed task will populate"
+      ) if restaurant.nil?
+
+      timed("GET /api/v1/restaurants/#{restaurant.slug}/items") do
+        response = get("/api/v1/restaurants/#{restaurant.slug}/items")
+        ok       = response.is_a?(Net::HTTPSuccess)
+        detail   = if ok
+                     body = JSON.parse(response.body) rescue {}
+                     "items=#{(body["items"] || []).size}"
+                   else
+                     "expected 2xx, got #{response.code}"
+                   end
+        [ok, response.code, detail]
+      end
+    end
+
+    # Wrap a block that returns [ok, status, detail] in timing + struct
+    # construction. Catches network errors so the task reports them
+    # rather than crashing partway through.
+    def timed(name)
+      elapsed_ms = nil
+      ok, status, detail = nil
+      elapsed_ms = (Benchmark.realtime { ok, status, detail = yield } * 1000).round
+      CheckResult.new(name: name, ok: ok, status: status, elapsed_ms: elapsed_ms, detail: detail)
+    rescue StandardError => e
+      CheckResult.new(
+        name:       name,
+        ok:         false,
+        status:     "error",
+        elapsed_ms: elapsed_ms || 0,
+        detail:     "#{e.class}: #{e.message}"
+      )
+    end
+
+    def get(path)
+      uri = URI.join(@host + "/", path.delete_prefix("/"))
+      http = @http_client.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.read_timeout = 10
+      http.open_timeout = 5
+      http.get(uri.request_uri, "Accept" => "application/json")
+    end
+
+    def log_summary(results)
+      @logger.puts "BiteWorthy production smoke @ #{@host}"
+      results.each do |r|
+        mark = r.ok ? "OK " : "FAIL"
+        @logger.puts "  [#{mark}] #{r.name}  status=#{r.status}  #{r.elapsed_ms}ms  #{r.detail}"
+      end
+      @logger.puts(results.all?(&:ok) ? "  → all checks passed" : "  → at least one check failed")
+    end
+  end
+end

--- a/apps/api/bin/docker-entrypoint
+++ b/apps/api/bin/docker-entrypoint
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+# Phase 5.1 — Docker entrypoint shared by the `app` (puma) and
+# `worker` (solid_queue:start) processes Fly runs from the same image.
+#
+# Only the puma process should run `db:prepare` on boot. The release
+# command in fly.toml ALSO runs `db:prepare` so this is belt-and-
+# suspenders — running it twice is a no-op when the schema is current.
+
+if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+  ./bin/rails db:prepare
+fi
+
+exec "${@}"

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -1,0 +1,80 @@
+# Phase 5.1 — Fly.io app config for the BiteWorthy API.
+#
+# Two processes, one image (see Dockerfile):
+#   * `app`    — puma serving the public API on :3000
+#   * `worker` — solid_queue:start running ingestion + record-visit jobs
+#
+# Region: DEN (Denver) — closest to Durango, low single-digit ms RTT
+# for the launch market. Add fra/syd machines later only if real
+# users elsewhere materialize.
+#
+# Bring-up (one-time, human):
+#   fly auth login
+#   fly launch --no-deploy --copy-config --name biteworthy-api
+#   fly postgres create --name biteworthy-pg --region den --vm-size shared-cpu-1x
+#   fly postgres attach biteworthy-pg
+#   fly secrets set RAILS_MASTER_KEY=$(cat config/master.key) \
+#                   ANTHROPIC_API_KEY=... \
+#                   DEVISE_JWT_SECRET_KEY=$(rails secret) \
+#                   ADMIN_USERNAME=... ADMIN_PASSWORD=...
+#   fly deploy
+#
+# Subsequent deploys (automated once 5.4 wires CI):
+#   fly deploy --image-label v$(git rev-parse --short HEAD)
+
+app = "biteworthy-api"
+primary_region = "den"
+
+[build]
+
+[deploy]
+  release_command = "./bin/rails db:prepare"
+
+[env]
+  RAILS_ENV = "production"
+  RAILS_LOG_TO_STDOUT = "true"
+  RAILS_SERVE_STATIC_FILES = "true"
+  PUBLIC_HOST = "https://api.bite-worthy.com"
+  # Workers run as a separate process; never embed in puma in
+  # production (we want the puma machine to scale-to-zero independently).
+  SOLID_QUEUE_IN_PUMA = "false"
+  # libjemalloc reduces RSS on long-running puma; the Dockerfile
+  # installs the lib but Ruby has to be told to use it.
+  LD_PRELOAD = "/usr/lib/x86_64-linux-gnu/libjemalloc.so.2"
+
+[processes]
+  app = "./bin/rails server"
+  worker = "bundle exec rake solid_queue:start"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 200
+    hard_limit = 250
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/up"
+
+# Two VM specs — puma can scale to zero between requests; the worker
+# stays warm so queued ingestion jobs run promptly. Tier up after the
+# Phase 5.7 seed run reveals real load.
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  processes = ["app"]
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  processes = ["worker"]

--- a/apps/api/lib/tasks/production.rake
+++ b/apps/api/lib/tasks/production.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Phase 5.1 — production smoke task.
+#
+# Wraps Biteworthy::ProductionSmoke (app/services/biteworthy/) with
+# a Rake-friendly entrypoint. The runner stays read-only so this task
+# is safe to call from CI on every deploy.
+#
+# Usage:
+#   bin/rails biteworthy:production:smoke              # uses PUBLIC_HOST
+#   bin/rails biteworthy:production:smoke HOST=...     # override target
+#   bin/rails biteworthy:production:smoke EXIT_CODE=1  # exit non-zero on
+#                                                      # any failure (CI mode)
+namespace :biteworthy do
+  namespace :production do
+    desc "Smoke-test the deployed API on /up + a real items query"
+    task :smoke => :environment do
+      host = ENV["HOST"].presence ||
+             ENV["PUBLIC_HOST"].presence ||
+             abort("HOST or PUBLIC_HOST must be set")
+
+      runner = Biteworthy::ProductionSmoke.new(host: host, logger: $stdout)
+      ok = runner.run
+
+      exit(1) if ENV["EXIT_CODE"] == "1" && !ok
+    end
+  end
+end

--- a/apps/api/spec/lib/production_smoke_spec.rb
+++ b/apps/api/spec/lib/production_smoke_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+require "stringio"
+
+# Phase 5.1 — guards the production smoke runner the rake task wraps.
+RSpec.describe Biteworthy::ProductionSmoke do
+  let(:logger) { StringIO.new }
+
+  # Stub Net::HTTP-shaped responses so the spec doesn't hit a real
+  # socket. Each `plan` entry maps a path to a Net::HTTPResponse.
+  def fake_http(plan)
+    Class.new do
+      define_singleton_method(:new) do |_host, _port|
+        instance = Object.new
+        plan_ref = plan
+        instance.define_singleton_method(:use_ssl=) { |_| nil }
+        instance.define_singleton_method(:read_timeout=) { |_| nil }
+        instance.define_singleton_method(:open_timeout=) { |_| nil }
+        instance.define_singleton_method(:get) do |path, _headers = {}|
+          plan_ref.fetch(path) do
+            raise "no plan entry for #{path.inspect} (plans: #{plan_ref.keys.inspect})"
+          end
+        end
+        instance
+      end
+    end
+  end
+
+  def ok_response(body = "{}")
+    res = Net::HTTPOK.new("1.1", "200", "OK")
+    res.instance_variable_set(:@read, true)
+    res.instance_variable_set(:@body, body)
+    res
+  end
+
+  def fail_response
+    Net::HTTPInternalServerError.new("1.1", "500", "ISE")
+  end
+
+  describe "#run" do
+    context "with no published restaurants in the DB" do
+      it "passes /up + reports the items query as skipped" do
+        http = fake_http("/up" => ok_response)
+        runner = described_class.new(host: "https://api.example.com", logger: logger, http_client: http)
+
+        ok = runner.run
+
+        expect(ok).to be true
+        expect(logger.string).to include("[OK ] GET /up")
+        expect(logger.string).to include("status=skipped")
+        expect(logger.string).to include("Phase 5.7's seed task will populate")
+      end
+    end
+
+    context "with a published restaurant" do
+      let!(:restaurant) { create(:restaurant, :published, slug: "ninis") }
+
+      it "calls /up + the items query for that restaurant" do
+        http = fake_http(
+          "/up" => ok_response,
+          "/api/v1/restaurants/ninis/items" => ok_response('{"items":[{"id":"a"},{"id":"b"}]}')
+        )
+        runner = described_class.new(host: "https://api.example.com", logger: logger, http_client: http)
+
+        expect(runner.run).to be true
+        expect(logger.string).to include("items=2")
+        expect(logger.string).to include("→ all checks passed")
+      end
+
+      it "reports a non-2xx /up as failed without raising" do
+        http = fake_http(
+          "/up" => fail_response,
+          "/api/v1/restaurants/ninis/items" => ok_response('{"items":[]}')
+        )
+        runner = described_class.new(host: "https://api.example.com", logger: logger, http_client: http)
+
+        expect(runner.run).to be false
+        expect(logger.string).to include("[FAIL] GET /up")
+        expect(logger.string).to include("→ at least one check failed")
+      end
+
+      it "captures network errors as a single FAIL line" do
+        boom_http = Class.new do
+          def self.new(*)
+            instance = Object.new
+            instance.define_singleton_method(:use_ssl=) { |_| nil }
+            instance.define_singleton_method(:read_timeout=) { |_| nil }
+            instance.define_singleton_method(:open_timeout=) { |_| nil }
+            instance.define_singleton_method(:get) { |*| raise Errno::ECONNREFUSED, "connection refused" }
+            instance
+          end
+        end
+        runner = described_class.new(host: "https://api.example.com", logger: logger, http_client: boom_http)
+
+        expect(runner.run).to be false
+        expect(logger.string).to include("status=error")
+        expect(logger.string).to include("Errno::ECONNREFUSED")
+      end
+    end
+  end
+end

--- a/docs/adr/0002-production-hosting.md
+++ b/docs/adr/0002-production-hosting.md
@@ -1,0 +1,111 @@
+# ADR 0002: production hosting (Fly.io for the API)
+
+- **Date:** 2026-04-30
+- **Status:** Accepted
+- **Supersedes:** N/A
+- **Refines:** ADR 0001 — `Hosting | Fly.io (api) + Vercel (web) + EAS (mobile)`
+
+## Context
+
+ADR 0001 picked Fly.io as the API host at the stack-decision level. Phase 5.1 needs an implementation-level decision: machine model, region, process layout, healthchecks, secret rotation lifecycle. Those choices get baked into `apps/api/fly.toml` + `apps/api/Dockerfile` and rotating any of them means a real migration later, so they deserve a dedicated record.
+
+The alternatives considered now (Render, Railway) were also considered in ADR 0001; this ADR reaffirms the Fly.io pick against Phase 5's actual requirements rather than re-litigating it from scratch.
+
+## Decision
+
+### Machine model — Fly Machines (not Apps v1)
+
+Fly's "Machines" platform replaces the older "Apps v1" model. Differences that matter for BiteWorthy:
+
+- **Per-process VM specs**: `app` (puma) and `worker` (`solid_queue:start`) get separate `[[vm]]` blocks. Puma can scale to zero between requests; the worker stays warm so queued ingestion jobs run promptly.
+- **Auto-stop / auto-start**: `auto_stop_machines = "stop"` + `min_machines_running = 1` keeps one puma VM alive for `/up` healthchecks; additional VMs spin up on demand. At Durango-launch volume this should stay at 1 machine ~95% of the day.
+- **Release commands run as a one-off Machine**: `release_command = "./bin/rails db:prepare"` runs in its own VM, not in the puma process — schema migrations don't block the rolling deploy.
+
+### Region — DEN (Denver)
+
+Closest Fly region to Durango (~6h drive). Single-digit-ms RTT for the launch market matters less than for a global product, but it's free to pick the right one upfront. Add fra/syd later only if real traffic from Europe/AU materializes.
+
+### Process model — two processes, one image
+
+```
+[processes]
+  app    = "./bin/rails server"
+  worker = "bundle exec rake solid_queue:start"
+```
+
+Same Dockerfile, same gemset, different command. Wrong shape (`SOLID_QUEUE_IN_PUMA=true` to embed jobs in puma) was rejected because:
+
+- Puma `auto_stop` would kill in-flight ingestion jobs.
+- Puma RSS would balloon to fit the worst-case ingestion job's image-decode buffer.
+- Independent scaling of puma vs worker is a near-certain Phase 6 need.
+
+### Postgres — Fly Postgres dev tier to start
+
+`fly postgres create --vm-size shared-cpu-1x` provisions a single-VM unmanaged Postgres. Switch to a real plan (e.g. Supabase or Crunchy Bridge) when:
+
+1. Daily backups become a compliance requirement, OR
+2. The Phase 5.7 seed run reveals connection-pool pressure, OR
+3. Restore-time SLAs become a thing.
+
+Fly Postgres dev is fine for a launch beta. Connection string flows in via `fly postgres attach` (sets `DATABASE_URL` automatically).
+
+### Secret rotation lifecycle
+
+Production secrets live in `fly secrets`:
+
+- **Bootstrap**: `fly secrets set RAILS_MASTER_KEY=... ANTHROPIC_API_KEY=... DEVISE_JWT_SECRET_KEY=... ADMIN_USERNAME=... ADMIN_PASSWORD=...` once.
+- **Rotation**: re-run `fly secrets set` for the changed key; Fly performs a rolling restart automatically.
+- **Audit**: `fly secrets list` shows hashes only (Fly never echoes values back). Real audit relies on the source-of-truth (1Password vault or similar — human-managed).
+
+`config/master.key` itself stays out of git (`.gitignore`); only the encrypted `config/credentials.yml.enc` is checked in.
+
+### Healthcheck — `/up` (Rails default)
+
+Rails 8's `rails/health#show` mounted at `/up` returns 200 when the app boots without raising. fly.toml polls every 30s with a 10s grace period on boot.
+
+### Image build — multi-stage Dockerfile, not buildpacks
+
+Hand-rolled multi-stage Dockerfile (see `apps/api/Dockerfile`) over Fly's auto-detect. Reasons:
+
+- Phase 4.11.1's `imagemagick` runtime dep + Phase 5.3's planned `libvips` need explicit OS-package install — buildpacks would miss them.
+- Multi-stage gives ~150MB smaller images vs the buildpack default (matters for cold-boot times on auto-stopped machines).
+- Bootsnap precompile is the single biggest cold-boot speedup; needs explicit `bundle exec bootsnap precompile` in the build stage.
+
+### What this PR ships
+
+- `apps/api/Dockerfile` + `.dockerignore` + `bin/docker-entrypoint`
+- `apps/api/fly.toml` with the process / vm / healthcheck config above
+- `apps/api/lib/tasks/production.rake` + `app/services/biteworthy/production_smoke.rb` for post-deploy smoke
+- `apps/api/.env.example` updated with Fly-specific env vars
+- This ADR
+
+### What requires a human (Phase 5.1 acceptance criterion)
+
+The acceptance criterion (`curl https://api.bite-worthy.com/up` returns 200) needs:
+
+1. `fly auth login` with a personal Fly account.
+2. `fly launch --no-deploy --copy-config --name biteworthy-api` to register the app.
+3. `fly postgres create --name biteworthy-pg --region den` + `fly postgres attach biteworthy-pg`.
+4. `fly secrets set ...` for the secrets enumerated above.
+5. `fly deploy`.
+6. DNS: `api.bite-worthy.com` CNAME to `biteworthy-api.fly.dev`, then `fly certs add api.bite-worthy.com`.
+7. `bin/rails biteworthy:production:smoke HOST=https://api.bite-worthy.com` to confirm.
+
+Steps 1–3 + 7 are one-time bootstrap; 4 happens whenever a secret rotates; 5 happens on every merge to master once Phase 5.4 wires CI to drive `fly deploy`.
+
+## Trade-offs
+
+**Why not Render** — Render's free tier doesn't include background workers; the paid tier (~$7/mo per service × 2 services + DB) is more than Fly's equivalent. Render's git-driven deploys are nicer than Fly's CLI-driven model, but Phase 5.4 closes that gap with CI.
+
+**Why not Railway** — comparable pricing, but the worker-process abstraction is less mature than Fly's `[[vm]]` block. Railway is on the shortlist if Fly's billing surprises us.
+
+**Why not Heroku** — pricing per dyno is now meaningfully higher than Fly Machines for the same RAM. Add-on ecosystem advantage is moot since we're using Solid Queue (no Redis) + Fly Postgres.
+
+**Why not raw EC2 / Hetzner / etc.** — operational overhead (TLS termination, healthchecks, log aggregation, secret store, deploy automation) rivals the per-month cost difference. Phase 5 is about shipping; reaching for IaaS is for Phase 6+ if Fly's bill ever bites.
+
+## Consequences
+
+- **Cost** — projected $5–15/mo for the API + worker + Postgres dev tier at launch volume. Tier up after the Phase 5.7 seed run reveals real load.
+- **Vendor lock-in** — fly.toml is Fly-specific but small (~50 lines); a Render / Railway migration would be a 1-day port. The Dockerfile is portable as-is.
+- **Single region** — all data lives in DEN. Adding a read replica or fail-over plan is Phase 6+ work; we accept the single point of failure at launch.
+- **Secret-rotation discipline** — Fly secrets show only hashes; the loop CANNOT verify a secret value, only its presence. Rotation events live in human-kept logs (1Password audit trail).

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,52 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 17:19 — tick #77. PR #171 (Phase 5 subplan) merged at
+16:48 UTC. Anthropic still capped (~6.5h to reset); cassette PR
+stays BLOCKED. Picked the next unblocked Next-up item: **Phase
+5.1 — production API deploy wiring**. Split the work cleanly into
+"loop-shippable wiring" vs "human-only provisioning" per the
+subplan's Stop conditions. Shipped:
+- Multi-stage `apps/api/Dockerfile` (Rails 8 prod, libpq + libvips
+  + imagemagick + libjemalloc2, non-root rails:1000 user) +
+  `.dockerignore` (no secrets/.git/specs in upload) +
+  `bin/docker-entrypoint` (runs db:prepare on the puma process
+  only — release_command is the belt-and-suspenders).
+- `apps/api/fly.toml` with two processes (`app` puma,
+  `worker` `bundle exec rake solid_queue:start`), region DEN
+  (closest to Durango), `/up` healthcheck every 30s, force_https,
+  separate `[[vm]]` per process. Workers explicitly OUT of puma
+  (`SOLID_QUEUE_IN_PUMA=false`) — auto_stop would kill in-flight
+  ingestion jobs. libjemalloc2 LD_PRELOAD'd to trim puma RSS.
+- `lib/tasks/production.rake` thin Rake adapter +
+  `app/services/biteworthy/production_smoke.rb` (extracted so
+  the spec doesn't need Rake's DSL). Read-only smoke: GET /up +
+  GET /api/v1/restaurants/:slug/items, one timing line per check,
+  exits non-zero with `EXIT_CODE=1` so CI can fail a deploy.
+  Stays read-only so it's safe on every deploy; Phase 5.7's seed
+  task is the right place for IngestionRun creation against prod.
+- `docs/adr/0002-production-hosting.md` capturing implementation-
+  level Fly.io decisions (machine model, region, process split,
+  Postgres dev tier to start, secret rotation lifecycle, why not
+  Render/Railway/Heroku/IaaS). Refines ADR 0001 rather than
+  superseding it.
+- `apps/api/.env.example` adds `PUBLIC_HOST`,
+  `SOLID_QUEUE_IN_PUMA=false`, commented Rails 8 prod ENV.
+- `apps/api/README.md` new "Production deploy" section with the
+  one-time bootstrap + every-deploy commands.
+What still needs a human (per ADR 0002 step list): fly auth login,
+fly launch, fly postgres create/attach, fly secrets set
+(RAILS_MASTER_KEY + ANTHROPIC_API_KEY + DEVISE_JWT_SECRET_KEY +
+ADMIN credentials), fly deploy, DNS for api.bite-worthy.com (CNAME
+→ biteworthy-api.fly.dev) + fly certs add, then run the smoke
+task to confirm. Roadmap: ticked 4.11.2 (#170) and 4.11.4 (#169) +
+flagged Phase 4.11 structurally complete in PR #171; next-up after
+this PR is 5.2 (SMTP). Tests: 4 new specs against
+`Biteworthy::ProductionSmoke` (no-restaurants branch, happy path
+with one published restaurant, non-2xx /up, network-error
+capture). Local: rspec 341/0/1 pending (+4); pnpm typecheck +
+lint full-turbo cached green.
+
 2026-04-30 16:46 — tick #76. PR #170 (Phase 4.11.2 structural)
 merged at 16:18 UTC. Anthropic still capped (~7h to reset);
 Next-up was a single `[BLOCKED]` cassette item. Per the


### PR DESCRIPTION
## Why

Phase 5.1 from `docs/plans/phase-5.md` — production API deploy wiring on Fly.io. Splits cleanly into "loop-shippable wiring" (this PR) vs "human-only provisioning" (Fly account, Postgres tier, DNS, secrets — enumerated in ADR 0002 + the README). The acceptance criterion (`curl https://api.bite-worthy.com/up` returns 200) is gated on those human steps; this PR makes them copy-paste-able.

## What

- **`apps/api/Dockerfile`** — multi-stage Rails 8 production image. Build stage installs gems + bootsnap-precompiles app/lib; final stage carries only runtime libs (libpq5, libvips42, imagemagick for Phase 4.11 dish photos, libjemalloc2 for puma RSS), runs as non-root rails:1000.
- **`apps/api/.dockerignore`** — keeps `.env`, logs, specs, docs, and `.git` out of the image upload.
- **`apps/api/bin/docker-entrypoint`** — runs `db:prepare` only for the puma process; `release_command` in `fly.toml` runs it again as belt-and-suspenders.
- **`apps/api/fly.toml`** — two processes from the same image:
  - `app` (puma serving `:3000`)
  - `worker` (`bundle exec rake solid_queue:start`)
  Region `den` (closest to Durango). `/up` healthcheck every 30s. `force_https`. Separate `[[vm]]` per process so puma can `auto_stop` while the worker stays warm. `SOLID_QUEUE_IN_PUMA=false` because `auto_stop` would kill in-flight ingestion jobs. `LD_PRELOAD` libjemalloc2 for ~30% RSS savings on puma.
- **`apps/api/lib/tasks/production.rake`** + **`app/services/biteworthy/production_smoke.rb`** — read-only smoke runner hitting `/up` + a real items query, prints one timing line per check, exits non-zero with `EXIT_CODE=1` so CI can fail a deploy. Stays read-only so it's safe on every deploy; Phase 5.7's seed task is the right place to exercise IngestionRun creation.
- **`docs/adr/0002-production-hosting.md`** — implementation-level Fly.io decisions (machine model, region, process split, Postgres dev tier to start, secret rotation lifecycle, why not Render/Railway/Heroku/IaaS). Refines ADR 0001 rather than superseding.
- **`apps/api/.env.example`** — adds `PUBLIC_HOST`, `SOLID_QUEUE_IN_PUMA=false`, commented Rails-8 production ENV.
- **`apps/api/README.md`** — new "Production deploy" section with the one-time bootstrap + every-deploy commands inline.

## Tests

4 new specs against `Biteworthy::ProductionSmoke`:

- No published restaurants in DB → `/up` passes, items query reports `skipped`.
- One published restaurant → both endpoints called; output reports `items=N`.
- Non-2xx `/up` → reported as `FAIL` without raising.
- Network error (`Errno::ECONNREFUSED`) → captured as a single `FAIL` line.

`bundle exec rspec`: **341/0/1 pending** (+4 from baseline). `pnpm typecheck` + `pnpm lint`: full-turbo cached green (no JS changes).

## What still needs a human (per ADR 0002)

```bash
cd apps/api
fly auth login
fly launch --no-deploy --copy-config --name biteworthy-api
fly postgres create --name biteworthy-pg --region den --vm-size shared-cpu-1x
fly postgres attach biteworthy-pg
fly secrets set \
    RAILS_MASTER_KEY=$(cat config/master.key) \
    DEVISE_JWT_SECRET_KEY=$(bin/rails secret) \
    ANTHROPIC_API_KEY=... \
    ADMIN_USERNAME=... ADMIN_PASSWORD=...
fly deploy
# DNS: api.bite-worthy.com CNAME → biteworthy-api.fly.dev
fly certs add api.bite-worthy.com
bin/rails biteworthy:production:smoke HOST=https://api.bite-worthy.com EXIT_CODE=1
```

Steps 1–3 + last are one-time bootstrap; secrets set on rotation; deploy on every merge to master once Phase 5.4 wires CI.

## Notes

- The `bin/jobs` referenced in CLAUDE.md doesn't currently exist in the repo (Solid Queue's installer was never run). Avoided creating it here since `bundle exec rake solid_queue:start` works the same and keeps this PR's scope tight; if a follow-up wants to run the installer, that's its own PR.
- ADR 0002 deliberately accepts single-region (DEN) as the launch posture. Multi-region + read replicas are Phase 6+ work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)