### PR TITLE
feat(api,web): SEO city/diet pages at /durango/[diet] (phase 5.6)

### DIFF
--- a/apps/api/app/controllers/api/v1/city_restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/city_restaurants_controller.rb
@@ -1,0 +1,60 @@
+module Api
+  module V1
+    # GET /api/v1/cities/:city_slug/restaurants?profile=:diet_slug
+    #
+    # Phase 5.6 — backs the SSR `/durango/[diet]` SEO pages. Returns
+    # the city's published restaurants ranked by how many items pass
+    # the given dietary preset's filter (visible_count DESC, then
+    # name ASC).
+    #
+    # Public + unauthenticated. The endpoint is anonymous-friendly
+    # because the SEO landing pages have to render for crawlers + new
+    # visitors who haven't signed up.
+    #
+    # 404s on:
+    #   * unknown city slug
+    #   * unknown diet slug
+    #
+    # Empty `restaurants` array is normal (city has no published
+    # restaurants yet — Phase 5.7's seed run populates it).
+    class CityRestaurantsController < BaseController
+      skip_before_action :authenticate_user!, only: [:index]
+
+      def index
+        city    = City.find_by!(slug: params[:city_slug])
+        profile = DietaryProfile
+          .includes(:dietary_profile_ingredients, :dietary_profile_tags)
+          .find_by!(slug: params[:profile])
+
+        ranked = Cities::RestaurantRanking.new(city: city, dietary_profile: profile).call
+
+        render json: {
+          city:    serialize_city(city),
+          profile: serialize_profile(profile),
+          restaurants: ranked.map { |r| serialize_ranked(r) }
+        }
+      end
+
+      private
+
+      def serialize_city(city)
+        { id: city.id, slug: city.slug, name: city.name, region: city.region }
+      end
+
+      def serialize_profile(profile)
+        { id: profile.id, slug: profile.slug, name: profile.name, description: profile.description }
+      end
+
+      def serialize_ranked(r)
+        {
+          id:            r.restaurant.id,
+          slug:          r.restaurant.slug,
+          name:          r.restaurant.name,
+          visible_count: r.visible_count,
+          hidden_count:  r.hidden_count,
+          total_count:   r.total_count
+        }
+      end
+    end
+  end
+end

--- a/apps/api/app/services/cities/restaurant_ranking.rb
+++ b/apps/api/app/services/cities/restaurant_ranking.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Phase 5.6 — rank a city's published restaurants by how many of
+# their items pass a given dietary preset's filter.
+#
+# Returns a deterministic order — `(visible_count DESC, name ASC)` —
+# so the same SEO page renders identically across requests / regions.
+#
+# One SQL query: filter logic mirrors `Items::FILTERED` in spirit but
+# applies it at the count level so we don't N+1 (running the items
+# endpoint 30 times during SSR would tank the page).
+#
+# The aggregate uses Postgres `FILTER (WHERE ...)` clauses against
+# the `items.ingredient_ids uuid[]` + `items.tag_ids uuid[]` GIN
+# arrays the schema is shaped around (see `docs/schema.md`).
+module Cities
+  class RestaurantRanking
+    Ranked = Struct.new(:restaurant, :visible_count, :total_count, keyword_init: true) do
+      def hidden_count
+        total_count - visible_count
+      end
+    end
+
+    def initialize(city:, dietary_profile:)
+      @city    = city
+      @profile = dietary_profile
+    end
+
+    # Returns an Array<Ranked>. Empty when the city has no published
+    # restaurants.
+    def call
+      avoid_ingredient_ids = @profile.dietary_profile_ingredients.where(rule: "avoid").pluck(:ingredient_id)
+      avoid_tag_ids        = @profile.dietary_profile_tags.where(rule: "avoid").pluck(:tag_id)
+
+      rows = Restaurant
+        .published
+        .where(city_id: @city.id)
+        .left_outer_joins(:items)
+        .merge(published_items_or_null)
+        .group("restaurants.id")
+        .select(
+          "restaurants.id",
+          visible_count_sql(avoid_ingredient_ids, avoid_tag_ids),
+          total_count_sql
+        )
+        .order("visible_count DESC, restaurants.name ASC")
+
+      restaurants_by_id = Restaurant.includes(:city).where(id: rows.map(&:id)).index_by(&:id)
+      rows.map do |row|
+        Ranked.new(
+          restaurant:    restaurants_by_id[row.id],
+          visible_count: row.visible_count.to_i,
+          total_count:   row.total_count.to_i
+        )
+      end
+    end
+
+    private
+
+    # `LEFT OUTER JOIN items` so restaurants with zero published items
+    # still show up. Filter the joined items down to published-only
+    # via WHERE on the items half of the join — a NULLs-permissive
+    # condition (the OR i.id IS NULL preserves no-items restaurants).
+    def published_items_or_null
+      Restaurant.where("items.status = 'published' OR items.id IS NULL")
+    end
+
+    def visible_count_sql(avoid_ingredient_ids, avoid_tag_ids)
+      avoid_ing_array = sanitize_uuid_array(avoid_ingredient_ids)
+      avoid_tag_array = sanitize_uuid_array(avoid_tag_ids)
+
+      <<~SQL.squish + " AS visible_count"
+        COUNT(items.id) FILTER (
+          WHERE items.id IS NOT NULL
+            AND items.status = 'published'
+            AND NOT (items.ingredient_ids && ARRAY[#{avoid_ing_array}]::uuid[])
+            AND NOT (items.tag_ids        && ARRAY[#{avoid_tag_array}]::uuid[])
+        )
+      SQL
+    end
+
+    def total_count_sql
+      "COUNT(items.id) FILTER (WHERE items.id IS NOT NULL AND items.status = 'published') AS total_count"
+    end
+
+    # ARRAY[]::uuid[] doesn't accept an empty list inline — emit a
+    # safe placeholder UUID that no real row will match. Otherwise
+    # quote each id so it interpolates safely.
+    def sanitize_uuid_array(ids)
+      return "'00000000-0000-0000-0000-000000000000'" if ids.blank?
+      ids.map { |id| ActiveRecord::Base.connection.quote(id) }.join(",")
+    end
+  end
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -56,6 +56,13 @@ Rails.application.routes.draw do
         get :history, to: "profile_history#index"
       end
       resources :cities, only: [:index, :show]
+      # Phase 5.6 — backs the SSR /durango/[diet] SEO pages. Flat
+      # route (not nested) so the `:city_slug` param name is explicit;
+      # the parent `resources :cities` has no controller yet (Phase 0
+      # stub) so nesting would be misleading.
+      get "/cities/:city_slug/restaurants",
+          to: "city_restaurants#index",
+          as: :city_restaurants_ranking
       resources :restaurants, only: [:index, :show] do
         resources :items, only: [:index, :show]
         # Phase 4.9 — restaurant claim flow.

--- a/apps/api/spec/requests/api/v1/cities/restaurants_spec.rb
+++ b/apps/api/spec/requests/api/v1/cities/restaurants_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+# Phase 5.6 — backs the SSR /durango/[diet] SEO pages.
+RSpec.describe "GET /api/v1/cities/:city_slug/restaurants", type: :request do
+  let(:durango) { create(:city, slug: "durango", name: "Durango", region: "CO") }
+
+  let!(:cheese) { create(:ingredient, slug: "dairy-cheese") }
+  let!(:dairy_tag) { create(:tag, slug: "allergen-contains-dairy") }
+  let!(:vegan_preset) do
+    preset = create(:dietary_profile, slug: "vegan", name: "Vegan")
+    create(:dietary_profile_ingredient, dietary_profile: preset, ingredient: cheese, rule: "avoid")
+    create(:dietary_profile_tag,        dietary_profile: preset, tag: dairy_tag,    rule: "avoid")
+    preset
+  end
+
+  let!(:tacos) { create(:restaurant, :published, slug: "tacos", name: "Tacos", city: durango) }
+  let!(:cream) { create(:restaurant, :published, slug: "cream", name: "Cream", city: durango) }
+
+  before do
+    create(:item, :published, :confirmed, restaurant: tacos, name: "Veggie", ingredients: [])
+    create(:item, :published, :confirmed, restaurant: tacos, name: "Cheesy",
+           ingredients: [cheese], tag_list: [dairy_tag])
+    create(:item, :published, :confirmed, restaurant: cream, name: "Mac",
+           ingredients: [cheese], tag_list: [dairy_tag])
+  end
+
+  it "returns the city + profile metadata + ranked restaurants" do
+    get "/api/v1/cities/durango/restaurants?profile=vegan"
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+
+    expect(body["city"]).to include(
+      "slug" => "durango", "name" => "Durango", "region" => "CO"
+    )
+    expect(body["profile"]).to include(
+      "slug" => "vegan", "name" => "Vegan"
+    )
+    slugs = body["restaurants"].map { |r| r["slug"] }
+    expect(slugs).to eq(%w[tacos cream]) # tacos has 1 vegan-safe item, cream has 0
+    expect(body["restaurants"].first).to include(
+      "visible_count" => 1, "hidden_count" => 1, "total_count" => 2
+    )
+  end
+
+  it "404s on an unknown city slug" do
+    get "/api/v1/cities/nope/restaurants?profile=vegan"
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "404s on an unknown profile slug" do
+    get "/api/v1/cities/durango/restaurants?profile=no-such-diet"
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "is unauthenticated (anonymous browsers + crawlers)" do
+    get "/api/v1/cities/durango/restaurants?profile=vegan"
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "returns an empty restaurants array when the city has none yet" do
+    barren = create(:city, slug: "barren", name: "Barren", region: "WY")
+    _ = barren
+    get "/api/v1/cities/barren/restaurants?profile=vegan"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["restaurants"]).to eq([])
+  end
+end

--- a/apps/api/spec/services/cities/restaurant_ranking_spec.rb
+++ b/apps/api/spec/services/cities/restaurant_ranking_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+# Phase 5.6 — guards the city + dietary-preset ranking that backs
+# the SSR /durango/[diet] SEO pages. Hits a real Postgres so the
+# `&&` (overlap) operator + `FILTER (WHERE ...)` aggregation behave
+# the same as production.
+RSpec.describe Cities::RestaurantRanking do
+  let(:city)  { create(:city, slug: "durango", name: "Durango", region: "CO") }
+  let(:other_city) { create(:city, slug: "telluride", name: "Telluride", region: "CO") }
+
+  let!(:beef)   { create(:ingredient, slug: "meat-beef") }
+  let!(:cheese) { create(:ingredient, slug: "dairy-cheese") }
+  let!(:salmon) { create(:ingredient, slug: "fish-salmon") }
+  let!(:vegan_tag)   { create(:tag, slug: "diet-vegan") }
+  let!(:dairy_tag)   { create(:tag, slug: "allergen-contains-dairy") }
+
+  # Vegan preset: avoid dairy ingredient + the contains-dairy tag.
+  let(:vegan_preset) do
+    preset = create(:dietary_profile, slug: "vegan")
+    create(:dietary_profile_ingredient, dietary_profile: preset, ingredient: cheese, rule: "avoid")
+    create(:dietary_profile_tag,        dietary_profile: preset, tag: dairy_tag,    rule: "avoid")
+    preset
+  end
+
+  let(:empty_preset) { create(:dietary_profile, slug: "balanced") }
+
+  # Two restaurants in Durango, one in Telluride.
+  let!(:tacos)     { create(:restaurant, :published, slug: "tacos", name: "Tacos", city: city) }
+  let!(:cream)     { create(:restaurant, :published, slug: "cream", name: "Cream", city: city) }
+  let!(:far_away)  { create(:restaurant, :published, slug: "far",   name: "Far Away", city: other_city) }
+
+  before do
+    # Tacos: 2 vegan-safe items + 1 dairy item.
+    create(:item, :published, :confirmed, restaurant: tacos, name: "Veggie Taco", ingredients: [], tag_list: [])
+    create(:item, :published, :confirmed, restaurant: tacos, name: "Bean Taco",   ingredients: [], tag_list: [])
+    create(:item, :published, :confirmed, restaurant: tacos, name: "Beef Cheese Taco",
+           ingredients: [beef, cheese], tag_list: [dairy_tag])
+
+    # Cream: 1 dairy item, 0 vegan-safe.
+    create(:item, :published, :confirmed, restaurant: cream, name: "Mac and Cheese",
+           ingredients: [cheese], tag_list: [dairy_tag])
+
+    # Far Away: 5 vegan items but in Telluride, not Durango — must not appear.
+    5.times { |i| create(:item, :published, :confirmed, restaurant: far_away, name: "FA #{i}") }
+  end
+
+  describe "#call" do
+    it "returns Durango restaurants only, ranked by visible_count desc" do
+      ranked = described_class.new(city: city, dietary_profile: vegan_preset).call
+
+      expect(ranked.map { |r| r.restaurant.slug }).to eq(%w[tacos cream])
+      expect(ranked.first.visible_count).to eq(2)
+      expect(ranked.first.total_count).to eq(3)
+      expect(ranked.first.hidden_count).to eq(1)
+
+      expect(ranked.last.visible_count).to eq(0)
+      expect(ranked.last.total_count).to eq(1)
+    end
+
+    it "tiebreaks alphabetically by restaurant name" do
+      # Wipe Tacos's items so both Durango restaurants tie at 0 visible.
+      tacos.items.destroy_all
+
+      ranked = described_class.new(city: city, dietary_profile: vegan_preset).call
+
+      # Cream alphabetically before Tacos.
+      expect(ranked.map { |r| r.restaurant.slug }).to eq(%w[cream tacos])
+    end
+
+    it "returns every restaurant when the preset has no avoid lists" do
+      ranked = described_class.new(city: city, dietary_profile: empty_preset).call
+
+      # Both Durango restaurants present; visible_count == total_count.
+      expect(ranked.map { |r| [r.restaurant.slug, r.visible_count, r.total_count] }).to contain_exactly(
+        ["tacos", 3, 3],
+        ["cream", 1, 1]
+      )
+    end
+
+    it "still returns restaurants with zero published items" do
+      empty_restaurant = create(:restaurant, :published, slug: "empty", name: "Aaa Empty", city: city)
+      _ = empty_restaurant
+      ranked = described_class.new(city: city, dietary_profile: vegan_preset).call
+
+      empty_row = ranked.find { |r| r.restaurant.slug == "empty" }
+      expect(empty_row).not_to be_nil
+      expect(empty_row.visible_count).to eq(0)
+      expect(empty_row.total_count).to eq(0)
+    end
+
+    it "ignores draft restaurants (status != 'published')" do
+      create(:restaurant, slug: "draft-spot", name: "Draft", city: city) # default status: draft
+      ranked = described_class.new(city: city, dietary_profile: vegan_preset).call
+
+      expect(ranked.map { |r| r.restaurant.slug }).not_to include("draft-spot")
+    end
+  end
+end

--- a/apps/web/src/app/durango/[diet]/page.tsx
+++ b/apps/web/src/app/durango/[diet]/page.tsx
@@ -1,0 +1,231 @@
+/**
+ * Phase 5.6 — SEO landing for `<diet> restaurants in Durango`.
+ *
+ * Pure SSR (no client islands). Indexable. The metadata block uses
+ * the diet slug to compose a deterministic title + description that
+ * Google can use as the SERP snippet.
+ *
+ * 404 path: an unknown diet slug 404s the page via Next's
+ * `notFound()` — the upstream API returns 404 for an unknown
+ * `profile` slug, so we propagate. Same for an empty city. The diet
+ * list in `lib/durango.ts` mirrors `db/seeds/dietary_profiles.yml`
+ * but a stale slug here just shows 404 instead of a stale grid —
+ * that's the right failure mode.
+ */
+
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import { notFound } from 'next/navigation';
+import {
+  DURANGO_DIET_SLUGS,
+  type DurangoDietSlug,
+  CityRankingError,
+  fetchCityRanking,
+  type CityRanked,
+} from '../../../lib/durango';
+
+interface Params {
+  diet: string;
+}
+
+interface PageProps {
+  params: Promise<Params>;
+}
+
+export async function generateStaticParams(): Promise<Params[]> {
+  // Pre-render every curated diet at build time so the SEO pages
+  // don't pay an SSR penalty on first crawl. Dynamic-route fallback
+  // still kicks in for diets we ship between builds.
+  return DURANGO_DIET_SLUGS.map((diet) => ({ diet }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { diet } = await params;
+  if (!isCuratedDiet(diet)) {
+    return { title: 'Not found — BiteWorthy', robots: { index: false } };
+  }
+  const dietName = humanizeDietSlug(diet);
+  const title = `${dietName} restaurants in Durango — BiteWorthy`;
+  const description = `Find Durango restaurants ranked by how many menu items pass a ${dietName.toLowerCase()} filter. Built for celiac, allergies, vegan, and every other dietary need.`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `/durango/${diet}` },
+    openGraph: { title, description, type: 'website', url: `/durango/${diet}` },
+    twitter: { card: 'summary_large_image', title, description },
+  };
+}
+
+export default async function DurangoDietPage({ params }: PageProps): Promise<ReactElement> {
+  const { diet } = await params;
+  if (!isCuratedDiet(diet)) notFound();
+
+  let ranking: CityRanked;
+  try {
+    ranking = await fetchCityRanking('durango', diet);
+  } catch (e) {
+    if (e instanceof CityRankingError && e.status === 404) notFound();
+    throw e;
+  }
+
+  const visibleSlugs = ranking.restaurants.filter((r) => r.visible_count > 0);
+  const allHiddenSlugs = ranking.restaurants.filter((r) => r.visible_count === 0);
+
+  return (
+    <main className="bg-white">
+      <Hero
+        dietName={ranking.profile.name}
+        totalRestaurants={ranking.restaurants.length}
+        visibleRestaurants={visibleSlugs.length}
+      />
+
+      {ranking.restaurants.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <RestaurantGrid
+          ranked={ranking.restaurants}
+          dietName={ranking.profile.name}
+          visibleSlugs={visibleSlugs}
+          allHiddenSlugs={allHiddenSlugs}
+        />
+      )}
+    </main>
+  );
+}
+
+function Hero({
+  dietName,
+  totalRestaurants,
+  visibleRestaurants,
+}: {
+  dietName: string;
+  totalRestaurants: number;
+  visibleRestaurants: number;
+}): ReactElement {
+  return (
+    <section className="mx-auto max-w-4xl px-bw-6 pt-bw-16 pb-bw-12">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">
+        Durango, Colorado
+      </p>
+      <h1 className="mt-bw-3 text-bw-3xl font-bold leading-tight text-zinc-900 md:text-bw-4xl">
+        {dietName} restaurants in Durango
+      </h1>
+      <p className="mt-bw-4 max-w-2xl text-bw-base text-zinc-700">
+        {totalRestaurants === 0
+          ? `We're seeding Durango restaurants now — check back soon.`
+          : `${visibleRestaurants} of ${totalRestaurants} restaurants in our index have at least one ${dietName.toLowerCase()}-safe menu item. Ranked by how many items pass the filter.`}
+      </p>
+    </section>
+  );
+}
+
+function RestaurantGrid({
+  ranked,
+  dietName,
+  visibleSlugs,
+  allHiddenSlugs,
+}: {
+  ranked: CityRanked['restaurants'];
+  dietName: string;
+  visibleSlugs: CityRanked['restaurants'];
+  allHiddenSlugs: CityRanked['restaurants'];
+}): ReactElement {
+  // Mark unused for clarity; consumers may want them in future.
+  void ranked;
+  return (
+    <section className="mx-auto max-w-4xl px-bw-6 pb-bw-16">
+      {visibleSlugs.length > 0 && (
+        <ul className="mt-bw-4 grid gap-bw-3 md:grid-cols-2">
+          {visibleSlugs.map((r) => (
+            <RestaurantCard key={r.id} r={r} dietName={dietName} />
+          ))}
+        </ul>
+      )}
+
+      {allHiddenSlugs.length > 0 && (
+        <details className="mt-bw-8" data-testid="all-hidden">
+          <summary className="cursor-pointer text-bw-sm font-semibold text-bite hover:text-bite-dark">
+            Show {allHiddenSlugs.length} restaurant{allHiddenSlugs.length === 1 ? '' : 's'} with no
+            {' '}
+            {dietName.toLowerCase()}-safe items
+          </summary>
+          <ul className="mt-bw-3 grid gap-bw-3 md:grid-cols-2">
+            {allHiddenSlugs.map((r) => (
+              <RestaurantCard key={r.id} r={r} dietName={dietName} />
+            ))}
+          </ul>
+        </details>
+      )}
+    </section>
+  );
+}
+
+function RestaurantCard({
+  r,
+  dietName,
+}: {
+  r: CityRanked['restaurants'][number];
+  dietName: string;
+}): ReactElement {
+  const allHidden = r.visible_count === 0;
+  return (
+    <li
+      data-testid={`restaurant-${r.slug}`}
+      className={[
+        'rounded-bw-lg border p-bw-4',
+        allHidden ? 'border-zinc-200 bg-zinc-50' : 'border-zinc-200 bg-white shadow-sm',
+      ].join(' ')}
+    >
+      <a
+        href={`/restaurants/${encodeURIComponent(r.slug)}`}
+        className="block"
+        data-testid={`restaurant-link-${r.slug}`}
+      >
+        <h2 className={['text-bw-lg font-bold', allHidden ? 'text-zinc-500' : 'text-zinc-900'].join(' ')}>
+          {r.name}
+        </h2>
+        <p className="mt-bw-1 text-bw-sm text-zinc-600">
+          {allHidden ? (
+            <>No {dietName.toLowerCase()}-safe items in our index yet.</>
+          ) : (
+            <>
+              <span className="font-semibold text-zinc-900">{r.visible_count}</span> safe item
+              {r.visible_count === 1 ? '' : 's'}
+              {' '}
+              <span className="text-zinc-500">
+                · {r.hidden_count} hidden by your filter
+              </span>
+            </>
+          )}
+        </p>
+      </a>
+    </li>
+  );
+}
+
+function EmptyState(): ReactElement {
+  return (
+    <section className="mx-auto max-w-3xl px-bw-6 pb-bw-16 text-center">
+      <p className="text-bw-base text-zinc-600">
+        We&rsquo;re seeding the Durango launch with 30 independent restaurants now.
+      </p>
+      <a
+        href="/onboarding"
+        className="mt-bw-6 inline-block rounded-bw-md bg-bite px-bw-6 py-bw-3 text-bw-base font-bold text-white shadow-sm hover:bg-bite-dark"
+      >
+        Set up your filter while you wait →
+      </a>
+    </section>
+  );
+}
+
+function isCuratedDiet(diet: string): diet is DurangoDietSlug {
+  return (DURANGO_DIET_SLUGS as readonly string[]).includes(diet);
+}
+
+function humanizeDietSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((p) => (p.length > 0 ? p[0]!.toUpperCase() + p.slice(1) : p))
+    .join(' ');
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -18,10 +18,15 @@
 
 import type { MetadataRoute } from 'next';
 import { buildSitemapEntries } from '../lib/sitemap';
+import { DURANGO_DIET_SLUGS } from '../lib/durango';
 
 const DEFAULT_BASE_URL = 'https://bite-worthy.com';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_BASE_URL;
-  return buildSitemapEntries(baseUrl);
+  return buildSitemapEntries(baseUrl, {
+    // Phase 5.6 — every curated diet slug becomes /durango/[diet].
+    // Phase 5.7 will populate restaurantSlugs once the seed run lands.
+    dietSlugs: [...DURANGO_DIET_SLUGS],
+  });
 }

--- a/apps/web/src/lib/__tests__/durango.test.ts
+++ b/apps/web/src/lib/__tests__/durango.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CityRankingError,
+  DURANGO_DIET_SLUGS,
+  fetchCityRanking,
+  type CityRanked,
+} from '../durango';
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'NOT FOUND',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+const samplePayload: CityRanked = {
+  city: { id: 'c-1', slug: 'durango', name: 'Durango', region: 'CO' },
+  profile: { id: 'p-1', slug: 'vegan', name: 'Vegan', description: null },
+  restaurants: [
+    { id: 'r-1', slug: 'tacos', name: 'Tacos', visible_count: 5, hidden_count: 2, total_count: 7 },
+  ],
+};
+
+describe('fetchCityRanking', () => {
+  it('GETs /api/v1/cities/:city/restaurants?profile=:diet with Accept JSON', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    const out = await fetchCityRanking('durango', 'vegan', { fetchImpl });
+    expect(out.restaurants[0]!.name).toBe('Tacos');
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('/api/v1/cities/durango/restaurants?profile=vegan');
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Accept).toBe('application/json');
+  });
+
+  it('encodes city + diet slugs containing reserved chars', async () => {
+    const fetchImpl = fakeFetch(200, samplePayload);
+    await fetchCityRanking('san josé', 'tree nut free', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('/api/v1/cities/san%20jos%C3%A9/restaurants?profile=tree%20nut%20free');
+  });
+
+  it('throws CityRankingError preserving the upstream status (404 → notFound() in SSR)', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'unknown city' });
+    await expect(fetchCityRanking('nope', 'vegan', { fetchImpl })).rejects.toMatchObject({
+      name: 'CityRankingError',
+      status: 404,
+    });
+  });
+
+  it('throws on 500 too so SSR can boundary-error rather than render half a page', async () => {
+    const fetchImpl = fakeFetch(500, {});
+    await expect(fetchCityRanking('durango', 'vegan', { fetchImpl })).rejects.toBeInstanceOf(
+      CityRankingError,
+    );
+  });
+});
+
+describe('DURANGO_DIET_SLUGS', () => {
+  it('contains the curated production-ready presets seeded in Phase 3.1', () => {
+    expect(DURANGO_DIET_SLUGS).toContain('vegan');
+    expect(DURANGO_DIET_SLUGS).toContain('celiac');
+    expect(DURANGO_DIET_SLUGS).toContain('tree-nut-free');
+    // Order matters for stable sitemap output.
+    expect(DURANGO_DIET_SLUGS[0]).toBe('vegan');
+  });
+});

--- a/apps/web/src/lib/durango.ts
+++ b/apps/web/src/lib/durango.ts
@@ -1,0 +1,78 @@
+/**
+ * Phase 5.6 — fetcher + curated diet-slug list for the SSR
+ * `/durango/[diet]` SEO pages and the sitemap entry hook.
+ *
+ * The slug list is hard-coded rather than fetched at build time:
+ *
+ *   * Production sitemap.ts is an async function but Vercel build
+ *     workers shouldn't need an HTTP round-trip to the API to emit
+ *     a list that changes once a quarter.
+ *   * `db/seeds/dietary_profiles.yml` is the source of truth on the
+ *     API side; this list mirrors it. When a new preset ships,
+ *     update both.
+ *   * Mismatch is non-catastrophic: the SSR page renders 404 for an
+ *     unknown diet (via Next's `notFound()` from the upstream 404),
+ *     so a stale slug here just hides one URL from the sitemap
+ *     until the next deploy.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export const DURANGO_CITY_SLUG = 'durango';
+
+/**
+ * Curated dietary-profile slugs Phase 3.1 seeded. Order is the
+ * sitemap order (priority is the same for all, so order is just
+ * stable URL listing).
+ */
+export const DURANGO_DIET_SLUGS = [
+  'vegan',
+  'vegetarian',
+  'celiac',
+  'tree-nut-free',
+  'shellfish-free',
+  'lactose-free',
+  'low-fodmap',
+  'pescatarian',
+] as const;
+
+export type DurangoDietSlug = (typeof DURANGO_DIET_SLUGS)[number];
+
+export interface CityRanked {
+  city: { id: string; slug: string; name: string; region: string };
+  profile: { id: string; slug: string; name: string; description: string | null };
+  restaurants: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    visible_count: number;
+    hidden_count: number;
+    total_count: number;
+  }>;
+}
+
+export interface FetchOptions {
+  fetchImpl?: typeof fetch;
+}
+
+export class CityRankingError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    this.name = 'CityRankingError';
+  }
+}
+
+export async function fetchCityRanking(
+  citySlug: string,
+  dietSlug: string,
+  opts: FetchOptions = {},
+): Promise<CityRanked> {
+  const { fetchImpl = fetch } = opts;
+  const url = `${API_BASE}/api/v1/cities/${encodeURIComponent(citySlug)}/restaurants?profile=${encodeURIComponent(dietSlug)}`;
+
+  const res = await fetchImpl(url, { headers: { Accept: 'application/json' } });
+  if (!res.ok) {
+    throw new CityRankingError(res.status, `fetchCityRanking ${citySlug}/${dietSlug} failed: ${res.status}`);
+  }
+  return (await res.json()) as CityRanked;
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,13 +13,12 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.5 — marketing landing page at `/`** (`docs/plans/phase-5.md#55--marketing-landing-page-at-`) — this PR.
+1. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`) — this PR.
 2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7 mass-ingests Durango menus.
-3. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`).
-4. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
-5. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
-6. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
-7. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
+3. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
+4. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+5. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+6. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
 
@@ -72,6 +71,7 @@ the merge / review / status rules.
 - ✅ Phase 5.2 — production SMTP + email smoke task (#173)
 - ✅ Phase 5.3 — production blob storage on Cloudflare R2 + backfill task (#174)
 - ✅ Phase 5.4 — production web deploy wiring: vercel.json + sitemap + cookie domain (#175) — **Phase 5 production infrastructure structurally complete (5.1 API + 5.2 SMTP + 5.3 R2 + 5.4 web)**
+- ✅ Phase 5.5 — marketing landing page at / (#176)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,53 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 20:18 — tick #83. PR #176 (Phase 5.5 marketing landing)
+merged at 19:46 UTC, all CI green. Anthropic still capped (~3.7h
+to reset); cassette PR stays BLOCKED. Picked the next unblocked
+Next-up item: **Phase 5.6 — SEO city/diet pages
+(/durango/[diet])**. Indexable per-diet ranking pages (the
+queries Durango folks actually type). Shipped both API + web:
+- **API**: new `Cities::RestaurantRanking` service computes
+  visible/total item counts per restaurant via one SQL query
+  with Postgres `FILTER (WHERE …)` aggregation against the
+  GIN-indexed `ingredient_ids uuid[]` + `tag_ids uuid[]` arrays.
+  Order: `(visible_count DESC, name ASC)`. LEFT-OUTER joins so
+  zero-item restaurants still appear; ignores draft restaurants;
+  empty avoid lists handled with placeholder UUID so
+  `ARRAY[]::uuid[]` doesn't trip Postgres. New
+  `GET /api/v1/cities/:city_slug/restaurants?profile=:diet_slug`
+  endpoint (public, unauthenticated). 404s on unknown city or
+  diet slug. Flat route since the parent `:cities` resource has
+  no controller (Phase 0 stub). 10 new specs (5 service + 5
+  request); rspec 359/0/1 (+10).
+- **Web**: `apps/web/src/app/durango/[diet]/page.tsx` pure-SSR.
+  `generateStaticParams` pre-renders every curated diet at build
+  time. `generateMetadata` composes deterministic title
+  ("Vegan restaurants in Durango — BiteWorthy") + description.
+  Unknown diet routes to Next's `notFound()`. Restaurants with
+  zero safe items collapse into a `<details>` block at bottom so
+  the page stays useful without burying the leads. Empty-state
+  CTA back to /onboarding for the gap before Phase 5.7's seed
+  run.
+- `apps/web/src/lib/durango.ts` — fetcher +
+  `DURANGO_DIET_SLUGS` curated constant (mirrors
+  `db/seeds/dietary_profiles.yml`). Hard-coded rather than
+  build-time-fetched: list changes once a quarter; mismatch is
+  non-catastrophic (404 vs stale grid). 5 new vitest cases (URL
+  composition, slug encoding, 404+500 propagation, slug list).
+  Web vitest 82/82 (+5).
+- `app/sitemap.ts` extended to enumerate diet URLs via the
+  `dietSlugs` hook PR #175 already wired in.
+Local: pnpm typecheck + lint full-turbo green; rspec 359/0/1
+(+10). Roadmap: ticked 5.5 (#176); reordered Next-up. Eager-
+rebase applied. Surfaced one **Discovered**-worthy gap during
+implementation: addresses table has no `neighborhood` column;
+the subplan asked for a per-row neighborhood label which I left
+out. Worth a Phase 5+ followup once the launch market grows
+beyond "Durango itself." Next tick: 5.7 (seed 30 Durango
+restaurants) — OR if the Anthropic cap clears at 00:00 UTC
+(~3.7h from now), retry the cassette PR.
+
 2026-04-30 19:45 — tick #82. PR #175 (Phase 5.4 web deploy wiring)
 merged at 19:18 UTC, all CI green. Anthropic still capped (~4.3h
 to reset); cassette PR stays BLOCKED. Picked the next unblocked


### PR DESCRIPTION
## Why

Phase 5.6 from `docs/plans/phase-5.md` — indexable per-diet ranking pages (`/durango/celiac`, `/durango/vegan`, …), the actual queries Durango folks already type into Google. SSR, no client islands, sitemap-listed.

## What

### API

- **`Cities::RestaurantRanking`** service computes visible/total item counts per restaurant in **one SQL query** via Postgres `FILTER (WHERE …)` aggregation against the GIN-indexed `ingredient_ids uuid[]` + `tag_ids uuid[]` arrays the schema is shaped around. Order: `(visible_count DESC, name ASC)` — deterministic so SSR snapshots are stable. LEFT-OUTER joins items so zero-item restaurants still appear; ignores draft restaurants; empty avoid lists handled with a placeholder UUID so `ARRAY[]::uuid[]` doesn't trip Postgres.
- **New endpoint** `GET /api/v1/cities/:city_slug/restaurants?profile=:diet_slug` — public, unauthenticated (SEO crawlers + new visitors). Returns `{ city, profile, restaurants[] }` consumable by SSR without further joins. **404s** on unknown city + unknown diet. Flat route (not nested under `resources :cities`) so the `:city_slug` param name is explicit; the parent `:cities` resource has no controller (Phase 0 stub).
- **Specs**: 5 service-level (ranking + tiebreak + empty preset + zero-item restaurants + draft skip) + 5 request specs (happy path + 404s + anon-friendly + empty city). **rspec 359/0/1 pending** (+10).

### Web

- **`apps/web/src/app/durango/[diet]/page.tsx`** — pure-SSR ranked grid. `generateStaticParams` pre-renders every curated diet at build time so first crawl pays no SSR penalty. `generateMetadata` composes a deterministic SEO title (`"Vegan restaurants in Durango — BiteWorthy"`) + description per page. Unknown diet → Next's `notFound()` (mirrors the upstream API 404). Per-restaurant card shows visible-count + hidden-count; restaurants with zero safe items collapse into a `<details>` block at the bottom (still indexable, doesn't bury the leads).
- **Empty state** for the gap before Phase 5.7's seed run lands — CTA back to `/onboarding` so visitors don't bounce.
- **`apps/web/src/lib/durango.ts`** — fetcher + `DURANGO_DIET_SLUGS` curated constant. Hard-coded rather than build-time-fetched because the list changes once a quarter; mismatch is non-catastrophic (404 instead of stale grid).
- **Sitemap** from PR #175 extended to enumerate the diet URLs via the `dietSlugs` hook it already had wired.
- **Specs**: 5 vitest cases for `fetchCityRanking` (URL composition, slug encoding, 404 + 500 propagation, curated slug list contents). **Web vitest 82/82** (+5).

## What still needs a human (Phase 5.6 acceptance criterion)

- Visual review on a Vercel preview once Phase 5.4's deploy lands real env vars. Acceptance: Google's mobile-friendly tester gives `/durango/gluten-free` a passing grade.
- Per-diet OG images deferred to Phase 5.10 (press kit). The default site-wide OG card from Phase 5.5 renders gracefully until per-page images ship.

## Discovered

The `addresses` table has no `neighborhood` column; the subplan asked for a per-row neighborhood label which I left out (no schema change). Worth a Phase 5+ followup once the launch market grows beyond "Durango itself" — multiple neighborhoods only matter at scale. Logged here rather than the roadmap Discovered section because the gap is small + clearly Phase 6+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)