### PR TITLE
feat(web): marketing landing page at / (phase 5.5)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,19 +1,169 @@
+import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+import { buildLandingMetadata } from '../lib/landing-meta';
+
+/**
+ * Phase 5.5 — marketing landing.
+ *
+ * Pure SSR. No client components. Tailwind only — colors flow from
+ * `@biteworthy/ui-tokens` via `tailwind.config.ts`'s extended palette
+ * (`bite`, `bite-light`, `bite-dark`).
+ *
+ * The structure is deliberately conservative:
+ *
+ *   1. Hero — value prop in one sentence + subhead + CTAs.
+ *   2. Three-up — "Scan", "Pick filter", "See safe dishes."
+ *   3. Local-first note — Durango is the launch market.
+ *   4. Footer — privacy / terms (placeholders until 5.9), GitHub.
+ *
+ * App Store + Play Store CTAs render as "Coming soon" badges until
+ * Phase 5.9 lands the real store URLs. "Try the web app" deep-links
+ * straight to /onboarding so a curious visitor lands in the
+ * profile-creation flow — the existing 6-tap path from Phase 3.2 +
+ * 3.8 takes over from there.
+ */
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bite-worthy.com';
+
+export const metadata: Metadata = buildLandingMetadata({ siteUrl: SITE_URL });
 
 export default function HomePage(): ReactElement {
   return (
-    <main className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center gap-6 px-6">
-      <span className="text-bite text-sm font-medium uppercase tracking-wider">BiteWorthy</span>
-      <h1 className="text-4xl font-bold leading-tight md:text-5xl">
-        Scan any menu, see only what you can eat.
-      </h1>
-      <p className="text-lg text-zinc-600">
-        A pocket food filter for allergies, intolerances, and dietary needs. Built for
-        independent restaurants — not just chains.
-      </p>
-      <p className="text-sm text-zinc-400">
-        Pre-MVP. The mobile app and the contributor tools are wired up next.
-      </p>
+    <main className="bg-white">
+      <Hero />
+      <FeatureRow />
+      <DurangoNote />
+      <Footer />
     </main>
+  );
+}
+
+function Hero(): ReactElement {
+  return (
+    <section className="mx-auto max-w-4xl px-bw-6 pt-bw-16 pb-bw-12 md:pt-bw-16">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">BiteWorthy</p>
+      <h1 className="mt-bw-3 text-bw-4xl font-bold leading-[1.05] text-zinc-900 md:text-[56px]">
+        Scan any menu,
+        <br />
+        see only what you can eat.
+      </h1>
+      <p className="mt-bw-6 max-w-2xl text-bw-lg text-zinc-700">
+        A pocket food filter for celiac, allergies, vegan, and every other dietary need.
+        Snap a photo of a menu — or paste a link — and BiteWorthy hides the dishes that
+        aren&rsquo;t safe for you. With <span className="font-bold">why</span>, every time.
+      </p>
+
+      <div className="mt-bw-8 flex flex-wrap gap-bw-3">
+        <a
+          href="/onboarding"
+          data-testid="cta-web"
+          className="rounded-bw-md bg-bite px-bw-6 py-bw-3 text-bw-base font-bold text-white shadow-sm hover:bg-bite-dark"
+        >
+          Try the web app →
+        </a>
+        <ComingSoonBadge label="iOS app" />
+        <ComingSoonBadge label="Android app" />
+      </div>
+
+      <p className="mt-bw-4 text-bw-xs text-zinc-500">
+        Free during the Durango beta. No ads, no email signup until you choose to save a profile.
+      </p>
+    </section>
+  );
+}
+
+function FeatureRow(): ReactElement {
+  const features: { title: string; body: string; emoji: string }[] = [
+    {
+      emoji: '📸',
+      title: 'Scan the menu',
+      body: 'Camera, photo library, or paste a link to a PDF / online menu. Multi-page menus are fine — the AI reads each page in seconds.',
+    },
+    {
+      emoji: '🥗',
+      title: 'Pick your filter',
+      body: 'Six taps to a working profile. Pick a preset (Celiac, Tree Nut, Vegan, Diabetes-friendly, …) or build your own avoid list.',
+    },
+    {
+      emoji: '✓',
+      title: 'See only safe dishes',
+      body: 'Hidden items each say why — "Contains dairy (cheese)" — so you never wonder. Tap "show anyway" to override one for this meal.',
+    },
+  ];
+  return (
+    <section className="bg-bite-light/30 px-bw-6 py-bw-16">
+      <div className="mx-auto grid max-w-5xl gap-bw-8 md:grid-cols-3">
+        {features.map((f) => (
+          <article key={f.title} className="rounded-bw-lg bg-white p-bw-6 shadow-sm">
+            <p aria-hidden className="text-bw-2xl">
+              {f.emoji}
+            </p>
+            <h2 className="mt-bw-3 text-bw-xl font-bold text-zinc-900">{f.title}</h2>
+            <p className="mt-bw-2 text-bw-base text-zinc-700">{f.body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DurangoNote(): ReactElement {
+  return (
+    <section className="mx-auto max-w-3xl px-bw-6 py-bw-16 text-center">
+      <h2 className="text-bw-2xl font-bold text-zinc-900">Built for Durango first.</h2>
+      <p className="mt-bw-3 text-bw-base text-zinc-700">
+        We&rsquo;re seeding the launch with 30 independent Durango restaurants — not chains, not
+        delivery apps. If you live here and want a place added, the app has a one-tap
+        &ldquo;suggest a restaurant&rdquo; flow that goes straight to the contributor queue.
+      </p>
+      <p className="mt-bw-4 text-bw-sm text-zinc-500">
+        Other towns next, once Durango proves the model.
+      </p>
+    </section>
+  );
+}
+
+function Footer(): ReactElement {
+  return (
+    <footer className="border-t border-zinc-200 bg-zinc-50 px-bw-6 py-bw-12">
+      <div className="mx-auto flex max-w-5xl flex-col gap-bw-3 text-bw-sm text-zinc-500 md:flex-row md:items-center md:justify-between">
+        <p>
+          &copy; {new Date().getFullYear()} BiteWorthy &middot; Made in Durango, CO.
+        </p>
+        <nav className="flex flex-wrap gap-bw-4">
+          <a href="/privacy" className="hover:text-zinc-700" data-testid="footer-privacy">
+            Privacy
+          </a>
+          <a href="/terms" className="hover:text-zinc-700" data-testid="footer-terms">
+            Terms
+          </a>
+          <a href="/press" className="hover:text-zinc-700" data-testid="footer-press">
+            Press
+          </a>
+          <a
+            href="https://github.com/Sky-Fox-Studios/biteworthy"
+            className="hover:text-zinc-700"
+            data-testid="footer-github"
+          >
+            GitHub
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+function ComingSoonBadge({ label }: { label: string }): ReactElement {
+  return (
+    <span
+      data-testid={`cta-soon-${label.toLowerCase().replace(/\s+/g, '-')}`}
+      className="inline-flex items-center gap-bw-2 rounded-bw-md border border-zinc-200 bg-zinc-50 px-bw-4 py-bw-3 text-bw-base font-semibold text-zinc-500"
+    >
+      {label}
+      <span className="rounded-bw-pill bg-zinc-200 px-bw-2 py-bw-0_5 text-bw-xs uppercase tracking-wider">
+        Coming soon
+      </span>
+    </span>
   );
 }

--- a/apps/web/src/lib/__tests__/landing-meta.test.ts
+++ b/apps/web/src/lib/__tests__/landing-meta.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { buildLandingMetadata } from '../landing-meta';
+
+describe('buildLandingMetadata', () => {
+  it('builds the canonical title + description (deterministic strings)', () => {
+    const meta = buildLandingMetadata({ siteUrl: 'https://bite-worthy.com' });
+    expect(meta.title).toBe('BiteWorthy — Scan any menu, see only what you can eat');
+    expect(meta.description).toMatch(/celiac, allergies, vegan/);
+  });
+
+  it('strips trailing slashes from siteUrl when composing OG URL + image', () => {
+    const meta = buildLandingMetadata({ siteUrl: 'https://bite-worthy.com////' });
+    expect(meta.openGraph?.url).toBe('https://bite-worthy.com');
+    const images = meta.openGraph?.images;
+    const first = Array.isArray(images) ? images[0] : images;
+    const url = (first as { url?: string } | undefined)?.url;
+    expect(url).toBe('https://bite-worthy.com/og.png');
+  });
+
+  it('emits Twitter summary_large_image with the same OG image', () => {
+    const meta = buildLandingMetadata({ siteUrl: 'https://bite-worthy.com' });
+    const twitter = meta.twitter as { card?: string; images?: unknown } | undefined;
+    expect(twitter?.card).toBe('summary_large_image');
+    const twitterImages = twitter?.images;
+    const first = Array.isArray(twitterImages) ? twitterImages[0] : twitterImages;
+    expect(first).toBe('https://bite-worthy.com/og.png');
+  });
+
+  it('sets canonical to / so preview deploys do not split SEO', () => {
+    const meta = buildLandingMetadata({ siteUrl: 'https://branch--biteworthy.vercel.app' });
+    expect(meta.alternates?.canonical).toBe('/');
+    expect(meta.metadataBase?.toString()).toBe('https://branch--biteworthy.vercel.app/');
+  });
+
+  it('includes BiteWorthy as the OG site name', () => {
+    const meta = buildLandingMetadata({ siteUrl: 'https://bite-worthy.com' });
+    expect((meta.openGraph as { siteName?: string } | undefined)?.siteName).toBe('BiteWorthy');
+  });
+});

--- a/apps/web/src/lib/landing-meta.ts
+++ b/apps/web/src/lib/landing-meta.ts
@@ -1,0 +1,55 @@
+/**
+ * Phase 5.5 — marketing landing metadata composition.
+ *
+ * Pure-TS helper so the title / description / Open Graph / Twitter
+ * card strings can be unit-tested without touching Next. The
+ * landing's `metadata` export wraps this.
+ */
+
+import type { Metadata } from 'next';
+
+export interface LandingMetaInput {
+  /**
+   * Public canonical origin. In prod: `https://bite-worthy.com`. In
+   * preview / dev: whatever Vercel emits (`NEXT_PUBLIC_SITE_URL`).
+   */
+  siteUrl: string;
+}
+
+const TITLE = 'BiteWorthy — Scan any menu, see only what you can eat';
+const DESCRIPTION =
+  'A pocket food filter for celiac, allergies, vegan, and any other dietary need. Scan any restaurant menu, see only the dishes you can actually eat. Independent restaurants, not just chains.';
+
+/** Built once per page render. Pure: same input → same output. */
+export function buildLandingMetadata({ siteUrl }: LandingMetaInput): Metadata {
+  const base = siteUrl.replace(/\/+$/, '');
+  const ogImage = `${base}/og.png`;
+
+  return {
+    title: TITLE,
+    description: DESCRIPTION,
+    metadataBase: new URL(base),
+    alternates: { canonical: '/' },
+    openGraph: {
+      title: TITLE,
+      description: DESCRIPTION,
+      url: base,
+      siteName: 'BiteWorthy',
+      type: 'website',
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: 'BiteWorthy — Scan any menu, see only what you can eat',
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: TITLE,
+      description: DESCRIPTION,
+      images: [ogImage],
+    },
+  };
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,14 +13,13 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.4 — production web deploy (Vercel + bite-worthy.com)** (`docs/plans/phase-5.md#54--production-web-deploy-vercel--bite-worthycom`) — this PR.
+1. **Phase 5.5 — marketing landing page at `/`** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`) — this PR.
 2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7 mass-ingests Durango menus.
-3. **Phase 5.5 — marketing landing page** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`).
-4. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
-5. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
-6. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
-7. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
-8. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
+3. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
+4. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
+5. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+6. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+7. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
 
@@ -72,6 +71,7 @@ the merge / review / status rules.
 - ✅ Phase 5.1 — production API deploy wiring: Fly.io + Dockerfile + smoke task (#172)
 - ✅ Phase 5.2 — production SMTP + email smoke task (#173)
 - ✅ Phase 5.3 — production blob storage on Cloudflare R2 + backfill task (#174)
+- ✅ Phase 5.4 — production web deploy wiring: vercel.json + sitemap + cookie domain (#175) — **Phase 5 production infrastructure structurally complete (5.1 API + 5.2 SMTP + 5.3 R2 + 5.4 web)**
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,44 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 19:45 — tick #82. PR #175 (Phase 5.4 web deploy wiring)
+merged at 19:18 UTC, all CI green. Anthropic still capped (~4.3h
+to reset); cassette PR stays BLOCKED. Picked the next unblocked
+Next-up item: **Phase 5.5 — marketing landing page at /**.
+Replaced the "Pre-MVP" placeholder home page with the real launch
+landing. Pure SSR, Tailwind-only, ui-tokens colors. Shipped:
+- **Hero** with one-line value prop ("Scan any menu, see only
+  what you can eat."), subhead, primary CTA → /onboarding (entry
+  to the Phase 3.2/3.8 6-tap profile flow). iOS + Android render
+  as "Coming soon" badges until Phase 5.9 lands real store URLs
+  — honest scope vs fake hrefs that 404 on launch announcement.
+- **Three-up feature row** (Scan / Pick filter / See safe dishes)
+  on a soft `bg-bite-light/30` background.
+- **Durango note** explicit launch-market positioning ("30
+  independent restaurants, not chains").
+- **Footer** with copyright, /privacy /terms /press placeholders
+  (Phase 5.9 + 5.10 ship the actual pages — links are markup-
+  stable across PRs), real GitHub link.
+- **Open Graph + Twitter card metadata** via Next 13+ `metadata`
+  export. Pulled into pure-TS `apps/web/src/lib/landing-meta.ts`
+  so the strings are unit-testable. `metadataBase` derived from
+  `NEXT_PUBLIC_SITE_URL`; preview deploys still emit a canonical
+  `/` so SEO doesn't split across vercel.app subdomains.
+5 new vitest cases for `buildLandingMetadata` (title/description,
+trailing-slash stripping in OG URL + image, Twitter
+summary_large_image, canonical, OG siteName). Web vitest 77/77
+(+5). One tsc gotcha caught during spec authoring: Next 16's
+`Twitter` type is a discriminated union — `meta.twitter?.card`
+only resolves with narrowing. Fixed via a local cast in the
+spec; production code stays type-correct. Local: pnpm typecheck
++ lint full-turbo green; rspec 349/0/1 unchanged. Roadmap:
+ticked 5.4 (#175); reordered Next-up. Eager-rebase applied.
+**Phase 5 production infrastructure stays structurally complete**;
+this PR opens the public-surface bucket. Next tick: 5.6
+(/durango/[diet] SEO pages — sitemap hook from #175 already
+ready) — OR if the Anthropic cap clears at 00:00 UTC (~4h
+from now), finally retry the cassette PR.
+
 2026-04-30 19:17 — tick #81. PR #174 (Phase 5.3 R2 blob storage)
 merged at 18:48 UTC, all CI green. Anthropic still capped (~4.7h
 to reset); cassette PR stays BLOCKED. Picked the next unblocked


### PR DESCRIPTION
## Why

Phase 5.5 from `docs/plans/phase-5.md` — replaces the "Pre-MVP" placeholder home page with the real launch landing. First impression for organic visitors; first surface anyone who clicks a Durango press link will see; first thing the App Store reviewer will check when they tap the "support URL."

## What

Pure SSR. No client islands. Tailwind-only — colors flow from `@biteworthy/ui-tokens` via `tailwind.config.ts`'s extended palette. Four sections:

- **Hero** — one-line value prop ("Scan any menu, see only what you can eat."), subhead explaining the dietary filter, CTAs.
  - **Try the web app →** deep-links to `/onboarding` (entry to the 6-tap profile from Phases 3.2 + 3.8).
  - **iOS app** + **Android app** render as **"Coming soon"** badges until Phase 5.9 lands the real store URLs. Honest scope: better than fake `href`s that 404 in the launch announcement post.
- **Three-up feature row** — Scan → Pick filter → See safe dishes, on a soft `bg-bite-light/30` background. Each card describes the corresponding flow with concrete examples.
- **Durango note** — explicit launch-market positioning ("30 independent restaurants, not chains") + one sentence about expansion.
- **Footer** — copyright + Made-in-Durango line; nav to `/privacy`, `/terms`, `/press` (Phase 5.9 + 5.10 ship the actual pages — links are placeholders so the footer markup stays stable across PRs), real GitHub link.

## Metadata

`metadata` export via Next 13+ `Metadata` API, composed by **`apps/web/src/lib/landing-meta.ts`** (pure-TS so the strings are unit-testable). Includes:

- Title + description with the canonical hero copy.
- `metadataBase` derived from `NEXT_PUBLIC_SITE_URL` (set on Vercel by Phase 5.4); preview deploys still emit a canonical `/` so SEO doesn't split across `*.vercel.app` subdomains.
- Open Graph: title, description, URL, siteName, type, image (`/og.png` 1200×630).
- Twitter: `summary_large_image` card with the same OG image.

## Tests

5 new vitest cases for `buildLandingMetadata`:

- Title + description deterministic strings.
- Trailing-slash stripping in OG URL + image composition.
- Twitter `summary_large_image` card with shared image.
- Canonical href is `/` regardless of preview-vs-prod siteUrl.
- OG `siteName` is `BiteWorthy`.

`pnpm --filter @biteworthy/web test`: **77/77** (was 72). `pnpm typecheck` + `pnpm lint`: full-turbo cached green. `bundle exec rspec`: 349/0/1 pending unchanged.

**Tsc gotcha caught during spec authoring**: Next 16's `Twitter` type is a discriminated union (`Twitter | TwitterMetadata`); `meta.twitter?.card` only resolves with narrowing. Fixed via a local cast in the spec; production code stays type-correct via the canonical `Metadata` shape.

## Notes

- **`og.png`** at `apps/web/public/og.png` is referenced but not committed. Phase 5.10's press kit covers the actual image generation. Twitter / Facebook gracefully fall back to `siteName` + `description` until the file exists, so the PR is shippable as-is.
- **Privacy / terms / press** routes 404 until Phase 5.9 + 5.10 ship them. Footer links are placeholders that keep the markup stable across PRs — once those phases land, no markup change here.
- After this merges, the only remaining public-surface item is **Phase 5.6** (`/durango/[diet]` SEO pages, which the sitemap from PR #175 already has hooks for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)