### PR TITLE
feat(api): durango batch ingest task + csv template (phase 5.7)

### DIFF
--- a/apps/api/app/services/biteworthy/durango_seed.rb
+++ b/apps/api/app/services/biteworthy/durango_seed.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "csv"
+
+# Phase 5.7 — operator-driven batch ingest of Durango restaurants.
+#
+# Reads a CSV (template at `docs/seeds/durango.csv.example`),
+# find-or-creates each Restaurant in the durango City, kicks off
+# an IngestionRun via the Phase 2.8 URL/PDF entrypoint, polls until
+# the run hits `:staged` or `:failed` (or the per-run timeout
+# elapses), prints one status line per row, returns a tally.
+#
+# Idempotent: a row whose Restaurant already has a non-failed
+# IngestionRun in `:staged` or `:published` is skipped (the runner
+# logs `[skip]`). To re-run a failed restaurant, mark its old runs
+# as `:failed` (Avo can do this) or delete them — the next seed
+# call will pick the row up.
+#
+# Doesn't auto-publish the run. The Phase 2.5 swipe-verify queue
+# still gates publication via the 80%-accepted threshold; the seed
+# task's job is to land 30 staged runs, not to bypass human review.
+module Biteworthy
+  class DurangoSeed
+    DEFAULT_WAIT_SECONDS = 600 # 10 minutes per run, conservative
+    POLL_INTERVAL_SEC    = 5
+
+    Result = Struct.new(:created, :skipped, :failed, :rows, keyword_init: true) do
+      def total
+        created + skipped + failed
+      end
+    end
+
+    Row = Struct.new(:restaurant_slug, :outcome, :detail, keyword_init: true)
+
+    def initialize(
+      csv_path:,
+      city_slug: "durango",
+      city_name: "Durango",
+      city_region: "CO",
+      logger: $stdout,
+      wait_seconds: DEFAULT_WAIT_SECONDS,
+      url_fetcher: UrlFetcher,
+      operator_user: nil
+    )
+      @csv_path        = csv_path
+      @city_slug       = city_slug
+      @city_name       = city_name
+      @city_region     = city_region
+      @logger          = logger
+      @wait_seconds    = wait_seconds
+      @url_fetcher     = url_fetcher
+      @operator_user   = operator_user
+    end
+
+    def run
+      city = find_or_create_city!
+      result = Result.new(created: 0, skipped: 0, failed: 0, rows: [])
+
+      @logger.puts "BiteWorthy seed → city=#{city.slug}  csv=#{@csv_path}"
+
+      parse_rows.each do |row|
+        slug = row.fetch(:slug).presence || row.fetch(:name).parameterize
+        outcome = process(row.merge(slug: slug), city)
+        result.rows << outcome
+
+        case outcome.outcome
+        when :created  then result.created += 1
+        when :skipped  then result.skipped += 1
+        when :failed   then result.failed  += 1
+        end
+
+        @logger.puts "  [#{label(outcome.outcome)}] #{outcome.restaurant_slug.ljust(30)} #{outcome.detail}"
+      end
+
+      @logger.puts "  → created=#{result.created}  skipped=#{result.skipped}  failed=#{result.failed}"
+      result
+    end
+
+    private
+
+    def label(outcome)
+      case outcome
+      when :created then "ok  "
+      when :skipped then "skip"
+      when :failed  then "FAIL"
+      else outcome.to_s.upcase
+      end
+    end
+
+    def find_or_create_city!
+      City.find_or_create_by!(slug: @city_slug) do |c|
+        c.name   = @city_name
+        c.region = @city_region
+      end
+    end
+
+    # Skip comment lines + blank lines. Tolerate trailing whitespace.
+    def parse_rows
+      lines = File.readlines(@csv_path).reject { |l| l.strip.empty? || l.start_with?("#") }
+      CSV.parse(lines.join, headers: true).map do |csv_row|
+        csv_row.to_h.transform_keys(&:to_sym).transform_values { |v| v.to_s.strip }
+      end
+    end
+
+    def process(row, city)
+      restaurant = find_or_create_restaurant!(row, city)
+
+      if previously_seeded?(restaurant)
+        return Row.new(
+          restaurant_slug: restaurant.slug,
+          outcome:         :skipped,
+          detail:          "already has a non-failed run"
+        )
+      end
+
+      run = create_ingestion_run(restaurant, row.fetch(:menu_source))
+      poll_until_complete(run)
+
+      Row.new(
+        restaurant_slug: restaurant.slug,
+        outcome:         run.failed? ? :failed : :created,
+        detail:          run.failed? ? (run.failure_message.to_s.truncate(120)) : "run=#{run.id} status=#{run.status}"
+      )
+    rescue StandardError => e
+      Row.new(
+        restaurant_slug: row[:slug] || row[:name],
+        outcome:         :failed,
+        detail:          "#{e.class}: #{e.message.to_s.truncate(120)}"
+      )
+    end
+
+    def find_or_create_restaurant!(row, city)
+      Restaurant.find_or_create_by!(city: city, slug: row.fetch(:slug)) do |r|
+        r.name    = row.fetch(:name)
+        r.phone   = row[:phone].presence
+        r.website = row[:website].presence
+        r.about   = row[:neighborhood].presence ? "Neighborhood: #{row[:neighborhood]}" : nil
+        # Restaurants stay :draft until the swipe-verify threshold flips
+        # them. The Phase 2.5 publish path takes over from there.
+        r.status = "draft"
+      end
+    end
+
+    def previously_seeded?(restaurant)
+      # Restaurant has no has_many :ingestion_runs association; query
+      # directly so we don't add one for this single check.
+      IngestionRun.where(restaurant_id: restaurant.id, status: %w[staged published]).exists?
+    end
+
+    def create_ingestion_run(restaurant, menu_source)
+      run = IngestionRun.create!(
+        user:       @operator_user,
+        restaurant: restaurant,
+        input_kind: input_kind_for(menu_source),
+        source_url: menu_source.start_with?("http") ? menu_source : nil
+      )
+      attach_input!(run, menu_source)
+      run.transition_to!(:extracting)
+      run
+    end
+
+    def input_kind_for(menu_source)
+      return "pdf" if menu_source.downcase.end_with?(".pdf")
+      return "url" if menu_source.start_with?("http")
+      "photo"
+    end
+
+    # URL → fetch via UrlFetcher (handles redirects + 10MB cap).
+    # Local path → open the file directly. Anything else → raise.
+    def attach_input!(run, menu_source)
+      if menu_source.start_with?("http")
+        result = @url_fetcher.fetch(menu_source)
+        run.inputs.attach(io: result.io, filename: result.filename, content_type: result.content_type)
+      elsif File.exist?(menu_source)
+        run.inputs.attach(
+          io:           File.open(menu_source, "rb"),
+          filename:     File.basename(menu_source),
+          content_type: content_type_for(menu_source)
+        )
+      else
+        raise UrlFetcher::FetchError.new("invalid_menu_source: #{menu_source}")
+      end
+    end
+
+    def content_type_for(path)
+      case File.extname(path).downcase
+      when ".pdf"  then "application/pdf"
+      when ".png"  then "image/png"
+      when ".jpg", ".jpeg" then "image/jpeg"
+      when ".webp" then "image/webp"
+      else "application/octet-stream"
+      end
+    end
+
+    def poll_until_complete(run)
+      return run if @wait_seconds <= 0
+      deadline = Time.current + @wait_seconds
+      loop do
+        run.reload
+        return run if run.staged? || run.published? || run.failed?
+        break if Time.current >= deadline
+        sleep(POLL_INTERVAL_SEC)
+      end
+      run
+    end
+  end
+end

--- a/apps/api/lib/tasks/seed.rake
+++ b/apps/api/lib/tasks/seed.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Phase 5.7 — Durango batch ingest task.
+#
+# Wraps Biteworthy::DurangoSeed with a Rake adapter. CSV path is
+# required; everything else has sensible defaults.
+#
+# Usage:
+#   bin/rails biteworthy:seed:durango FILE=docs/seeds/durango.csv
+#   bin/rails biteworthy:seed:durango FILE=... WAIT=0   # skip polling
+#   bin/rails biteworthy:seed:durango FILE=... CITY=durango CITY_REGION=CO
+#   bin/rails biteworthy:seed:durango FILE=... EXIT_CODE=1  # CI mode
+namespace :biteworthy do
+  namespace :seed do
+    desc "Batch ingest Durango restaurants from a CSV"
+    task :durango => :environment do
+      file = ENV["FILE"].presence || abort("FILE=<path/to/durango.csv> is required")
+      abort("FILE not found: #{file}") unless File.exist?(file)
+
+      runner = Biteworthy::DurangoSeed.new(
+        csv_path:     file,
+        city_slug:    ENV.fetch("CITY", "durango"),
+        city_name:    ENV.fetch("CITY_NAME", "Durango"),
+        city_region:  ENV.fetch("CITY_REGION", "CO"),
+        wait_seconds: (ENV["WAIT"].presence || "600").to_i,
+        logger:       $stdout
+      )
+      result = runner.run
+
+      exit(1) if ENV["EXIT_CODE"] == "1" && result.failed.positive?
+    end
+  end
+end

--- a/apps/api/spec/lib/durango_seed_spec.rb
+++ b/apps/api/spec/lib/durango_seed_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+require "stringio"
+require "tempfile"
+
+# Phase 5.7 — guards the Durango batch ingest runner. We don't move
+# real bytes (no Anthropic, no real HTTP) — the contract-level
+# question is "does the runner correctly find/create rows + start
+# IngestionRuns + isolate per-row failures?" and that's answered by
+# stubbing UrlFetcher.
+RSpec.describe Biteworthy::DurangoSeed do
+  let(:logger) { StringIO.new }
+
+  # Stand-in for UrlFetcher — call counts + per-URL plan so the spec
+  # can simulate "URL X fetches OK, URL Y times out."
+  class FakeFetcher
+    Result = Struct.new(:io, :content_type, :filename, :byte_size, keyword_init: true)
+
+    def initialize(plan)
+      @plan = plan
+    end
+
+    def fetch(url)
+      action = @plan.fetch(url) { raise "no plan for #{url}" }
+      raise action if action.is_a?(StandardError)
+      action
+    end
+  end
+
+  def fake_blob_result(filename: "menu.html", content_type: "text/html")
+    FakeFetcher::Result.new(
+      io:           StringIO.new("<html>fake menu</html>"),
+      content_type: content_type,
+      filename:     filename,
+      byte_size:    24
+    )
+  end
+
+  def write_csv(rows)
+    tempfile = Tempfile.new(["durango", ".csv"])
+    tempfile.write("name,slug,address,phone,website,menu_source,neighborhood\n")
+    tempfile.write("# Comments are allowed inline.\n")
+    rows.each { |r| tempfile.write(r + "\n") }
+    tempfile.close
+    tempfile.path
+  end
+
+  describe "#run" do
+    it "find-or-creates the city + restaurants and kicks off ingestion runs" do
+      csv = write_csv([
+        "Tacos,tacos,1 Main,(970) 555,https://tacos.example,https://tacos.example/menu,Downtown",
+        "Cream,cream,2 Main,(970) 666,https://cream.example,https://cream.example/menu,Downtown"
+      ])
+      fetcher = FakeFetcher.new(
+        "https://tacos.example/menu" => fake_blob_result,
+        "https://cream.example/menu" => fake_blob_result
+      )
+
+      result = described_class.new(
+        csv_path:     csv,
+        wait_seconds: 0,
+        url_fetcher:  fetcher,
+        logger:       logger
+      ).run
+
+      expect(City.where(slug: "durango").count).to eq(1)
+      expect(Restaurant.where(slug: %w[tacos cream]).count).to eq(2)
+      expect(IngestionRun.count).to eq(2)
+      expect(IngestionRun.pluck(:status).uniq).to eq(%w[extracting])
+      expect(result.created).to eq(2)
+      expect(result.failed).to eq(0)
+      expect(logger.string).to include("[ok  ]")
+    end
+
+    it "is idempotent — re-running skips restaurants that already have a non-failed run" do
+      csv = write_csv([
+        "Tacos,tacos,1 Main,,,https://tacos.example/menu,Downtown"
+      ])
+      fetcher = FakeFetcher.new("https://tacos.example/menu" => fake_blob_result)
+
+      first = described_class.new(csv_path: csv, wait_seconds: 0, url_fetcher: fetcher, logger: StringIO.new).run
+      expect(first.created).to eq(1)
+
+      # Mark the run as :staged so the idempotence guard kicks in.
+      IngestionRun.first.update!(status: "staged")
+
+      second = described_class.new(csv_path: csv, wait_seconds: 0, url_fetcher: fetcher, logger: logger).run
+      expect(second.skipped).to eq(1)
+      expect(second.created).to eq(0)
+      expect(logger.string).to include("[skip]")
+      expect(IngestionRun.count).to eq(1) # no new run
+    end
+
+    it "isolates per-row failures so one bad URL doesn't kill the rest" do
+      csv = write_csv([
+        "Good,good,1 Main,,,https://good.example/menu,Downtown",
+        "Bad,bad,2 Main,,,https://broken.example/menu,Downtown",
+        "Also Good,also-good,3 Main,,,https://also.example/menu,Downtown"
+      ])
+      fetcher = FakeFetcher.new(
+        "https://good.example/menu"   => fake_blob_result,
+        "https://broken.example/menu" => UrlFetcher::FetchError.new("dns_failed", status: 0),
+        "https://also.example/menu"   => fake_blob_result
+      )
+
+      result = described_class.new(
+        csv_path:     csv,
+        wait_seconds: 0,
+        url_fetcher:  fetcher,
+        logger:       logger
+      ).run
+
+      expect(result.created).to eq(2)
+      expect(result.failed).to eq(1)
+      bad_row = result.rows.find { |r| r.outcome == :failed }
+      expect(bad_row.restaurant_slug).to eq("bad")
+      expect(bad_row.detail).to include("dns_failed")
+      expect(logger.string).to include("[FAIL]")
+    end
+
+    it "tallies created / skipped / failed in the summary line" do
+      csv = write_csv([
+        "Tacos,tacos,1 Main,,,https://tacos.example/menu,Downtown"
+      ])
+      fetcher = FakeFetcher.new("https://tacos.example/menu" => fake_blob_result)
+
+      described_class.new(csv_path: csv, wait_seconds: 0, url_fetcher: fetcher, logger: logger).run
+
+      expect(logger.string).to match(/created=1\s+skipped=0\s+failed=0/)
+    end
+
+    it "writes restaurants as :draft so the Phase 2.5 swipe-verify queue still gates publication" do
+      csv = write_csv([
+        "Tacos,tacos,1 Main,,,https://tacos.example/menu,Downtown"
+      ])
+      fetcher = FakeFetcher.new("https://tacos.example/menu" => fake_blob_result)
+
+      described_class.new(csv_path: csv, wait_seconds: 0, url_fetcher: fetcher, logger: StringIO.new).run
+
+      expect(Restaurant.find_by(slug: "tacos").status).to eq("draft")
+    end
+
+    it "skips comment lines (starting with #) + blank lines in the CSV" do
+      csv_path = Tempfile.new(["durango", ".csv"]).tap do |f|
+        f.write("name,slug,address,phone,website,menu_source,neighborhood\n")
+        f.write("# Comment line, ignored\n")
+        f.write("\n") # blank line, ignored
+        f.write("Tacos,tacos,1 Main,,,https://tacos.example/menu,Downtown\n")
+        f.close
+      end.path
+      fetcher = FakeFetcher.new("https://tacos.example/menu" => fake_blob_result)
+
+      result = described_class.new(csv_path: csv_path, wait_seconds: 0, url_fetcher: fetcher, logger: StringIO.new).run
+
+      expect(result.total).to eq(1)
+      expect(result.created).to eq(1)
+    end
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,12 +13,11 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.6 — SEO city/diet pages (`/durango/[diet]`)** (`docs/plans/phase-5.md#56--seo-landing-pages-durangodiet`) — this PR.
-2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7 mass-ingests Durango menus.
-3. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`).
-4. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
-5. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
-6. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
+1. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`) — this PR. Loop ships the batch tooling; populating the CSV + actually running the seed is a human task.
+2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before the seed task from this PR mass-ingests real Durango menus.
+3. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+4. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+5. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
 
@@ -72,6 +71,7 @@ the merge / review / status rules.
 - ✅ Phase 5.3 — production blob storage on Cloudflare R2 + backfill task (#174)
 - ✅ Phase 5.4 — production web deploy wiring: vercel.json + sitemap + cookie domain (#175) — **Phase 5 production infrastructure structurally complete (5.1 API + 5.2 SMTP + 5.3 R2 + 5.4 web)**
 - ✅ Phase 5.5 — marketing landing page at / (#176)
+- ✅ Phase 5.6 — SEO city/diet pages at /durango/[diet] (#177)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/seeds/durango.csv.example
+++ b/docs/seeds/durango.csv.example
@@ -1,0 +1,18 @@
+name,slug,address,phone,website,menu_source,neighborhood
+# Phase 5.7 — Durango seed CSV template.
+#
+# Each row creates (or finds) a Restaurant in the durango City and
+# kicks off an IngestionRun via `bin/rails biteworthy:seed:durango
+# FILE=docs/seeds/durango.csv`. The runner picks `url` vs `pdf`
+# entrypoint based on whether `menu_source` ends in .pdf.
+#
+# Slug rules: kebab-case, ASCII only, deduped if blank (uses the
+# parameterized name).
+#
+# Lines starting with `#` are ignored — keep notes inline.
+#
+# DO NOT commit the populated `durango.csv` — that's the launch
+# operator's research output. Only this template lives in git.
+Ninis Taqueria,ninis-taqueria,901 Main Ave,(970) 555-0101,https://ninisdurango.com,https://ninisdurango.com/menu.pdf,East 9th Street
+Cream Bean Berry,cream-bean-berry,1021 Main Ave,(970) 555-0102,https://creambeanberry.com,https://creambeanberry.com/menu,East 11th Street
+Olde Tymer's Cafe,olde-tymers-cafe,1000 Main Ave,(970) 555-0103,https://oldetymerscafe.com,https://oldetymerscafe.com/lunch.pdf,Historic Downtown

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,47 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 20:46 — tick #84. PR #177 (Phase 5.6 SEO city/diet pages)
+merged at 20:19 UTC. Anthropic still capped (~3.2h to reset);
+cassette PR stays BLOCKED. **Title-lint failed** on #177
+("SEO" caps tripped `subjectPattern: ^(?![A-Z])(?!.*\.$).+$`) —
+auto-merge config doesn't gate on title-lint so the merge happened
+anyway; future titles avoid all-caps acronyms. Picked the next
+unblocked Next-up item: **Phase 5.7 — seed 30 Durango
+restaurants**. Operator-driven batch ingest tooling (the loop
+ships the runner; populating the CSV + actually running the
+seed is human work). Shipped:
+- `docs/seeds/durango.csv.example` — column template
+  (name/slug/address/phone/website/menu_source/neighborhood) with
+  inline guidance + 3 example rows. The populated `durango.csv`
+  stays out of git per inline note.
+- `Biteworthy::DurangoSeed` runner. Idempotent — already-staged
+  rows skip, per-row failures (UrlFetcher errors, missing files)
+  caught + logged + tallied so one bad URL doesn't kill the
+  batch. Uses Phase 2.8's UrlFetcher for HTTP sources, falls
+  back to direct File.open for local paths. Restaurants stay
+  :draft so Phase 2.5's 80%-accepted swipe-verify threshold
+  still gates publication.
+- `bin/rails biteworthy:seed:durango FILE=…` rake adapter with
+  ENV overrides (CITY, CITY_NAME, CITY_REGION, WAIT, EXIT_CODE).
+6 new specs covering happy path (2 rows → 2 runs created),
+idempotent re-run (skips :staged), per-row failure isolation
+(UrlFetcher::FetchError → :failed outcome, batch continues),
+tally summary, draft-status guard, and CSV comment/blank-line
+parsing. Total rspec 365/0/1 (+6); pnpm typecheck + lint
+full-turbo green. Caught one bug during spec authoring:
+Restaurant has no `has_many :ingestion_runs` association — fixed
+by querying `IngestionRun.where(restaurant_id: …)` directly
+rather than adding an association for a single check. Roadmap:
+ticked 5.6 (#177); reordered Next-up. Eager-rebase applied.
+**Avo dashboard tile** (subplan called for one) deferred — rake
+stdout is sufficient for the seed run; an Avo widget is a
+better stand-alone PR once the seed has run + we know what
+counts matter. Next tick: 5.8 (PostHog instrumentation) — OR if
+the Anthropic cap clears at 00:00 UTC (~3.2h from now), retry
+the cassette PR (also unblocks the operator's actual Durango
+seed run, since 30 menus need real Anthropic capacity).
+
 2026-04-30 20:18 — tick #83. PR #176 (Phase 5.5 marketing landing)
 merged at 19:46 UTC, all CI green. Anthropic still capped (~3.7h
 to reset); cassette PR stays BLOCKED. Picked the next unblocked


### PR DESCRIPTION
## Why

Phase 5.7 from `docs/plans/phase-5.md` — operator-driven seed of 30 Durango restaurants. The loop ships the runner + CSV template; populating the CSV with real research + actually running the batch is a human task. The runner reuses Phase 2.8's URL/PDF entrypoint + Phase 2.5's swipe-verify gate.

## What

- **`docs/seeds/durango.csv.example`** — column template with inline comment guidance: `name, slug, address, phone, website, menu_source, neighborhood`. Three example rows. The populated `durango.csv` stays out of git per inline note (operator's research output, not source).
- **`apps/api/app/services/biteworthy/durango_seed.rb`** — runner class.
  - **Idempotent**: a row whose Restaurant already has a non-failed IngestionRun (`:staged` or `:published`) is skipped. Re-running the seed is safe.
  - **Per-row failure isolation**: bad URLs / missing files / fetch errors are caught + logged + tallied so one broken row doesn't kill the batch.
  - Uses Phase 2.8's `UrlFetcher` for HTTP sources (10 MB cap, 3 redirects, 15s timeout). Falls back to direct `File.open` for local PDF paths.
  - Restaurants are created `:draft` — the Phase 2.5 swipe-verify 80%-accepted threshold still gates publication. The seed task lands staged runs; humans flip the bit.
  - Polls each run until `:staged` / `:published` / `:failed` (or per-run timeout, default 10 min). `wait_seconds: 0` skips polling for spec runs.
- **`apps/api/lib/tasks/seed.rake`** — Rake adapter. `bin/rails biteworthy:seed:durango FILE=docs/seeds/durango.csv` is canonical; ENV overrides for `CITY`, `CITY_NAME`, `CITY_REGION`, `WAIT`, `EXIT_CODE`.

## Tests

6 new specs in `spec/lib/durango_seed_spec.rb`:

- Happy path: 2 rows → city + 2 restaurants + 2 IngestionRuns created.
- Idempotent re-run: marking a run `:staged` and re-running skips that row.
- Per-row failure isolation: 1 bad URL among 3 rows → tally is `created=2 failed=1`; batch continues.
- Tally summary line: `created=N skipped=N failed=N`.
- Draft-status guard: created Restaurants are `:draft` so Phase 2.5 publication still applies.
- CSV parsing: `#` comment lines + blank lines skipped.

`bundle exec rspec`: **365/0/1 pending** (+6). `pnpm typecheck` + `pnpm lint`: full-turbo cached green (no JS changes).

**Spec authoring caught a real bug**: `Restaurant` has no `has_many :ingestion_runs` association. Fixed by querying `IngestionRun.where(restaurant_id: ...)` directly rather than adding an association for a single check.

## What still needs a human (Phase 5.7 acceptance criterion)

```
1. Research + populate `docs/seeds/durango.csv` with 30 real Durango
   restaurants (menu URLs or downloaded PDFs).
2. Confirm Anthropic billing tier covers ~$15 burn (30 menus at the
   Phase 2.9 dashboard's measured rates).
3. From a `fly ssh console` post-Phase-5.1 deploy:
   bin/rails biteworthy:seed:durango FILE=durango.csv
4. Use Phase 2.5's swipe-verify queue (or Avo) to accept items per
   restaurant; the 80%-threshold flips each run + restaurant to
   :published.
```

## Notes

- **Avo dashboard tile** (subplan called for one — "Durango seed run" with running totals) is **deferred**. The rake task's stdout output is sufficient for the seed run, and a stand-alone Avo widget is better as its own PR once the seed has actually run and we know which counts matter most. If the operator hits visibility issues, log it as a Discovered followup.
- The Anthropic cap (still active until 2026-05-01 00:00 UTC, ~3.2h from now) is the gating dependency for actually running the seed. After cap clears, the live cassette PR + this seed PR can both proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)