### PR TITLE
feat(api): production blob storage on cloudflare r2 + backfill task (phase 5.3)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -93,3 +93,26 @@ SMTP_DOMAIN=bite-worthy.com
 # password resets). Web origin (NOT the API origin); matches the
 # Phase 5.4 Vercel domain.
 MAILER_HOST=https://bite-worthy.com
+
+# --- Production blob storage (Phase 5.3) -----------------------------------
+# Cloudflare R2 — S3-compatible, no egress charges (ADR 0004).
+# Generate a Cloudflare R2 API token with read/write to the bucket;
+# use the same value for ACCESS_KEY_ID + SECRET_ACCESS_KEY ONLY if
+# the token has both forms (they're separate fields in the dashboard).
+# R2_ENDPOINT looks like: https://<account-id>.r2.cloudflarestorage.com
+# R2_REGION must be "auto" (R2's only valid region string).
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_ENDPOINT=
+R2_BUCKET=biteworthy-blobs
+R2_REGION=auto
+
+# --- AWS S3 fallback (Phase 5.3) -------------------------------------------
+# storage.yml keeps an `:amazon` block as a no-code-change fallback
+# for the case where R2 has a regional outage. To switch back, flip
+# `active_storage.service` in production.rb from `:r2` to `:amazon`.
+# Uncomment + populate only if exercising the fallback.
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_REGION=us-east-1
+# AWS_S3_BUCKET=

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -107,3 +107,28 @@ fly ssh console -C 'bin/rails biteworthy:email:smoke EMAIL=you@example.com'
 Reports the SMTP Message-ID per delivery; `EXIT_CODE=1` makes it fail loudly for CI.
 
 **What works after secrets are set** — Devise password reset (built-in), `RestaurantClaimMailer.verify_email` (Phase 4.9), and any new mailer added later. No code change needed per mailer.
+
+## Blob storage (Phase 5.3)
+
+Production blobs (review photos, dish photos, ingestion menu pages) live on **Cloudflare R2**. Decision + trade-offs in `docs/adr/0004-blob-storage.md` (R2 over S3 because zero egress charges; `aws-sdk-s3` works unchanged because R2 speaks S3). Dev keeps `:local` (disk under `storage/`); test uses in-memory `:test`.
+
+**One-time bootstrap (human):**
+
+```bash
+# 1. Cloudflare → R2 → create bucket "biteworthy-blobs", generate
+#    an API token with Object Read & Write on the bucket.
+fly secrets set \
+    R2_ACCESS_KEY_ID=<token-id> \
+    R2_SECRET_ACCESS_KEY=<token-secret> \
+    R2_BUCKET=biteworthy-blobs \
+    R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
+fly deploy
+```
+
+**(Optional) Migrate any pre-existing blobs to R2:**
+
+```bash
+fly ssh console -C 'bin/rails biteworthy:storage:backfill EXIT_CODE=1'
+```
+
+The backfill task is **idempotent** — blobs already on the configured service are no-ops, so it's safe to re-run after every deploy or any future service flip (R2 → S3 or back). Logs `[ok] / [skip] / [FAIL]` per blob.

--- a/apps/api/app/services/biteworthy/storage_backfill.rb
+++ b/apps/api/app/services/biteworthy/storage_backfill.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Phase 5.3 — migrates ActiveStorage blobs whose `service_name` doesn't
+# match the env's currently-configured service. Idempotent: blobs
+# already on the right service are no-ops.
+#
+# When does this matter?
+#
+#   * After flipping `production.rb` from `:amazon` (or `:local`) to
+#     `:r2`, older blobs still record `service_name = "amazon"` (or
+#     "local"). Their downloads keep working from the old service AS
+#     LONG AS the credentials are still set, but new uploads go to
+#     R2 — leaving a bifurcated set the next operator has to remember.
+#     This task copies them across so production has one source of
+#     truth.
+#
+#   * When dev/test runs accidentally seed local-disk attachments
+#     into a production database (rare but happens with shared DB
+#     dumps). Re-running with R2 creds set migrates them.
+#
+# Returns true if every blob ends up on the target service. Logs each
+# migration as `[ok]  <id>  <old_service> → <new_service>` and any
+# failure as `[FAIL] <id>  <error>`. Skipped (already-on-target) blobs
+# log `[skip] <id>  already on <service>` to keep the audit trail
+# explicit.
+#
+# Wraps `ActiveStorage::Blob#open` (download) + `Blob.service.upload`
+# (upload-to-target) + `Blob#update_columns` (rewrite service_name).
+# Doesn't delete the source blob — humans confirm the migration
+# before flipping the old service's bucket lifecycle to expire keys.
+module Biteworthy
+  class StorageBackfill
+    Result = Struct.new(:migrated, :skipped, :failed, keyword_init: true)
+
+    def initialize(target_service: ActiveStorage::Blob.service.name, logger: $stdout)
+      @target_service = target_service.to_s
+      @logger         = logger
+    end
+
+    def run
+      result = Result.new(migrated: 0, skipped: 0, failed: 0)
+      @logger.puts "BiteWorthy storage backfill → #{@target_service}"
+
+      ActiveStorage::Blob.find_each do |blob|
+        case status_for(blob)
+        when :on_target
+          @logger.puts "  [skip] #{blob.id}  already on #{blob.service_name}"
+          result.skipped += 1
+        when :needs_migration
+          # Capture the source service name BEFORE migrate rewrites it
+          # via update_columns (which bypasses dirty tracking).
+          from_service = blob.service_name
+          migrated, error = migrate(blob)
+          if migrated
+            @logger.puts "  [ok]   #{blob.id}  #{from_service} → #{@target_service}"
+            result.migrated += 1
+          else
+            @logger.puts "  [FAIL] #{blob.id}  #{error}"
+            result.failed += 1
+          end
+        end
+      end
+
+      @logger.puts(
+        "  → migrated=#{result.migrated}  skipped=#{result.skipped}  failed=#{result.failed}"
+      )
+      result
+    end
+
+    private
+
+    def status_for(blob)
+      blob.service_name.to_s == @target_service ? :on_target : :needs_migration
+    end
+
+    # Download via the source service, upload to the target, rewrite
+    # service_name. ActiveStorage::Service.lookup builds clients
+    # lazily from storage.yml so naming the source service by string
+    # is enough.
+    def migrate(blob)
+      source = ActiveStorage::Blob.services.fetch(blob.service_name)
+      target = ActiveStorage::Blob.services.fetch(@target_service)
+
+      source.open(blob.key, checksum: blob.checksum) do |file|
+        target.upload(blob.key, file, checksum: blob.checksum, content_type: blob.content_type)
+      end
+
+      blob.update_columns(service_name: @target_service)
+      [true, nil]
+    rescue StandardError => e
+      [false, "#{e.class}: #{e.message}"]
+    end
+  end
+end

--- a/apps/api/config/environments/production.rb
+++ b/apps/api/config/environments/production.rb
@@ -7,7 +7,10 @@ Rails.application.configure do
 
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  config.active_storage.service = :amazon
+  # Phase 5.3 — production blobs live on Cloudflare R2 (ADR 0004).
+  # `:amazon` (AWS S3) stays in storage.yml as a no-code-change
+  # fallback — flip this back if R2 ever has a regional outage.
+  config.active_storage.service = :r2
 
   config.force_ssl = true
   config.assume_ssl = true

--- a/apps/api/config/storage.yml
+++ b/apps/api/config/storage.yml
@@ -12,3 +12,19 @@ amazon:
   secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
   region: <%= ENV.fetch("AWS_REGION", "us-east-1") %>
   bucket: <%= ENV["AWS_S3_BUCKET"] %>
+
+# Phase 5.3 — Cloudflare R2 (S3-compatible). The aws-sdk-s3 client
+# is unchanged; only the endpoint differs. ADR 0004 documents the
+# pick + the no-egress-charges argument vs AWS S3.
+#
+# region must be "auto" for R2; force_path_style is required because
+# R2 buckets aren't addressable as virtual-hosted subdomains the way
+# S3 buckets are.
+r2:
+  service: S3
+  access_key_id: <%= ENV["R2_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["R2_SECRET_ACCESS_KEY"] %>
+  endpoint: <%= ENV["R2_ENDPOINT"] %>
+  region: <%= ENV.fetch("R2_REGION", "auto") %>
+  bucket: <%= ENV["R2_BUCKET"] %>
+  force_path_style: true

--- a/apps/api/lib/tasks/storage.rake
+++ b/apps/api/lib/tasks/storage.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Phase 5.3 — ActiveStorage backfill task.
+#
+# Wraps Biteworthy::StorageBackfill with a Rake adapter. Idempotent:
+# safe to run from a `fly ssh console` after the R2 secrets are set,
+# and safe to re-run any time the production service flips.
+#
+# Usage:
+#   bin/rails biteworthy:storage:backfill
+#   bin/rails biteworthy:storage:backfill TARGET=amazon  # override target
+#   bin/rails biteworthy:storage:backfill EXIT_CODE=1    # CI mode
+namespace :biteworthy do
+  namespace :storage do
+    desc "Migrate ActiveStorage blobs to the configured (or TARGET=) service"
+    task :backfill => :environment do
+      target = ENV["TARGET"].presence || ActiveStorage::Blob.service.name
+
+      runner = Biteworthy::StorageBackfill.new(target_service: target, logger: $stdout)
+      result = runner.run
+
+      exit(1) if ENV["EXIT_CODE"] == "1" && result.failed.positive?
+    end
+  end
+end

--- a/apps/api/spec/lib/storage_backfill_spec.rb
+++ b/apps/api/spec/lib/storage_backfill_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+require "stringio"
+
+# Phase 5.3 — guards the ActiveStorage migration runner the rake
+# task wraps. We don't actually move bytes — the test env only
+# configures the `:test` service, and the contract-level question
+# (does the runner correctly route by `service_name`?) is answered
+# by stubbing the services hash.
+RSpec.describe Biteworthy::StorageBackfill do
+  let(:logger) { StringIO.new }
+
+  # Tiny stand-in for an ActiveStorage::Service. open() yields a
+  # buffer; upload() records the keys it received so the spec can
+  # assert "we attempted to write to the right service."
+  class FakeService
+    attr_reader :uploaded_keys
+
+    def initialize(name, raise_on: nil)
+      @name = name
+      @uploaded_keys = []
+      @raise_on = raise_on
+    end
+
+    def open(_key, **_)
+      raise @raise_on, "boom from #{@name}" if @raise_on
+      yield StringIO.new("payload from #{@name}")
+    end
+
+    def upload(key, _io, **_)
+      @uploaded_keys << key
+    end
+  end
+
+  def stub_services!(services)
+    allow(ActiveStorage::Blob).to receive(:services).and_return(services)
+  end
+
+  def make_blob(service_name:, key: SecureRandom.uuid)
+    # Blobs are normally created via attachments; building one
+    # directly with a chosen service_name lets us cover the
+    # migration branch without uploading actual bytes.
+    ActiveStorage::Blob.create!(
+      key:           key,
+      filename:      "fixture.bin",
+      service_name:  service_name,
+      byte_size:     0,
+      checksum:      "00000000000000000000000000",
+      content_type:  "application/octet-stream"
+    )
+  end
+
+  describe "#run" do
+    it "skips blobs already on the target service (idempotent re-run)" do
+      stub_services!("test" => FakeService.new("test"))
+      make_blob(service_name: "test")
+
+      result = described_class.new(target_service: "test", logger: logger).run
+
+      expect(result.skipped).to eq(1)
+      expect(result.migrated).to eq(0)
+      expect(result.failed).to eq(0)
+      expect(logger.string).to include("[skip]")
+      expect(logger.string).to include("already on test")
+    end
+
+    it "migrates blobs whose service_name differs from the target" do
+      target_service = FakeService.new("r2")
+      stub_services!("test" => FakeService.new("test"), "r2" => target_service)
+      blob = make_blob(service_name: "test")
+
+      result = described_class.new(target_service: "r2", logger: logger).run
+
+      expect(result.migrated).to eq(1)
+      expect(target_service.uploaded_keys).to eq([blob.key])
+      expect(blob.reload.service_name).to eq("r2")
+      expect(logger.string).to include("[ok]")
+      expect(logger.string).to include("test → r2")
+    end
+
+    it "captures per-blob failures without aborting the run" do
+      flaky_source = FakeService.new("test", raise_on: Errno::ECONNRESET)
+      target       = FakeService.new("r2")
+      stub_services!("test" => flaky_source, "r2" => target)
+
+      make_blob(service_name: "test", key: "blob-a")  # will fail on download
+      make_blob(service_name: "r2")                   # already on target
+
+      result = described_class.new(target_service: "r2", logger: logger).run
+
+      expect(result.failed).to eq(1)
+      expect(result.skipped).to eq(1)
+      expect(result.migrated).to eq(0)
+      expect(logger.string).to include("[FAIL]")
+      expect(logger.string).to include("Errno::ECONNRESET")
+    end
+
+    it "summarizes the run with migrated / skipped / failed counts" do
+      target = FakeService.new("r2")
+      stub_services!("test" => FakeService.new("test"), "r2" => target)
+      make_blob(service_name: "test")
+      make_blob(service_name: "r2")
+      make_blob(service_name: "r2")
+
+      described_class.new(target_service: "r2", logger: logger).run
+
+      expect(logger.string).to match(/migrated=1\s+skipped=2\s+failed=0/)
+    end
+  end
+end

--- a/docs/adr/0004-blob-storage.md
+++ b/docs/adr/0004-blob-storage.md
@@ -1,0 +1,103 @@
+# ADR 0004: production blob storage (Cloudflare R2)
+
+- **Date:** 2026-04-30
+- **Status:** Accepted
+- **Refines:** ADR 0001 (the stack pick named "ActiveStorage → S3 / R2" but didn't pick which)
+
+## Context
+
+Phases 2.3, 4.3, and 4.11.3 all attach blobs via ActiveStorage:
+- Phase 2.3 — `IngestionRun.has_many_attached :inputs` (uploaded menu pages, kept around for the ingestion lifetime + audit trail).
+- Phase 4.3 — `Review.has_one_attached :photo` (review photos, kept forever).
+- Phase 4.11.3 — `Item.has_one_attached :photo` (cropped dish photos, kept forever).
+
+All three deferred the production storage choice to "Phase 5+ when we're actually launching." This is that decision.
+
+The launch volume:
+- Review photos at ~1MB average, ~50–500/month → 0.5–5 GB/year.
+- Dish photos at ~100KB average (cropped JPEGs from menu pages), ~1k/month after seed → 0.1–1 GB/year.
+- Ingestion inputs at ~3MB average (full menu page photos), ~100/month → 4 GB/year, but with a TTL (delete after 90 days).
+
+Total: 5–10 GB/year + heavy READ traffic on review + dish photos (every restaurant page render fans out).
+
+## Decision
+
+**Cloudflare R2** for production. Use the existing `aws-sdk-s3` gem unchanged — R2 speaks the S3 API, so the only delta from `:amazon` is endpoint + region + `force_path_style: true`.
+
+### Why R2 over S3
+
+Read traffic dominates the bill on a photo-heavy product. AWS S3 charges $0.09/GB egress (after the first 100 GB free tier) — at ~10k restaurant page views/month with ~5 dish photos averaging 100KB each, that's ~5 GB/month, or ~$45/month at scale just for serving images. **R2 charges $0 egress.** Period.
+
+| Provider | Storage | Egress | Op cost (per million GET) |
+|---|---|---|---|
+| **Cloudflare R2** | $0.015/GB-month | **$0** | $0.36 |
+| AWS S3 (Standard) | $0.023/GB-month | $0.09/GB | $0.40 |
+| Backblaze B2 | $0.005/GB-month | $0.01/GB | $0.40 |
+| Wasabi | $0.0069/GB-month | $0 (with caps) | included |
+
+R2 wins on the metric that scales with our traffic. Backblaze + Wasabi are cheaper on storage but worse on operational maturity (Wasabi's "free egress" has fine-print caps; Backblaze has a smaller global edge footprint). AWS S3 is the most mature but the egress cost is real money at scale.
+
+### Why use `aws-sdk-s3` instead of an R2-native gem
+
+R2 implements the S3 API. ActiveStorage's `service: S3` adapter works against R2 with three extra config keys:
+
+```yaml
+r2:
+  service: S3
+  endpoint: <%= ENV["R2_ENDPOINT"] %>
+  region: <%= ENV.fetch("R2_REGION", "auto") %>
+  force_path_style: true
+```
+
+That's it. No new gem, no new wire format, no new test infra. If R2 ever goes down or pricing changes, flip back to `:amazon` with a one-line `production.rb` change — both services share `aws-sdk-s3` so blobs already uploaded to R2 are accessible from any S3-compatible client.
+
+### What this PR ships
+
+- `apps/api/config/storage.yml` — new `:r2` block (S3 service with R2 endpoint).
+- `apps/api/config/environments/production.rb` — `active_storage.service = :r2` (was `:amazon`). The `:amazon` block stays in `storage.yml` as a no-code-change fallback.
+- `apps/api/.env.example` — adds `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT`, `R2_BUCKET`, `R2_REGION` (defaults to `auto`).
+- `apps/api/app/services/biteworthy/storage_backfill.rb` + `lib/tasks/storage.rake` — idempotent migration that re-uploads any blob whose `service_name` doesn't match the configured service. Logs `[ok] / [skip] / [FAIL]` per blob; exits non-zero with `EXIT_CODE=1` on any failure for CI.
+- 4 specs guarding the runner.
+- `apps/api/README.md` — new "Storage" section documenting the bootstrap + the migration command.
+- This ADR.
+
+### What still needs a human (Phase 5.3 acceptance criterion)
+
+The acceptance ("a review photo posted in production survives a server restart and renders on the web restaurant page") needs:
+
+1. Create a Cloudflare account + an R2 bucket named `biteworthy-blobs` (or your preferred name). Enable public access if you want CDN-served URLs without ActiveStorage's signed-redirect; otherwise leave private and rely on Rails-routed URLs (`rails_blob_url`).
+2. Generate an R2 API token with read/write to the bucket. Note the **endpoint** URL Cloudflare gives (typically `https://<accountid>.r2.cloudflarestorage.com`).
+3. ```bash
+   fly secrets set \
+       R2_ACCESS_KEY_ID=<token-id> \
+       R2_SECRET_ACCESS_KEY=<token-secret> \
+       R2_BUCKET=biteworthy-blobs \
+       R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
+   ```
+4. `fly deploy`.
+5. Optional CORS — required only if the Phase 5.4 web app starts uploading directly to R2 via signed URLs. ActiveStorage's redirect flow (Rails serves `rails_blob_url`, 302s to the R2 signed URL) doesn't need CORS.
+6. (Pre-existing blobs only) `fly ssh console -C 'bin/rails biteworthy:storage:backfill EXIT_CODE=1'` once the secrets are set, to migrate any old `:local` or `:amazon` blobs to R2.
+
+### Direct CDN serving (deferred)
+
+ActiveStorage today serves blobs via `rails_blob_url`, which 302s to a signed R2 URL. This works but adds one round-trip per image and burns puma's request handlers on what should be edge-cached static. For Phase 5+ we can:
+
+1. Make the R2 bucket public, OR
+2. Front R2 with a Cloudflare Worker that handles auth + caching.
+
+Either is non-blocking for v1 launch. The redirect overhead (~40ms) is invisible at Durango-beta volume.
+
+## Trade-offs
+
+**Vendor lock-in (mild)** — R2's API is S3-compatible but Cloudflare's specific value prop (zero egress) is unique to them. Migrating off R2 means paying egress somewhere else. Acceptable: they're the cheapest choice for the launch, and migration is a one-line config change.
+
+**No multi-region replication** — R2 has multi-region buckets in beta but they cost more. Single-region is the right launch posture; revisit if Durango-beta traffic justifies it.
+
+**Public-read posture deferred** — keeping the bucket private + signed-redirect serving is the most conservative choice. Phase 5.5 / 5.6 might want public CDN URLs for the og:image generator — call it out then.
+
+## Consequences
+
+- **Cost** — projected $1–3/month at launch volume; scales linearly with storage but not with traffic.
+- **Operational** — one provider for blobs (separate from the API host on Fly.io). Cloudflare account is a new place to look when something's wrong; document credentials in 1Password alongside Fly + Postmark.
+- **Test infra** — unchanged. The `:test` ActiveStorage service (in-memory) keeps specs fast and offline.
+- **Migration** — `bin/rails biteworthy:storage:backfill` is reusable for any future service flip (R2 → S3, or back), not just this one launch event.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,16 +13,15 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.2 — SMTP wiring** (`docs/plans/phase-5.md#52--smtp-wiring-real-email-for-reviews--claims--password-resets`) — this PR. Closes the long-deferred email gap from Phase 4 (claim verification + Devise password reset).
+1. **Phase 5.3 — ActiveStorage S3 / R2** (`docs/plans/phase-5.md#53--activestorage-s3--r2-review--dish-photos-in-production`) — this PR. Closes the long-deferred blob-storage gap from Phase 2 + 4 + 4.11.
 2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7 mass-ingests Durango menus.
-3. **Phase 5.3 — ActiveStorage S3 / R2** (`docs/plans/phase-5.md#53--activestorage-s3--r2-review--dish-photos-in-production`). Closes the long-deferred blob-storage gap from Phase 2 + 4.
-4. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`).
-5. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
-6. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
-7. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
-8. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
-9. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
-10. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
+3. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`).
+4. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
+5. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
+6. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
+7. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+8. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+9. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
 
@@ -72,6 +71,7 @@ the merge / review / status rules.
 - ✅ Phase 4.11.2 — extend menu-extraction schema + prompt with image bboxes (#170) — **Phase 4.11 structurally complete; live cassette recording is the only remaining task**
 - ✅ Phase 5 — subplan committed (#171)
 - ✅ Phase 5.1 — production API deploy wiring: Fly.io + Dockerfile + smoke task (#172)
+- ✅ Phase 5.2 — production SMTP + email smoke task (#173)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,46 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 18:47 — tick #80. PR #173 (Phase 5.2 SMTP wiring) merged
+at 18:20 UTC, all CI green. Anthropic still capped (~5.2h to
+reset); cassette PR stays BLOCKED. Picked the next unblocked
+Next-up item: **Phase 5.3 — production blob storage**. Closes
+the long-deferred Phase 2 + 4 + 4.11 blob gap. Shipped:
+- `config/storage.yml` adds `:r2` block. R2 speaks S3 API so
+  `aws-sdk-s3` works unchanged — only endpoint + region (must
+  be "auto") + `force_path_style: true` differ. `:amazon` stays
+  as a one-line-flip fallback for R2 outages.
+- `production.rb` flips `active_storage.service` from `:amazon`
+  to `:r2`.
+- New `Biteworthy::StorageBackfill` runner +
+  `bin/rails biteworthy:storage:backfill` rake task. Migrates
+  any blob whose `service_name` differs from the configured
+  service. Idempotent — already-on-target blobs are no-ops.
+  Per-blob `[ok]/[skip]/[FAIL]` log; `EXIT_CODE=1` makes CI
+  fail loud on any failure. Reusable for future service flips.
+- ADR 0004 captures R2-over-S3 decision (zero egress charges
+  become real money at scale: $0/GB vs $0.09/GB; ~$45/mo
+  saved at modest growth scale). Why-not for Backblaze/Wasabi
+  (operational maturity) + why-not for R2-native gem
+  (portability). Direct CDN serving via public R2 URLs deferred
+  to Phase 5+ — ActiveStorage's signed-redirect adds ~40ms per
+  image, invisible at Durango-beta volume.
+- `.env.example` adds R2_* placeholders + commented AWS_*
+  fallback block. README gets new "Blob storage" section with
+  the bootstrap + backfill command.
+4 new specs in `spec/lib/storage_backfill_spec.rb` (already-
+on-target skip, cross-service migration, per-blob failure
+capture without aborting, summary counts). Caught one bug
+during spec authoring: `service_name_was` returns nil after
+update_columns (which bypasses dirty tracking) — fixed by
+capturing `from_service` before calling migrate. Local: rspec
+349/0/1 pending (+4); pnpm typecheck + lint full-turbo cached.
+Roadmap: ticked 5.2 (#173); reordered Next-up. **Eager-rebase
+applied** before branching. Next tick: babysit PR #174 to
+merge, then 5.4 (Vercel web deploy) — OR if Anthropic cap
+clears at 00:00 UTC (~5h from now), finally retry the
+cassette.
+
 2026-04-30 18:18 — tick #79. PR #172 (Phase 5.1 deploy wiring)
 merged at 17:45 UTC after the rebase, all CI green. Anthropic
 still capped (~5.7h to reset); cassette PR stays BLOCKED. Picked


### PR DESCRIPTION
## Why

Phase 5.3 from `docs/plans/phase-5.md` — closes the long-deferred Phase 2 + 4 + 4.11 blob-storage gap. Production now stores ActiveStorage attachments (review photos, dish photos, ingestion menu pages) on Cloudflare R2 instead of falling back to local disk.

## What

- **`config/storage.yml`** — new `:r2` block. R2 speaks the S3 API, so the existing `aws-sdk-s3` gem works unchanged: `service: S3` + `endpoint: <R2_ENDPOINT>` + `region: auto` + `force_path_style: true`. The `:amazon` block stays as a no-code-change fallback for the case where R2 has a regional outage.
- **`config/environments/production.rb`** — flips `active_storage.service` from `:amazon` to `:r2`.
- **`apps/api/app/services/biteworthy/storage_backfill.rb`** + **`lib/tasks/storage.rake`** — idempotent migration runner that re-uploads any blob whose `service_name` doesn't match the configured service. Per-blob `[ok] / [skip] / [FAIL]` log; exits non-zero with `EXIT_CODE=1` on any failure for CI. Reusable for any future service flip (R2 → S3 or back), not just this launch event. Doesn't delete from the source — humans confirm the migration before flipping the old bucket's lifecycle to expire keys.
- **`docs/adr/0004-blob-storage.md`** — captures R2-over-S3 decision. The headline argument: zero egress charges. AWS S3 charges $0.09/GB egress (after 100GB free); at ~10k restaurant page views/month with 5 dish photos averaging 100KB each, that's $45/mo just to serve images at modest scale. R2 is $0. Trade-offs section addresses Backblaze + Wasabi (worse operational maturity) and the R2-native gem alternatives (provider portability + no new dep).
- **`apps/api/.env.example`** — adds `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT`, `R2_BUCKET`, `R2_REGION` (defaults to `auto`). Commented `AWS_*` block for the fallback case.
- **`apps/api/README.md`** — new "Blob storage" section with the one-time bootstrap + the backfill command.

## Tests

4 new specs in `spec/lib/storage_backfill_spec.rb`:

- Skips blobs already on the target service (idempotent re-run).
- Migrates blobs whose `service_name` differs from the target (asserts upload + service_name rewrite).
- Captures per-blob failures (`Errno::ECONNRESET`) without aborting the run.
- Summarizes with migrated / skipped / failed counts.

`bundle exec rspec`: **349/0/1 pending** (+4). `pnpm typecheck` + `pnpm lint`: full-turbo cached green (no JS changes).

## What still needs a human (Phase 5.3 acceptance criterion)

```bash
# 1. Cloudflare → R2 → create bucket "biteworthy-blobs",
#    generate API token with Object Read & Write.
fly secrets set \
    R2_ACCESS_KEY_ID=<token-id> \
    R2_SECRET_ACCESS_KEY=<token-secret> \
    R2_BUCKET=biteworthy-blobs \
    R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
fly deploy

# (Optional) migrate any pre-existing blobs to R2:
fly ssh console -C 'bin/rails biteworthy:storage:backfill EXIT_CODE=1'
```

The acceptance ("a review photo posted in production survives a server restart and renders on the web restaurant page") is a manual smoke after secrets land.

## Notes

- **Direct CDN serving** (public R2 URLs without ActiveStorage's signed-redirect) is deferred to Phase 5+. The current redirect overhead is ~40ms per image — invisible at Durango-beta volume.
- **Spec authoring caught a real bug**: `service_name_was` returns nil after `update_columns` (which bypasses dirty tracking). Fixed by capturing `from_service = blob.service_name` before calling `migrate`. The migration was correct; only the log line was wrong. Without the spec, prod logs would have shown `[ok] 102 ? → r2` instead of `[ok] 102 amazon → r2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)