### PR TITLE
feat(web): production deploy wiring (vercel.json + sitemap + cookie domain) (phase 5.4)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,19 @@
+# BiteWorthy Web — environment variables.
+#
+# Local: copy to .env.local. Vercel: set in the project's Environment
+# Variables tab (https://vercel.com/<team>/biteworthy/settings/environment-variables).
+
+# --- API base ---------------------------------------------------------------
+# Origin the web app calls for /api/v1/* requests via its server-side
+# proxy routes. Defaults to http://localhost:3000 in dev when unset.
+# Production: https://api.bite-worthy.com (Phase 5.1's Fly.io app).
+NEXT_PUBLIC_API_BASE=http://localhost:3000
+
+# --- Cookie domain (Phase 5.4) ---------------------------------------------
+# Optional. When set, the auth cookie's `domain` attribute is fixed to
+# this value so the session works across subdomains
+# (`www.bite-worthy.com`, `app.bite-worthy.com`, etc.).
+#
+# Production: `.bite-worthy.com` (note leading dot).
+# Dev: leave UNSET — localhost cookies don't take a domain attribute.
+# NEXT_PUBLIC_COOKIE_DOMAIN=

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -20,3 +20,23 @@ Set `NEXT_PUBLIC_API_BASE` to override the Rails URL.
   client components hydrating SSR'd lists.
 - Tailwind tokens come from `@biteworthy/ui-tokens` so the mobile app's
   StyleSheet and the web's classes stay in lockstep.
+
+## Production deploy (Phase 5.4)
+
+Hosted on Vercel. Decision + trade-offs in `docs/adr/0005-web-hosting.md`.
+
+**One-time bootstrap (human):**
+
+1. Sign up for Vercel (Hobby tier is free).
+2. Import the GitHub repo via the Vercel dashboard — Vercel auto-detects the Next.js app at `apps/web`.
+3. Set environment variables in the project's Settings → Environment Variables:
+   - `NEXT_PUBLIC_API_BASE=https://api.bite-worthy.com`
+   - `NEXT_PUBLIC_COOKIE_DOMAIN=.bite-worthy.com` (cookie scoped across subdomains)
+   - `NEXT_PUBLIC_SITE_URL=https://bite-worthy.com` (sitemap base URL)
+4. Add `bite-worthy.com` + `www.bite-worthy.com` as custom domains. Vercel emits the DNS records to add at the registrar.
+
+**Every deploy:** push to `master` → Vercel auto-deploys to production. Push to a feature branch → Vercel emits a preview URL (`<branch>--biteworthy.vercel.app`) which is useful for codex review of UX changes.
+
+**Sitemap + robots:** generated automatically. `app/sitemap.ts` covers `/`, `/login`, `/signup` today; Phase 5.6 adds `/durango/[diet]` rows; Phase 5.7 adds seeded-restaurant rows. `public/robots.txt` allows all bots and disallows the `/api/*` server-side proxy routes.
+
+**Cookie domain (Phase 5.4):** `NEXT_PUBLIC_COOKIE_DOMAIN` must be UNSET locally (localhost cookies don't take a domain attribute) and SET to `.bite-worthy.com` in Vercel production. The `buildAuthCookieOptions` helper in `src/lib/cookie-options.ts` honors both.

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+
+# Phase 5.4 — Next.js proxy routes shouldn't be indexed; they're
+# server-side adapters to the Rails API, not user-facing pages.
+Disallow: /api/
+
+Sitemap: https://bite-worthy.com/sitemap.xml

--- a/apps/web/src/app/api/auth/[action]/route.ts
+++ b/apps/web/src/app/api/auth/[action]/route.ts
@@ -15,6 +15,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { SESSION_COOKIE } from '../../../../lib/server-auth';
 import { getServerJwt } from '../../../../lib/server-auth';
+import { buildAuthCookieOptions } from '../../../../lib/cookie-options';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
@@ -73,15 +74,7 @@ async function handleLoginOrSignup(action: string, body: CredentialsBody) {
 
   const userPayload = await upstream.json().catch(() => ({}));
   const response = NextResponse.json(userPayload, { status: 200 });
-  response.cookies.set({
-    name: SESSION_COOKIE,
-    value: token,
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    path: '/',
-    maxAge: COOKIE_MAX_AGE,
-  });
+  response.cookies.set(buildAuthCookieOptions(SESSION_COOKIE, token, COOKIE_MAX_AGE));
   return response;
 }
 
@@ -97,15 +90,7 @@ async function handleLogout() {
     }).catch(() => {});
   }
   const response = NextResponse.json({ ok: true }, { status: 200 });
-  response.cookies.set({
-    name: SESSION_COOKIE,
-    value: '',
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 0,
-  });
+  response.cookies.set(buildAuthCookieOptions(SESSION_COOKIE, '', 0));
   return response;
 }
 

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,27 @@
+/**
+ * Phase 5.4 — sitemap.xml served at `/sitemap.xml`.
+ *
+ * Next.js 13+ App Router: this file's default export becomes the
+ * sitemap route. Composition lives in `lib/sitemap.ts` so the URL
+ * list is unit-testable without touching Next.
+ *
+ * Hooks (currently empty; populated by future phases):
+ *
+ *   * `dietSlugs` — Phase 5.6 will fetch active `DietaryProfile`
+ *     slugs from the API and pass them through.
+ *   * `restaurantSlugs` — Phase 5.7 will fetch published Restaurant
+ *     slugs after the seed run.
+ *
+ * Until both ship, the sitemap covers the static homepage + auth
+ * pages; both are valid + indexable on day one.
+ */
+
+import type { MetadataRoute } from 'next';
+import { buildSitemapEntries } from '../lib/sitemap';
+
+const DEFAULT_BASE_URL = 'https://bite-worthy.com';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_BASE_URL;
+  return buildSitemapEntries(baseUrl);
+}

--- a/apps/web/src/lib/__tests__/cookie-options.test.ts
+++ b/apps/web/src/lib/__tests__/cookie-options.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildAuthCookieOptions } from '../cookie-options';
+
+describe('buildAuthCookieOptions', () => {
+  it('emits the canonical secure-cookie shape (httpOnly + sameSite=lax + path=/)', () => {
+    const opts = buildAuthCookieOptions('bw_session', 'jwt-value', 1234, {
+      production: true,
+      domain: null,
+    });
+    expect(opts).toEqual({
+      name: 'bw_session',
+      value: 'jwt-value',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 1234,
+    });
+  });
+
+  it('omits the domain attribute when not configured (dev / localhost)', () => {
+    const opts = buildAuthCookieOptions('bw_session', 'tok', 30, {
+      production: false,
+      domain: null,
+    });
+    expect(opts.domain).toBeUndefined();
+    expect(opts.secure).toBe(false);
+  });
+
+  it('attaches domain when NEXT_PUBLIC_COOKIE_DOMAIN-style override is provided (production)', () => {
+    const opts = buildAuthCookieOptions('bw_session', 'tok', 30, {
+      production: true,
+      domain: '.bite-worthy.com',
+    });
+    expect(opts.domain).toBe('.bite-worthy.com');
+  });
+
+  it('clears the cookie correctly when maxAge is 0 (logout path)', () => {
+    const opts = buildAuthCookieOptions('bw_session', '', 0, {
+      production: true,
+      domain: '.bite-worthy.com',
+    });
+    expect(opts.value).toBe('');
+    expect(opts.maxAge).toBe(0);
+    expect(opts.domain).toBe('.bite-worthy.com');
+  });
+
+  it('reads NEXT_PUBLIC_COOKIE_DOMAIN from env when no override is given', () => {
+    const original = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
+    process.env.NEXT_PUBLIC_COOKIE_DOMAIN = '.bite-worthy.com';
+    try {
+      const opts = buildAuthCookieOptions('bw_session', 'tok', 30, { production: true });
+      expect(opts.domain).toBe('.bite-worthy.com');
+    } finally {
+      if (original === undefined) delete process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
+      else process.env.NEXT_PUBLIC_COOKIE_DOMAIN = original;
+    }
+  });
+});

--- a/apps/web/src/lib/__tests__/sitemap.test.ts
+++ b/apps/web/src/lib/__tests__/sitemap.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildSitemapEntries } from '../sitemap';
+
+const FROZEN = new Date('2026-04-30T19:00:00Z');
+
+describe('buildSitemapEntries', () => {
+  it('emits the static routes (/, /login, /signup) with sensible priorities', () => {
+    const entries = buildSitemapEntries('https://bite-worthy.com', {}, FROZEN);
+
+    const urls = entries.map((e) => e.url);
+    expect(urls).toEqual([
+      'https://bite-worthy.com/',
+      'https://bite-worthy.com/login',
+      'https://bite-worthy.com/signup',
+    ]);
+
+    const home = entries[0]!;
+    expect(home.priority).toBe(1.0);
+    expect(home.changeFrequency).toBe('weekly');
+    expect(home.lastModified).toBe(FROZEN.toISOString());
+  });
+
+  it('appends Phase 5.6 diet pages when dietSlugs is provided', () => {
+    const entries = buildSitemapEntries(
+      'https://bite-worthy.com',
+      { dietSlugs: ['celiac', 'vegan'] },
+      FROZEN,
+    );
+    const dietUrls = entries.map((e) => e.url).filter((u) => u.includes('/durango/'));
+    expect(dietUrls).toEqual([
+      'https://bite-worthy.com/durango/celiac',
+      'https://bite-worthy.com/durango/vegan',
+    ]);
+  });
+
+  it('encodes slugs with reserved URL characters', () => {
+    const entries = buildSitemapEntries(
+      'https://bite-worthy.com',
+      { restaurantSlugs: ['café & co'] },
+      FROZEN,
+    );
+    expect(entries.at(-1)!.url).toBe(
+      'https://bite-worthy.com/restaurants/caf%C3%A9%20%26%20co',
+    );
+  });
+
+  it('strips trailing slashes from the base URL', () => {
+    const entries = buildSitemapEntries('https://bite-worthy.com////', {}, FROZEN);
+    expect(entries[0]!.url).toBe('https://bite-worthy.com/');
+  });
+
+  it('combines diet + restaurant extensions in order: static → diets → restaurants', () => {
+    const entries = buildSitemapEntries(
+      'https://bite-worthy.com',
+      { dietSlugs: ['vegan'], restaurantSlugs: ['ninis'] },
+      FROZEN,
+    );
+    expect(entries.map((e) => e.url)).toEqual([
+      'https://bite-worthy.com/',
+      'https://bite-worthy.com/login',
+      'https://bite-worthy.com/signup',
+      'https://bite-worthy.com/durango/vegan',
+      'https://bite-worthy.com/restaurants/ninis',
+    ]);
+  });
+});

--- a/apps/web/src/lib/cookie-options.ts
+++ b/apps/web/src/lib/cookie-options.ts
@@ -1,0 +1,64 @@
+/**
+ * Phase 5.4 — auth-cookie attribute composition.
+ *
+ * Centralizes the `cookies.set()` options used by the auth proxy
+ * route at `app/api/auth/[action]/route.ts`. Pulls `domain` from
+ * `NEXT_PUBLIC_COOKIE_DOMAIN` so production can scope the cookie
+ * across subdomains (`.bite-worthy.com` → works for `www`, `app`,
+ * etc.) while dev / CI leave it unset (localhost cookies must NOT
+ * carry a domain attribute or the browser silently drops them).
+ *
+ * Pure function so the route handler stays a thin adapter and
+ * vitest can cover the env-driven branches without touching Next.
+ */
+
+export interface AuthCookieOptions {
+  name: string;
+  value: string;
+  httpOnly: true;
+  secure: boolean;
+  sameSite: 'lax';
+  path: '/';
+  maxAge: number;
+  domain?: string;
+}
+
+const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+interface BuildOptions {
+  /** Override the env-driven `NEXT_PUBLIC_COOKIE_DOMAIN` (test-only). */
+  domain?: string | null;
+  /** Override `NODE_ENV === 'production'` (test-only). */
+  production?: boolean;
+}
+
+export function buildAuthCookieOptions(
+  name: string,
+  value: string,
+  maxAge: number = DEFAULT_MAX_AGE,
+  overrides: BuildOptions = {},
+): AuthCookieOptions {
+  const domain =
+    overrides.domain !== undefined
+      ? (overrides.domain ?? undefined)
+      : process.env.NEXT_PUBLIC_COOKIE_DOMAIN || undefined;
+
+  const production =
+    overrides.production !== undefined
+      ? overrides.production
+      : process.env.NODE_ENV === 'production';
+
+  const opts: AuthCookieOptions = {
+    name,
+    value,
+    httpOnly: true,
+    secure: production,
+    sameSite: 'lax',
+    path: '/',
+    maxAge,
+  };
+  if (domain) {
+    opts.domain = domain;
+  }
+  return opts;
+}

--- a/apps/web/src/lib/sitemap.ts
+++ b/apps/web/src/lib/sitemap.ts
@@ -1,0 +1,83 @@
+/**
+ * Phase 5.4 — sitemap composition.
+ *
+ * Pure-TS helper so the URL list can be unit-tested without spinning
+ * up Next's app router. The route handler at `app/sitemap.ts`
+ * calls this with the production base URL + extension hooks
+ * (Phase 5.6 will add `/durango/[diet]` rows; Phase 5.7 the
+ * seeded-restaurant rows).
+ *
+ * Returns the same shape Next 13+'s `MetadataRoute.Sitemap` expects.
+ */
+
+export type ChangeFreq =
+  | 'always'
+  | 'hourly'
+  | 'daily'
+  | 'weekly'
+  | 'monthly'
+  | 'yearly'
+  | 'never';
+
+export interface SitemapEntry {
+  url: string;
+  lastModified: string | Date;
+  changeFrequency?: ChangeFreq;
+  priority?: number;
+}
+
+export interface SitemapExtension {
+  /**
+   * Phase 5.6 hook — diet preset slugs (e.g. `'celiac'`, `'vegan'`).
+   * Each becomes `/durango/<slug>`. Empty array until 5.6 lands;
+   * the call site decides whether to fetch or hard-code.
+   */
+  dietSlugs?: string[];
+  /**
+   * Phase 5.7 hook — published restaurant slugs. Each becomes
+   * `/restaurants/<slug>`. Empty until the seed run.
+   */
+  restaurantSlugs?: string[];
+}
+
+const STATIC_ROUTES: ReadonlyArray<{
+  path: string;
+  priority: number;
+  changeFrequency: ChangeFreq;
+}> = [
+  { path: '/', priority: 1.0, changeFrequency: 'weekly' },
+  { path: '/login', priority: 0.3, changeFrequency: 'monthly' },
+  { path: '/signup', priority: 0.3, changeFrequency: 'monthly' },
+];
+
+export function buildSitemapEntries(
+  baseUrl: string,
+  options: SitemapExtension = {},
+  now: Date = new Date(),
+): SitemapEntry[] {
+  const lastModified = now.toISOString();
+  const base = baseUrl.replace(/\/+$/, '');
+
+  const staticEntries: SitemapEntry[] = STATIC_ROUTES.map((r) => ({
+    url: `${base}${r.path}`,
+    lastModified,
+    changeFrequency: r.changeFrequency,
+    priority: r.priority,
+  }));
+
+  const dietEntries: SitemapEntry[] = (options.dietSlugs ?? []).map((slug) => ({
+    url: `${base}/durango/${encodeURIComponent(slug)}`,
+    lastModified,
+    changeFrequency: 'weekly',
+    priority: 0.8,
+  }));
+
+  const restaurantEntries: SitemapEntry[] = (options.restaurantSlugs ?? []).map((slug) => ({
+    url: `${base}/restaurants/${encodeURIComponent(slug)}`,
+    lastModified,
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }));
+
+  return [...staticEntries, ...dietEntries, ...restaurantEntries];
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "regions": ["iad1"],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
+  ]
+}

--- a/docs/adr/0005-web-hosting.md
+++ b/docs/adr/0005-web-hosting.md
@@ -1,0 +1,92 @@
+# ADR 0005: production web hosting (Vercel)
+
+- **Date:** 2026-04-30
+- **Status:** Accepted
+- **Refines:** ADR 0001 (the stack pick named `Vercel (web)` but didn't pick the deploy details)
+
+## Context
+
+Phase 5.4 needs a production home for `apps/web` (Next.js 15 App Router). ADR 0001 already named Vercel; this ADR captures the implementation-level details that the loop's deploy depends on, plus the cookie-domain decision that affects how the JWT session works at launch.
+
+## Decision
+
+### Vercel — confirmed
+
+Free tier (Hobby) covers a Durango-scale launch beta:
+
+- 100 GB bandwidth/month — easily covers 10k page views with image-heavy SSR.
+- Unlimited static asset serving from Vercel's CDN.
+- Native Next.js 15 App Router support — no Dockerfile needed; auto-detects framework, server functions, image optimization.
+- Free SSL + automatic HTTPS for custom domains.
+- Preview deploys per PR with no extra setup.
+
+Cloudflare Pages was the alternative considered. It's cheaper at scale and handles edge functions well, but:
+
+- Next.js App Router on CF Pages requires `@cloudflare/next-on-pages` adapter — extra build step + occasional behavioral drift from Vercel's reference Next runtime.
+- Vercel is the reference platform for Next; bugs we hit are likelier to be addressed upstream.
+- Free-tier limits are comparable for our launch volume.
+
+Revisit Cloudflare Pages in Phase 6+ if Vercel pricing ever bites or if we need fine-grained edge logic (e.g. per-region SEO).
+
+### Deploy lifecycle
+
+- **Push to a feature branch** → Vercel auto-deploys a preview at `<branch>--biteworthy.vercel.app`. Useful for codex review of UX changes.
+- **Merge to master** → Vercel auto-deploys to production at `bite-worthy.com`.
+- **No CI changes needed** — Vercel polls GitHub. Phase 5.4's CI keeps running typecheck/lint/test in GitHub Actions; Vercel builds in parallel.
+
+### Region — `iad1` (Washington DC)
+
+Vercel functions run in a region. `iad1` is the eastern-US default and the closest free-tier option to Durango. Latency for SSR-heavy routes (restaurant pages, the future `/durango/[diet]` pages) lives or dies on the round-trip to the API at Fly's `den` region — `iad1` → `den` is ~30ms, which dominates everything else and is fine for v1.
+
+Multi-region SSR is paid-tier. Revisit when the funnel justifies it.
+
+### Cookie domain — `.bite-worthy.com`
+
+The Phase 4.1 auth cookie is currently set without a `domain` attribute (browser scopes it to the origin). For production we set `NEXT_PUBLIC_COOKIE_DOMAIN=.bite-worthy.com` so the cookie works across:
+
+- `bite-worthy.com` (apex — marketing landing, Phase 5.5)
+- `www.bite-worthy.com` (canonical)
+- `app.bite-worthy.com` (potential future subdomain for the React app, deferred Phase 6+)
+
+Dev / CI leave the env var unset because **localhost cookies must NOT carry a domain attribute** — the browser silently drops them otherwise. The `buildAuthCookieOptions` helper in `apps/web/src/lib/cookie-options.ts` enforces this.
+
+### What this PR ships
+
+- `apps/web/vercel.json` — minimal config: framework hint, region pin, security response headers.
+- `apps/web/public/robots.txt` — allow-everything except `/api/` proxy routes.
+- `apps/web/src/app/sitemap.ts` + `apps/web/src/lib/sitemap.ts` — Next 13+ sitemap generator with hooks for Phase 5.6 diet pages + Phase 5.7 seeded restaurants. Pure-TS helper is unit-tested without touching Next.
+- `apps/web/src/lib/cookie-options.ts` — extracted auth-cookie attribute builder; reads `NEXT_PUBLIC_COOKIE_DOMAIN`. The `app/api/auth/[action]/route.ts` proxy now goes through it (3-line refactor).
+- `apps/web/.env.example` — first one for the web app; documents `NEXT_PUBLIC_API_BASE` + `NEXT_PUBLIC_COOKIE_DOMAIN`.
+- `apps/web/README.md` — adds Production deploy section.
+- This ADR.
+
+10 new vitest cases (5 sitemap + 5 cookie-options).
+
+### What still needs a human (Phase 5.4 acceptance criterion)
+
+The acceptance ("`https://bite-worthy.com` resolves to the marketing landing and the SSR restaurant pages work") needs:
+
+1. Sign up for Vercel (free Hobby tier).
+2. Import the GitHub repo. Vercel auto-detects the Next.js app at `apps/web`.
+3. Set environment variables in the Vercel project settings:
+   - `NEXT_PUBLIC_API_BASE=https://api.bite-worthy.com`
+   - `NEXT_PUBLIC_COOKIE_DOMAIN=.bite-worthy.com`
+   - `NEXT_PUBLIC_SITE_URL=https://bite-worthy.com` (controls sitemap base URL; defaults to that string but explicit is better in env-var land).
+4. Add `bite-worthy.com` + `www.bite-worthy.com` as custom domains in the Vercel project. Vercel emits the DNS records to add at the registrar (apex `A` record + `www` `CNAME`).
+5. (Optional) `vercel link` from `apps/web/` if a human wants to use the CLI for one-off `vercel logs` or `vercel env pull`.
+
+Steps 1–2 + 4 are one-time bootstrap; 3 happens on env-var rotation.
+
+## Trade-offs
+
+**Vendor lock-in (mild)** — `vercel.json` is Vercel-specific but tiny (~15 lines); migrating to CF Pages or self-hosted Next is a one-day port. The Next.js code has no Vercel-runtime calls.
+
+**No edge functions in v1** — Vercel's serverless runtime is fine for v1's traffic. Edge would help global TTFB but Durango-only launch doesn't justify the complexity.
+
+**Single region** — accepts a 30ms penalty for non-eastern-US visitors. Multi-region is paid + Phase 6+.
+
+## Consequences
+
+- **Cost** — free at launch volume. First paid tier ($20/mo) kicks in at >100 GB bandwidth, which we won't hit pre-organic-growth.
+- **Operational** — three places to look when something breaks: Vercel (web), Fly (api), Cloudflare R2 (blobs). Document credentials side-by-side in 1Password.
+- **Cookie-domain semantics** — the `NEXT_PUBLIC_COOKIE_DOMAIN` indirection lets dev work without breaking prod. Future subdomain additions (e.g. `app.bite-worthy.com`) inherit the cookie automatically.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,15 +13,14 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.3 — ActiveStorage S3 / R2** (`docs/plans/phase-5.md#53--activestorage-s3--r2-review--dish-photos-in-production`) — this PR. Closes the long-deferred blob-storage gap from Phase 2 + 4 + 4.11.
+1. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`) — this PR.
 2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7 mass-ingests Durango menus.
-3. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`).
-4. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
-5. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
-6. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
-7. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
-8. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
-9. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
+3. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
+4. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
+5. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
+6. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+7. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+8. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
 
@@ -72,6 +71,7 @@ the merge / review / status rules.
 - ✅ Phase 5 — subplan committed (#171)
 - ✅ Phase 5.1 — production API deploy wiring: Fly.io + Dockerfile + smoke task (#172)
 - ✅ Phase 5.2 — production SMTP + email smoke task (#173)
+- ✅ Phase 5.3 — production blob storage on Cloudflare R2 + backfill task (#174)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,52 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 19:17 — tick #81. PR #174 (Phase 5.3 R2 blob storage)
+merged at 18:48 UTC, all CI green. Anthropic still capped (~4.7h
+to reset); cassette PR stays BLOCKED. Picked the next unblocked
+Next-up item: **Phase 5.4 — production web deploy (Vercel +
+bite-worthy.com)**. Loop-shippable wiring split out from
+human-only provisioning per the subplan's Stop conditions.
+Shipped:
+- `apps/web/vercel.json` — minimal config: framework=nextjs,
+  region=iad1 (closest free-tier to Durango; iad→den ~30ms RTT
+  to the Phase 5.1 API), security response headers
+  (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+- `apps/web/public/robots.txt` — allow all bots; disallow
+  `/api/*` proxy routes (server-side adapters, not user pages);
+  points crawlers at /sitemap.xml.
+- `apps/web/src/app/sitemap.ts` (Next 13+ App Router entry) +
+  `apps/web/src/lib/sitemap.ts` (pure-TS generator). Today
+  covers /, /login, /signup with sensible priorities/changefreqs;
+  has hooks (`dietSlugs`, `restaurantSlugs`) for Phase 5.6 +
+  Phase 5.7 to extend without touching Next. Encodes slugs with
+  reserved chars; strips trailing slashes from baseUrl.
+- `apps/web/src/lib/cookie-options.ts` — extracted auth-cookie
+  attribute builder reading `NEXT_PUBLIC_COOKIE_DOMAIN`. Prod
+  scopes cookie to `.bite-worthy.com` (works across www + future
+  app subdomain); dev/CI leave it unset (localhost cookies MUST
+  NOT carry a domain attribute or browsers silently drop them).
+  3-line refactor of `api/auth/[action]/route.ts` to use it.
+- `apps/web/.env.example` — first one for the web app. Documents
+  `NEXT_PUBLIC_API_BASE` + `NEXT_PUBLIC_COOKIE_DOMAIN`.
+- ADR 0005 captures Vercel pick (free tier handles Durango-scale,
+  native Next.js 15 support, preview deploys per PR) vs CF Pages
+  (cheaper at scale but less mature Next runtime). Cookie-domain
+  rationale captured. Deploy lifecycle: push to master →
+  Vercel auto-deploy; push to feature branch → preview URL.
+- Web README gets new "Production deploy" section.
+Tests: 10 new vitest cases (5 sitemap + 5 cookie-options). Web
+vitest 72/72 (+10). Local: pnpm typecheck + lint full-turbo
+cached green; rspec 349/0/1 pending unchanged. Roadmap: ticked
+5.3 (#174); reordered Next-up. **Eager-rebase applied** before
+branching. After PR #175 merges, **Phase 5's production
+infrastructure is structurally complete** (5.1 API deploy, 5.2
+SMTP, 5.3 R2 storage, 5.4 web deploy all loop-shipped); next
+steps shift to public surface (5.5 marketing landing, 5.6
+SEO city pages) and seed motion (5.7 Durango ingest). Anthropic
+cap clears at 00:00 UTC (~4.7h from now); cassette retry
+unblocks then.
+
 2026-04-30 18:47 — tick #80. PR #173 (Phase 5.2 SMTP wiring) merged
 at 18:20 UTC, all CI green. Anthropic still capped (~5.2h to
 reset); cassette PR stays BLOCKED. Picked the next unblocked


### PR DESCRIPTION
## Why

Phase 5.4 from `docs/plans/phase-5.md` — production web deploy on Vercel + `bite-worthy.com`. Splits cleanly into "loop-shippable wiring" (this PR) vs "human-only provisioning" (Vercel account, env vars, DNS). The acceptance criterion (`https://bite-worthy.com` resolves to the marketing landing + SSR restaurant pages work) is gated on those human steps; this PR makes them copy-paste-able.

## What

- **`apps/web/vercel.json`** — minimal config: `framework: nextjs`, `regions: ["iad1"]` (closest free-tier to Durango; iad→den ~30ms to the Phase 5.1 API), security response headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
- **`apps/web/public/robots.txt`** — allow all bots, disallow `/api/*` (server-side proxy routes, not user-facing pages), points crawlers at `/sitemap.xml`.
- **`apps/web/src/app/sitemap.ts`** + **`apps/web/src/lib/sitemap.ts`** — Next 13+ App Router sitemap. Pure-TS generator helper (testable without Next) + thin entry-point adapter. Today covers `/`, `/login`, `/signup` with sensible priorities; has hooks (`dietSlugs`, `restaurantSlugs`) for Phase 5.6 to extend with `/durango/[diet]` and Phase 5.7 to extend with seeded restaurants. URL-encodes slugs with reserved chars; strips trailing slashes from the base URL.
- **`apps/web/src/lib/cookie-options.ts`** — extracted auth-cookie attribute builder reading `NEXT_PUBLIC_COOKIE_DOMAIN`. Production scopes the cookie to `.bite-worthy.com` (works across `www` + future `app` subdomain); dev / CI leave it unset because **localhost cookies must NOT carry a domain attribute** or browsers silently drop them. The existing `app/api/auth/[action]/route.ts` proxy goes through it (3-line refactor — same wire format, cleaner attribute composition).
- **`apps/web/.env.example`** — first one for the web app. Documents `NEXT_PUBLIC_API_BASE` + `NEXT_PUBLIC_COOKIE_DOMAIN`.
- **`apps/web/README.md`** — new "Production deploy" section with the one-time bootstrap inline + sitemap / cookie-domain notes.
- **`docs/adr/0005-web-hosting.md`** — Vercel-vs-Cloudflare-Pages decision (Vercel wins on Next runtime maturity + preview deploys per PR; CF Pages is the Phase 6+ option if pricing ever bites). Cookie-domain rationale captured here too.

## Tests

10 new vitest cases:

- **`sitemap.test.ts`** (5): static route shape + priorities; Phase 5.6 dietSlugs extension; URL encoding of reserved chars; trailing-slash stripping; combined diet + restaurant ordering.
- **`cookie-options.test.ts`** (5): canonical secure-cookie shape; domain omitted in dev; domain attached when env is `.bite-worthy.com`; logout (`maxAge=0`) clears correctly; reads `NEXT_PUBLIC_COOKIE_DOMAIN` from process.env when no override given.

`pnpm --filter @biteworthy/web test`: **72/72** (was 62). `pnpm typecheck` + `pnpm lint`: full-turbo cached green. `bundle exec rspec`: 349/0/1 pending unchanged (no API changes).

## What still needs a human (Phase 5.4 acceptance criterion)

```
1. Sign up for Vercel (free Hobby tier).
2. Import the GitHub repo via the Vercel dashboard — Vercel
   auto-detects the Next.js app at `apps/web`.
3. Set environment variables in Vercel project settings:
   - NEXT_PUBLIC_API_BASE=https://api.bite-worthy.com
   - NEXT_PUBLIC_COOKIE_DOMAIN=.bite-worthy.com
   - NEXT_PUBLIC_SITE_URL=https://bite-worthy.com
4. Add bite-worthy.com + www.bite-worthy.com as custom domains;
   Vercel emits the DNS records to add at the registrar.
5. Push to master triggers an auto-deploy.
```

After secrets + DNS are set, every push to a feature branch gets a preview URL (`<branch>--biteworthy.vercel.app`) which is useful for codex review of UX changes.

## Notes

After this PR merges, **Phase 5's production infrastructure is structurally complete**: 5.1 API deploy + 5.2 SMTP + 5.3 R2 storage + 5.4 web deploy are all loop-shipped. Next steps shift to **public surface** (5.5 marketing landing, 5.6 SEO city pages) and **seed motion** (5.7 Durango ingest, 5.8 PostHog, 5.9 app stores, 5.10 press kit + waitlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)