### PR TITLE
feat(api): production SMTP + email smoke task (phase 5.2)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -73,3 +73,23 @@ SOLID_QUEUE_IN_PUMA=false
 # RAILS_LOG_TO_STDOUT=true
 # RAILS_SERVE_STATIC_FILES=true
 # RAILS_MASTER_KEY=  # contents of config/master.key, set via `fly secrets set`
+
+# --- Production SMTP (Phase 5.2) --------------------------------------------
+# Set via `fly secrets set` in production. ADR 0003 picks Postmark:
+# the SMTP user_name AND password are both the Postmark Server API
+# token (Postmark's auth pattern). Provider-agnostic: any SMTP-
+# capable service works by changing the SMTP_ADDRESS.
+#
+# DEFAULTS in production.rb fall back to smtp.postmarkapp.com:587 +
+# STARTTLS + plain auth, so a Postmark-only deploy only needs the
+# token via SMTP_USERNAME + SMTP_PASSWORD.
+SMTP_ADDRESS=smtp.postmarkapp.com
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_DOMAIN=bite-worthy.com
+
+# Public origin mailer-rendered URLs link back to (verify links,
+# password resets). Web origin (NOT the API origin); matches the
+# Phase 5.4 Vercel domain.
+MAILER_HOST=https://bite-worthy.com

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -81,3 +81,29 @@ The smoke task is read-only — safe to run repeatedly. It hits `/up` plus a rea
 | Fly app config | `fly.toml` |
 | Smoke task | `lib/tasks/production.rake` (wraps `app/services/biteworthy/production_smoke.rb`) |
 | Production env defaults | `[env]` block in `fly.toml`; secrets via `fly secrets` |
+
+## Email (Phase 5.2)
+
+Production SMTP is wired in `config/environments/production.rb`. Decision + trade-offs in `docs/adr/0003-email-provider.md` (Postmark via plain SMTP). Dev + test use the `:test` adapter — no real delivery — so specs don't open sockets.
+
+**One-time bootstrap (human):** sign up for Postmark, create a "BiteWorthy" server, verify the `bite-worthy.com` sender domain (DKIM + Return-Path DNS records), generate a Server API token, then:
+
+```bash
+fly secrets set \
+    SMTP_ADDRESS=smtp.postmarkapp.com \
+    SMTP_PORT=587 \
+    SMTP_USERNAME=$POSTMARK_TOKEN \
+    SMTP_PASSWORD=$POSTMARK_TOKEN \
+    SMTP_DOMAIN=bite-worthy.com \
+    MAILER_HOST=https://bite-worthy.com
+```
+
+**Confirm delivery:**
+
+```bash
+fly ssh console -C 'bin/rails biteworthy:email:smoke EMAIL=you@example.com'
+```
+
+Reports the SMTP Message-ID per delivery; `EXIT_CODE=1` makes it fail loudly for CI.
+
+**What works after secrets are set** — Devise password reset (built-in), `RestaurantClaimMailer.verify_email` (Phase 4.9), and any new mailer added later. No code change needed per mailer.

--- a/apps/api/app/mailers/biteworthy_mailer.rb
+++ b/apps/api/app/mailers/biteworthy_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Phase 5.2 — generic mailer for the production SMTP smoke task.
+#
+# Sends a single self-contained message that proves the wiring works
+# end-to-end: ActionMailer → ApplicationMailer layout → SMTP →
+# inbox. Doesn't depend on any database record, so the smoke task
+# can run on a fresh deploy before there are users / restaurants /
+# suggestions.
+class BiteworthyMailer < ApplicationMailer
+  def smoke_test(to:)
+    @sent_at = Time.current.utc
+    mail(
+      to:      to,
+      subject: "BiteWorthy SMTP smoke test (#{@sent_at.iso8601})"
+    )
+  end
+end

--- a/apps/api/app/services/biteworthy/email_smoke.rb
+++ b/apps/api/app/services/biteworthy/email_smoke.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Phase 5.2 — production SMTP smoke runner.
+#
+# Sends a single test message to the configured EMAIL= recipient and
+# reports the Message-ID. Wrapped by `bin/rails biteworthy:email:smoke`.
+#
+# Two modes:
+#
+#   * **production** — `delivery_method = :smtp` from
+#     `config/environments/production.rb` opens a real SMTP connection.
+#     Useful right after `fly secrets set SMTP_*=...` to confirm
+#     Postmark (or whichever provider) accepts the credentials.
+#
+#   * **dev / test** — `:test` adapter captures the message in
+#     `ActionMailer::Base.deliveries`. The runner reports the Message-ID
+#     anyway so the same code path is exercised. CI runs the spec
+#     against this mode.
+#
+# Returns true on success (delivery raised no error). Does NOT block
+# the task on Postmark response codes — the SMTP server's 250 OK is
+# already the success signal; reading further would require the
+# provider's REST API.
+module Biteworthy
+  class EmailSmoke
+    def initialize(to:, logger:, mailer: BiteworthyMailer)
+      @to     = to
+      @logger = logger
+      @mailer = mailer
+    end
+
+    def run
+      @logger.puts "BiteWorthy SMTP smoke → #{@to}"
+      @logger.puts "  delivery_method=#{ActionMailer::Base.delivery_method.inspect}"
+      @logger.puts "  smtp_address=#{ActionMailer::Base.smtp_settings[:address].inspect}" if smtp?
+
+      message = @mailer.smoke_test(to: @to).deliver_now
+
+      @logger.puts "  → delivered  Message-ID=#{message.message_id}"
+      true
+    rescue StandardError => e
+      @logger.puts "  → FAILED  #{e.class}: #{e.message}"
+      false
+    end
+
+    private
+
+    def smtp?
+      ActionMailer::Base.delivery_method == :smtp
+    end
+  end
+end

--- a/apps/api/app/views/biteworthy_mailer/smoke_test.html.erb
+++ b/apps/api/app/views/biteworthy_mailer/smoke_test.html.erb
@@ -1,0 +1,17 @@
+<h1>BiteWorthy SMTP smoke test</h1>
+
+<p>This message confirms that the production mail pipeline works end-to-end:</p>
+
+<pre>app  →  ActionMailer  →  SMTP  →  this inbox</pre>
+
+<ul>
+  <li><strong>Sent at:</strong> <%= @sent_at.iso8601 %></li>
+  <li><strong>Host:</strong> <%= ENV.fetch("MAILER_HOST", "(unset)") %></li>
+  <li><strong>SMTP:</strong> <%= ENV.fetch("SMTP_ADDRESS", "(default)") %></li>
+</ul>
+
+<p>
+  If you didn&rsquo;t run <code>bin/rails biteworthy:email:smoke</code>,
+  somebody else did. The task is read-only and only sends to the
+  <code>EMAIL=</code> argument.
+</p>

--- a/apps/api/app/views/biteworthy_mailer/smoke_test.text.erb
+++ b/apps/api/app/views/biteworthy_mailer/smoke_test.text.erb
@@ -1,0 +1,13 @@
+BiteWorthy SMTP smoke test
+==========================
+
+This message confirms that the production mail pipeline works end-to-end:
+
+  app  →  ActionMailer  →  SMTP  →  this inbox
+
+Sent at: <%= @sent_at.iso8601 %>
+Host:    <%= ENV.fetch("MAILER_HOST", "(unset)") %>
+SMTP:    <%= ENV.fetch("SMTP_ADDRESS", "(default)") %>
+
+If you didn't run `bin/rails biteworthy:email:smoke`, somebody else did.
+The task is read-only and only sends to the EMAIL= argument.

--- a/apps/api/config/environments/production.rb
+++ b/apps/api/config/environments/production.rb
@@ -22,6 +22,40 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Phase 5.2 — production SMTP. Provider-agnostic: any SMTP-capable
+  # service (Postmark, SES, SendGrid, Mailgun) works by setting the
+  # SMTP_* env vars via `fly secrets set`. ADR 0003 documents the
+  # Postmark pick + alternatives.
+  #
+  # Fail loudly if delivery raises — Solid Queue retries the mailer
+  # job on transient errors, but a misconfigured server should NOT
+  # silently swallow signups. Disable raise_delivery_errors only
+  # if a hosted-by-Fly outage requires it (rare).
+  config.action_mailer.delivery_method   = :smtp
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_deliveries    = true
+  config.action_mailer.smtp_settings = {
+    address:              ENV.fetch("SMTP_ADDRESS", "smtp.postmarkapp.com"),
+    port:                 ENV.fetch("SMTP_PORT", "587").to_i,
+    user_name:            ENV["SMTP_USERNAME"],
+    password:             ENV["SMTP_PASSWORD"],
+    domain:               ENV.fetch("SMTP_DOMAIN", "bite-worthy.com"),
+    authentication:       :plain,
+    enable_starttls_auto: true
+  }
+  # Mailers build full URLs (claim verify links, password resets) —
+  # MAILER_HOST is the public host the user clicks back into.
+  # Mirrors PUBLIC_HOST except mailers point at the WEB origin
+  # (bite-worthy.com), not the API origin.
+  mailer_host = ENV.fetch("MAILER_HOST", "https://bite-worthy.com")
+  uri         = URI.parse(mailer_host)
+  config.action_mailer.default_url_options = {
+    host:     uri.host,
+    port:     uri.port == uri.default_port ? nil : uri.port,
+    protocol: uri.scheme
+  }.compact
+  Rails.application.routes.default_url_options = config.action_mailer.default_url_options
+
   config.i18n.fallbacks = true
   config.active_support.report_deprecations = false
 end

--- a/apps/api/lib/tasks/email.rake
+++ b/apps/api/lib/tasks/email.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Phase 5.2 — production SMTP smoke task.
+#
+# Wraps Biteworthy::EmailSmoke with a Rake adapter. Stays read-only
+# (only sends to the EMAIL= argument; never persists a record). Safe
+# to run from CI or from a `fly ssh console` post-deploy.
+#
+# Usage:
+#   bin/rails biteworthy:email:smoke EMAIL=skylar@example.com
+#   bin/rails biteworthy:email:smoke EMAIL=... EXIT_CODE=1   # CI mode
+namespace :biteworthy do
+  namespace :email do
+    desc "Send a one-off SMTP smoke message to confirm production wiring"
+    task :smoke => :environment do
+      to = ENV["EMAIL"].presence || abort("EMAIL=<recipient> is required")
+
+      ok = Biteworthy::EmailSmoke.new(to: to, logger: $stdout).run
+
+      exit(1) if ENV["EXIT_CODE"] == "1" && !ok
+    end
+  end
+end

--- a/apps/api/spec/lib/email_smoke_spec.rb
+++ b/apps/api/spec/lib/email_smoke_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+require "stringio"
+
+# Phase 5.2 — guards the SMTP smoke runner the rake task wraps.
+# Test-env mailer uses the `:test` adapter so we can introspect
+# deliveries without opening a real socket.
+RSpec.describe Biteworthy::EmailSmoke do
+  let(:logger) { StringIO.new }
+
+  before { ActionMailer::Base.deliveries.clear }
+
+  describe "#run" do
+    it "delivers exactly one message via the configured mailer" do
+      runner = described_class.new(to: "skylar@example.com", logger: logger)
+
+      expect(runner.run).to be true
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      expect(ActionMailer::Base.deliveries.last.to).to eq(["skylar@example.com"])
+      expect(ActionMailer::Base.deliveries.last.subject).to start_with("BiteWorthy SMTP smoke test")
+    end
+
+    it "logs the recipient + delivery_method + Message-ID" do
+      runner = described_class.new(to: "skylar@example.com", logger: logger)
+
+      runner.run
+
+      expect(logger.string).to include("BiteWorthy SMTP smoke → skylar@example.com")
+      expect(logger.string).to match(/delivery_method=:test/)
+      expect(logger.string).to match(/Message-ID=\S+@\S+/)
+    end
+
+    it "returns false + logs FAIL when the mailer raises" do
+      flaky = Class.new do
+        def self.smoke_test(to:)
+          raise Net::SMTPAuthenticationError, "535 bad user/password"
+        end
+      end
+      runner = described_class.new(to: "skylar@example.com", logger: logger, mailer: flaky)
+
+      expect(runner.run).to be false
+      expect(logger.string).to include("FAILED  Net::SMTPAuthenticationError")
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+
+    it "renders both the text and HTML parts of the smoke template" do
+      described_class.new(to: "skylar@example.com", logger: logger).run
+
+      delivery = ActionMailer::Base.deliveries.last
+      expect(delivery.parts.size).to eq(2)
+      text_part = delivery.parts.find { |p| p.content_type.start_with?("text/plain") }
+      html_part = delivery.parts.find { |p| p.content_type.start_with?("text/html") }
+      expect(text_part.body.to_s).to include("BiteWorthy SMTP smoke test")
+      expect(html_part.body.to_s).to include("<h1>BiteWorthy SMTP smoke test</h1>")
+    end
+  end
+end

--- a/docs/adr/0003-email-provider.md
+++ b/docs/adr/0003-email-provider.md
@@ -1,0 +1,96 @@
+# ADR 0003: production email (Postmark via SMTP)
+
+- **Date:** 2026-04-30
+- **Status:** Accepted
+- **Refines:** ADR 0001 (the stack pick named SMTP-as-pluggable but didn't pick a provider)
+
+## Context
+
+Phase 4 shipped three mailer surfaces with `:test` adapter only:
+- Devise password reset (built-in `Devise::Mailer.reset_password_instructions`)
+- Phase 4.9's `RestaurantClaimMailer.verify_email`
+- Phase 4.6 moderation notifications (currently log-only)
+
+Phase 5.2 lights up real delivery. The pick has to clear three bars:
+
+1. **Reliability** — review/claim/password-reset emails are conversion-critical. Bouncing or going to spam costs real users.
+2. **Operational simplicity** — the loop should be able to ship the wiring; only credential drop should need a human.
+3. **Cost at launch volume** — Durango beta projects ~50–500 emails/month for the first quarter. Free tier or sub-$10/mo is the target.
+
+## Decision
+
+**Postmark, accessed via plain SMTP** (no custom gem).
+
+### Why Postmark over the alternatives
+
+| Provider | Why considered | Why not picked |
+|---|---|---|
+| **Postmark** | Best deliverability for transactional in industry surveys. Free tier: 100 emails/mo; $15/mo for 10k. Dedicated transactional product (no marketing-spray UI). | — picked. |
+| AWS SES | Cheapest at scale ($0.10 / 1k). Strong infra. | Higher operational ceiling: needs sandbox-mode escape, DKIM setup is more involved, deliverability history is owned by AWS not us. Worth revisiting if Postmark cost ever bites at >100k/mo. |
+| SendGrid | Generous free tier. | Deliverability has slipped per the same surveys. UI heavily pushes marketing features we don't want. |
+| Mailgun | Reasonable middle ground. | No free tier anymore. Pricing comparable to Postmark with worse deliverability reputation. |
+| Resend | New + dev-friendly. | Too young for transactional reliability claims at v1. Revisit Phase 6+. |
+
+### Why SMTP, not the `postmark-rails` gem
+
+- **Provider portability.** SMTP is the universal protocol; switching providers is a `fly secrets set SMTP_*=...` away. The `postmark-rails` gem locks every mailer's `delivery_method` to `:postmark` and adds a Mail::Postmark gem dep.
+- **No new gems.** Rails ships the SMTP delivery method out of the box. Less surface to upgrade across Rails versions, less Bundler audit churn.
+- **Postmark's REST API isn't worth the complexity here.** The REST API gives back per-message metadata (open/click) that we don't need for transactional. SMTP returns a Message-ID which is enough to grep `fly logs` if a delivery is questioned.
+
+If a future phase needs Postmark's tag-based analytics or template engine, swapping in `postmark-rails` is a one-PR operation.
+
+### What this PR ships
+
+- `config/environments/production.rb` — `delivery_method = :smtp`,
+  `smtp_settings` reading `SMTP_ADDRESS / SMTP_PORT / SMTP_USERNAME /
+  SMTP_PASSWORD / SMTP_DOMAIN`, defaults to `smtp.postmarkapp.com:587`
+  + STARTTLS + plain auth (Postmark's recommended config).
+- `default_url_options` derived from `MAILER_HOST` (defaults to
+  `https://bite-worthy.com`) so mailer-rendered URLs (verify links,
+  password resets) work.
+- `BiteworthyMailer.smoke_test(to:)` + text/html templates — a
+  self-contained, no-DB-record-needed smoke message.
+- `Biteworthy::EmailSmoke` runner (`app/services/biteworthy/`) +
+  `bin/rails biteworthy:email:smoke EMAIL=...` rake adapter. Reports
+  the SMTP Message-ID per delivery; exits non-zero on failure when
+  `EXIT_CODE=1` is set so CI can fail a deploy.
+- `.env.example` adds the SMTP_* placeholders + MAILER_HOST.
+- This ADR.
+
+### What needs a human (Phase 5.2 acceptance criterion)
+
+The acceptance ("a human runs `email:smoke EMAIL=...` and receives the message") needs:
+
+1. Sign up for Postmark (https://postmarkapp.com), create a "BiteWorthy" server in transactional mode.
+2. Verify the `bite-worthy.com` sender domain (DKIM + Return-Path DNS records — same registrar as the API CNAME from Phase 5.1).
+3. Generate a Postmark **Server API Token** (used as both SMTP user_name and password).
+4. `fly secrets set \
+       SMTP_ADDRESS=smtp.postmarkapp.com \
+       SMTP_PORT=587 \
+       SMTP_USERNAME=$POSTMARK_TOKEN \
+       SMTP_PASSWORD=$POSTMARK_TOKEN \
+       SMTP_DOMAIN=bite-worthy.com \
+       MAILER_HOST=https://bite-worthy.com`
+5. `fly ssh console -C 'bin/rails biteworthy:email:smoke EMAIL=skylar@gmail.com'`.
+
+Steps 1–3 are one-time; 4 happens on token rotation; 5 is the test.
+
+### Phase 4 mailer surfaces — what works after this lands
+
+- **Devise password reset** — automatic. Devise issues a token, the built-in `Devise::Mailer.reset_password_instructions` renders against `default_url_options`, SMTP delivers.
+- **`RestaurantClaimMailer.verify_email`** — automatic. The mailer already builds the verify URL itself (Phase 4.9's controller passes it in); SMTP just carries it now.
+- **Review confirmations** — Phase 4.3 chose not to send a confirmation on review create (only on flag/hide later via the moderation queue). Out of scope here; if a confirmation is desired, it's a separate one-line mailer.
+
+## Trade-offs
+
+**Cost ceiling** — Postmark $15/mo at 10k mails. If Phase 5.7's seed run plus organic signups push us past 10k/mo, revisit SES (cost gap becomes meaningful at ~50k/mo).
+
+**Single provider** — no failover. If Postmark has a regional outage, mail queues in Solid Queue (mailer jobs auto-retry). Multi-provider failover is Phase 6+ work.
+
+**SMTP password = API token** — Postmark's pattern (no separate username). Token rotation = `fly secrets set` + Fly rolling restart.
+
+## Consequences
+
+- **Operational simplicity** — one provider, one set of env vars, one ADR.
+- **Vendor lock-in for analytics only** — base SMTP delivery is portable; if we ever instrument open/click tracking via Postmark headers, that becomes provider-specific.
+- **Mailer template work has no Postmark-specific assumptions** — text + html parts, layout in `app/views/layouts/mailer.html.erb`, all standard Rails. Future Phase 6+ analytics (PostHog Email if it exists, Customer.io) plug in the same way.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,20 +11,18 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
-**Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md` — committed this PR. Awaiting human review of the plan before items auto-run.
+**Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5 subplan committed** — this PR. No code, just `docs/plans/phase-5.md` + Next-up reorder. **Phase 4.11 is structurally complete** (every line of consumer + producer code is on master); only the live cassette recording remains, which is now item #2 below.
+1. **Phase 5.2 — SMTP wiring** (`docs/plans/phase-5.md#52--smtp-wiring-real-email-for-reviews--claims--password-resets`) — this PR. Closes the long-deferred email gap from Phase 4 (claim verification + Devise password reset).
 2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7 mass-ingests Durango menus.
-3. **Phase 5.1 — production API deploy (Fly.io + Postgres + Solid Queue)** (`docs/plans/phase-5.md#51--production-api-deploy-flyio--postgres--solid-queue`). Foundation for everything below.
-4. **Phase 5.2 — SMTP wiring** (`docs/plans/phase-5.md#52--smtp-wiring-real-email-for-reviews--claims--password-resets`). Closes the long-deferred email gap from Phase 4.
-5. **Phase 5.3 — ActiveStorage S3 / R2** (`docs/plans/phase-5.md#53--activestorage-s3--r2-review--dish-photos-in-production`). Closes the long-deferred blob-storage gap from Phase 2 + 4.
-6. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`).
-7. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
-8. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
-9. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
-10. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
-11. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
-12. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
+3. **Phase 5.3 — ActiveStorage S3 / R2** (`docs/plans/phase-5.md#53--activestorage-s3--r2-review--dish-photos-in-production`). Closes the long-deferred blob-storage gap from Phase 2 + 4.
+4. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`).
+5. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
+6. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
+7. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
+8. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+9. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+10. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
 
@@ -72,6 +70,8 @@ the merge / review / status rules.
 - ✅ Phase 4.11.3 — IngestionItem promote attaches cropped dish photo (#168)
 - ✅ Phase 4.11.4 — render cropped dish photos on restaurant pages (#169)
 - ✅ Phase 4.11.2 — extend menu-extraction schema + prompt with image bboxes (#170) — **Phase 4.11 structurally complete; live cassette recording is the only remaining task**
+- ✅ Phase 5 — subplan committed (#171)
+- ✅ Phase 5.1 — production API deploy wiring: Fly.io + Dockerfile + smoke task (#172)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,44 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 18:18 — tick #79. PR #172 (Phase 5.1 deploy wiring)
+merged at 17:45 UTC after the rebase, all CI green. Anthropic
+still capped (~5.7h to reset); cassette PR stays BLOCKED. Picked
+the next unblocked Next-up item: **Phase 5.2 — SMTP wiring**.
+Closes the long-deferred Phase 4 email gap. Shipped:
+- `config/environments/production.rb` switches `delivery_method`
+  to `:smtp` with `smtp_settings` reading `SMTP_*` env vars
+  (defaults to Postmark's `smtp.postmarkapp.com:587` + STARTTLS +
+  plain auth). `raise_delivery_errors = true` so misconfig fails
+  loud; Solid Queue retries transient errors. `default_url_options`
+  derived from `MAILER_HOST` (web origin, not API origin) so
+  claim-verify links + Devise password resets render correct URLs.
+- New `BiteworthyMailer.smoke_test(to:)` + text/html templates +
+  `Biteworthy::EmailSmoke` runner + `bin/rails biteworthy:email:smoke
+  EMAIL=...` rake task. Self-contained, no DB record needed —
+  runnable on a fresh deploy. Reports SMTP Message-ID per delivery;
+  `EXIT_CODE=1` makes CI fail loud.
+- ADR 0003 captures Postmark-via-SMTP decision (why Postmark over
+  SES/SendGrid/Mailgun/Resend; why SMTP over postmark-rails gem;
+  secret-rotation lifecycle; what works after secrets are set).
+- `.env.example` adds SMTP_* placeholders + MAILER_HOST. README
+  gets a new "Email" section with bootstrap + smoke command.
+After this merges, Devise password reset + Phase 4.9's
+RestaurantClaimMailer.verify_email both light up automatically —
+no per-mailer code change needed (the wiring is per-environment).
+Tests: 4 new specs in `spec/lib/email_smoke_spec.rb` (happy path,
+log format, mailer-raise capture, text+html template rendering).
+Local: rspec 345/0/1 pending (+4); pnpm typecheck + lint
+full-turbo cached green. Roadmap: ticked 5.1 (#172) and the Phase
+5 subplan (#171); reordered Next-up. **Eager-rebase mitigation
+applied** (lesson from #172 going DIRTY): ran
+`git fetch origin && git pull origin master --ff-only` before
+branching this tick so 5.2 starts on the freshest master.
+**Note**: tick #78 was the rebase fix for PR #172 (resolved a
+docs/status.md conflict between #170-base and #171-merged); its
+own status entry got lost in #172's squash-merge, hence the
+#77 → #79 jump.
+
 2026-04-30 17:19 — tick #77. PR #171 (Phase 5 subplan) merged at
 16:48 UTC. Anthropic still capped (~6.5h to reset); cassette PR
 stays BLOCKED. Picked the next unblocked Next-up item: **Phase


### PR DESCRIPTION
## Why

Phase 5.2 from `docs/plans/phase-5.md` — closes the long-deferred Phase 4 email gap. Production now delivers real mail via SMTP; dev/test stay on `:test` so specs don't open sockets. Provider-agnostic wiring (any SMTP service works) with Postmark as the default per ADR 0003.

## What

- **`config/environments/production.rb`** — `delivery_method = :smtp` + `smtp_settings` reading `SMTP_ADDRESS / SMTP_PORT / SMTP_USERNAME / SMTP_PASSWORD / SMTP_DOMAIN`. Defaults to `smtp.postmarkapp.com:587` + STARTTLS + plain auth (Postmark's recommended config). `raise_delivery_errors = true` so a misconfigured server fails loudly; Solid Queue retries the mailer job on transient errors.
- **`default_url_options`** derived from `MAILER_HOST` (defaults to `https://bite-worthy.com`) so mailer-rendered URLs (claim verify links, password resets) work. The mailer host is the WEB origin, not the API origin.
- **`BiteworthyMailer.smoke_test(to:)`** — new mailer + text/html templates that prove the SMTP wire end-to-end without depending on any database record. Self-contained, runnable on a fresh deploy.
- **`Biteworthy::EmailSmoke`** runner + **`bin/rails biteworthy:email:smoke EMAIL=...`** rake adapter. Reports the SMTP Message-ID per delivery; exits non-zero with `EXIT_CODE=1` for CI.
- **`docs/adr/0003-email-provider.md`** — Postmark-via-SMTP decision (why Postmark over SES/SendGrid/Mailgun/Resend, why SMTP over `postmark-rails` gem, secret-rotation lifecycle, what works after secrets set).
- **`apps/api/.env.example`** — adds `SMTP_*` placeholders + `MAILER_HOST`.
- **`apps/api/README.md`** — new "Email" section with one-time Postmark bootstrap + the smoke command inline.

## Tests

4 new specs in `spec/lib/email_smoke_spec.rb`:

- Delivers exactly one message via the configured mailer (recipient + subject correct).
- Logs delivery_method + Message-ID in the expected format.
- Returns false + logs `FAILED` when the mailer raises (e.g. `Net::SMTPAuthenticationError`).
- Renders both text and HTML parts of the smoke template.

`bundle exec rspec`: **345/0/1 pending** (+4). `pnpm typecheck` + `pnpm lint`: full-turbo cached green (no JS changes).

## What still needs a human (Phase 5.2 acceptance criterion)

The acceptance ("a human runs `email:smoke EMAIL=...` and receives the message") needs:

1. Sign up for Postmark (https://postmarkapp.com), create a "BiteWorthy" server in transactional mode.
2. Verify the `bite-worthy.com` sender domain — DKIM + Return-Path DNS records (same registrar as the API CNAME from Phase 5.1).
3. Generate a Postmark **Server API Token** (used as both SMTP user_name and password).
4. ```bash
   fly secrets set \
       SMTP_ADDRESS=smtp.postmarkapp.com \
       SMTP_PORT=587 \
       SMTP_USERNAME=$POSTMARK_TOKEN \
       SMTP_PASSWORD=$POSTMARK_TOKEN \
       SMTP_DOMAIN=bite-worthy.com \
       MAILER_HOST=https://bite-worthy.com
   ```
5. ```bash
   fly ssh console -C 'bin/rails biteworthy:email:smoke EMAIL=skylar@gmail.com'
   ```

After secrets are set, **Devise password reset** + **Phase 4.9's `RestaurantClaimMailer.verify_email`** both light up automatically — no per-mailer code change needed.

## Notes

- Phase 4.3 chose not to ship a review-confirmation mailer (only flag/hide notifications via the moderation queue). The plan's "review confirmation" line is a no-op here; if a confirmation is later desired, it's a one-line mailer subclass.
- ADR 0003 picks SMTP over the `postmark-rails` gem deliberately — provider portability + no new gem dep + Rails-built-in.
- Eager-rebase mitigation applied this tick (lesson from PR #172 going DIRTY): branched from a freshly-pulled origin/master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)