### PR TITLE
feat(packages,web,mobile): analytics abstraction + event taxonomy (phase 5.8 structural)

### DIFF
--- a/apps/mobile/__tests__/lib/track.test.ts
+++ b/apps/mobile/__tests__/lib/track.test.ts
@@ -1,0 +1,44 @@
+import { noopTracker, type AnalyticsClient } from '@biteworthy/analytics';
+import { buildMobileTracker } from '../../lib/track';
+
+const fakeClient = (): AnalyticsClient & { calls: Array<[string, unknown]> } => {
+  const calls: Array<[string, unknown]> = [];
+  return {
+    calls,
+    capture: (name, props) => {
+      calls.push([name, props]);
+    },
+  };
+};
+
+describe('buildMobileTracker', () => {
+  it('returns noopTracker when no apiKey is set', () => {
+    expect(buildMobileTracker({ apiKey: null })).toBe(noopTracker);
+  });
+
+  it('returns noopTracker when the user has not explicitly opted in (App Store privacy posture)', () => {
+    expect(buildMobileTracker({ apiKey: 'k', optedIn: false })).toBe(noopTracker);
+  });
+
+  it('still returns noopTracker when key + opt-in but no client is injected (Phase 5.8 ships abstraction-only)', () => {
+    expect(buildMobileTracker({ apiKey: 'k', optedIn: true })).toBe(noopTracker);
+  });
+
+  it('returns a real tracker when apiKey + opt-in + client are all set', () => {
+    const client = fakeClient();
+    const tracker = buildMobileTracker({
+      apiKey: 'k',
+      optedIn: true,
+      client,
+    });
+
+    tracker.track('menu_filtered', {
+      restaurant_slug: 'cream-bean-berry',
+      visible_count: 12,
+      hidden_count: 2,
+      filter_source: 'preset',
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]![0]).toBe('menu_filtered');
+  });
+});

--- a/apps/mobile/lib/track.ts
+++ b/apps/mobile/lib/track.ts
@@ -1,0 +1,53 @@
+/**
+ * Phase 5.8 — mobile tracker wiring.
+ *
+ * Returns a `Tracker` from `@biteworthy/analytics`. The returned
+ * tracker is `noopTracker` when:
+ *
+ *   * `EXPO_PUBLIC_POSTHOG_KEY` is unset
+ *   * The user has opted out via the in-app analytics toggle
+ *
+ * RN doesn't have a Do-Not-Track analog the way browsers do, so the
+ * opt-in is explicit (default off until the user accepts in
+ * `/settings/analytics`).
+ *
+ * Phase 5.8 ships the wrapper without `posthog-react-native` as a
+ * hard dep — the follow-up wiring PR adds the package + replaces
+ * `null` below with a real client. Same ship-the-abstraction
+ * pattern as the web wrapper.
+ */
+
+import {
+  createTracker,
+  noopTracker,
+  type AnalyticsClient,
+  type Tracker,
+} from '@biteworthy/analytics';
+
+interface BuildOptions {
+  /** Test override; defaults to `process.env.EXPO_PUBLIC_POSTHOG_KEY`. */
+  apiKey?: string | null;
+  /** Test override for the analytics-opt-in flag. */
+  optedIn?: boolean;
+  /**
+   * Test override / Phase-5.8-wiring hook: inject a constructed
+   * AnalyticsClient (e.g. the posthog-react-native instance).
+   */
+  client?: AnalyticsClient | null;
+}
+
+export function buildMobileTracker(opts: BuildOptions = {}): Tracker {
+  const apiKey = opts.apiKey !== undefined ? opts.apiKey : process.env.EXPO_PUBLIC_POSTHOG_KEY;
+  if (!apiKey) return noopTracker;
+
+  // Mobile defaults to opted-out for App Store privacy posture; the
+  // user explicitly opts IN via /settings/analytics.
+  const optedIn = opts.optedIn === true;
+  if (!optedIn) return noopTracker;
+
+  if (!opts.client) {
+    // Same Phase 5.8 ship-abstraction-first guard as web.
+    return noopTracker;
+  }
+  return createTracker({ client: opts.client });
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,6 +15,7 @@
     "clean": "rm -rf .expo .turbo dist *.tsbuildinfo"
   },
   "dependencies": {
+    "@biteworthy/analytics": "workspace:*",
     "@biteworthy/api-types": "workspace:*",
     "@biteworthy/filter-engine": "workspace:*",
     "@biteworthy/ui-tokens": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -rf .next .turbo *.tsbuildinfo"
   },
   "dependencies": {
+    "@biteworthy/analytics": "workspace:*",
     "@biteworthy/api-types": "workspace:*",
     "@biteworthy/filter-engine": "workspace:*",
     "@biteworthy/ui-tokens": "workspace:*",

--- a/apps/web/src/lib/__tests__/track.test.ts
+++ b/apps/web/src/lib/__tests__/track.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { noopTracker, type AnalyticsClient } from '@biteworthy/analytics';
+import { buildWebTracker } from '../track';
+
+const fakeClient = (): AnalyticsClient & { calls: Array<[string, unknown]> } => {
+  const calls: Array<[string, unknown]> = [];
+  return {
+    calls,
+    capture: (name, props) => {
+      calls.push([name, props]);
+    },
+  };
+};
+
+describe('buildWebTracker', () => {
+  it('returns noopTracker when no apiKey is set (dev/CI)', () => {
+    expect(buildWebTracker({ apiKey: null })).toBe(noopTracker);
+  });
+
+  it('returns noopTracker when Do-Not-Track is on', () => {
+    expect(buildWebTracker({ apiKey: 'k', doNotTrack: true })).toBe(noopTracker);
+  });
+
+  it('returns noopTracker when the user opted out via localStorage', () => {
+    expect(
+      buildWebTracker({ apiKey: 'k', doNotTrack: false, optedOut: true }),
+    ).toBe(noopTracker);
+  });
+
+  it('still returns noopTracker when apiKey is set but no client is injected (Phase 5.8 ships abstraction-only)', () => {
+    expect(
+      buildWebTracker({ apiKey: 'k', doNotTrack: false, optedOut: false }),
+    ).toBe(noopTracker);
+  });
+
+  it('returns a real tracker when apiKey set + DNT off + opt-in + client injected', () => {
+    const client = fakeClient();
+    const tracker = buildWebTracker({
+      apiKey: 'k',
+      doNotTrack: false,
+      optedOut: false,
+      client,
+    });
+
+    tracker.track('app_open', { surface: 'web' });
+    expect(client.calls).toEqual([['app_open', { surface: 'web' }]]);
+  });
+});

--- a/apps/web/src/lib/track.ts
+++ b/apps/web/src/lib/track.ts
@@ -1,0 +1,82 @@
+/**
+ * Phase 5.8 — web tracker wiring.
+ *
+ * Returns a `Tracker` from `@biteworthy/analytics`. The returned
+ * tracker is `noopTracker` when:
+ *
+ *   * `NEXT_PUBLIC_POSTHOG_KEY` is unset (dev / CI / no-credentials)
+ *   * The browser sends `Do-Not-Track: 1`
+ *   * The user has opted out via the in-app analytics toggle
+ *     (`localStorage.bw_analytics_opt_out === '1'`)
+ *
+ * Otherwise it constructs a tracker around an injected
+ * `AnalyticsClient`. **Phase 5.8 ships the wrapper without
+ * `posthog-js` as a hard dep** — the follow-up wiring PR adds the
+ * package + replaces `null` below with the real client. Keeping
+ * this file noop-by-default means we can ship + review the
+ * abstraction without committing to a posthog-js install yet.
+ */
+
+import {
+  createTracker,
+  noopTracker,
+  type AnalyticsClient,
+  type Tracker,
+} from '@biteworthy/analytics';
+
+const OPT_OUT_KEY = 'bw_analytics_opt_out';
+
+interface BuildOptions {
+  /** Test override; defaults to `process.env.NEXT_PUBLIC_POSTHOG_KEY`. */
+  apiKey?: string | null;
+  /** Test override for `navigator.doNotTrack`. */
+  doNotTrack?: boolean;
+  /** Test override for the localStorage opt-out flag. */
+  optedOut?: boolean;
+  /**
+   * Test override / Phase-5.8-wiring hook: inject a constructed
+   * AnalyticsClient (e.g. a configured posthog-js instance). When
+   * absent + `apiKey` is set, the tracker still no-ops because we
+   * haven't installed the SDK yet — Phase 5.8-wiring follow-up
+   * fills this in.
+   */
+  client?: AnalyticsClient | null;
+}
+
+export function buildWebTracker(opts: BuildOptions = {}): Tracker {
+  const apiKey = opts.apiKey !== undefined ? opts.apiKey : process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!apiKey) return noopTracker;
+
+  const dnt = opts.doNotTrack !== undefined ? opts.doNotTrack : detectDoNotTrack();
+  if (dnt) return noopTracker;
+
+  const optedOut = opts.optedOut !== undefined ? opts.optedOut : detectOptOut();
+  if (optedOut) return noopTracker;
+
+  if (!opts.client) {
+    // Phase 5.8 ships without posthog-js installed. The presence of
+    // an apiKey alone isn't enough — a follow-up PR injects the
+    // real client here.
+    return noopTracker;
+  }
+  return createTracker({ client: opts.client });
+}
+
+function detectDoNotTrack(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const dnt =
+    (navigator as { doNotTrack?: string }).doNotTrack ??
+    (window as unknown as { doNotTrack?: string }).doNotTrack;
+  return dnt === '1' || dnt === 'yes';
+}
+
+function detectOptOut(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    return localStorage.getItem(OPT_OUT_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export { OPT_OUT_KEY };

--- a/docs/adr/0006-analytics.md
+++ b/docs/adr/0006-analytics.md
@@ -1,0 +1,103 @@
+# ADR 0006: analytics provider (PostHog)
+
+- **Date:** 2026-04-30
+- **Status:** Accepted
+- **Refines:** ADR 0001 (the stack pick named `Sentry` for errors but didn't pick a product analytics provider)
+
+## Context
+
+Phase 5.8 needs to measure the launch funnel:
+
+```
+app_open → profile_set → menu_filtered → restaurant_tap
+```
+
+Plus engagement (`review_posted`, `share_link_copied`, `restaurant_claimed`, `suggestion_submitted`, `filter_changed`).
+
+The pick has to clear three bars:
+
+1. **Cost at launch volume.** Durango-beta projects ~10k events/month for the first quarter. Free tier or sub-$20/mo target.
+2. **Privacy posture for App Store.** App Privacy screens require honest disclosure of what we collect; tools that automatically harvest device IDs / IP fingerprints fail this without careful config.
+3. **Web + RN parity.** One event taxonomy, two SDKs, same dashboard. Don't want to maintain two product-analytics surfaces.
+
+## Decision
+
+**PostHog Cloud** (https://posthog.com), accessed via the `posthog-js` (web) and `posthog-react-native` (mobile) SDKs in a follow-up wiring PR. This PR (Phase 5.8) ships only the typed abstraction + event taxonomy — same ship-the-wiring-first pattern as Phase 4.11.2 / Phase 5.1 / Phase 5.2 / Phase 5.3.
+
+### Why PostHog over alternatives
+
+| Provider | Why considered | Why not picked |
+|---|---|---|
+| **PostHog Cloud** | Free tier: 1M events/month + 5k recordings. Funnel + retention built-in. Native web + RN SDKs share an API. Privacy-friendly — no auto-fingerprinting. EU + US regions. | — picked. |
+| Plausible | Privacy-first, GDPR-by-default. Tiny snippet. | No funnel-builder UI; would need to query Plausible's data API + roll our own. RN SDK is community-maintained, not first-party. |
+| Mixpanel | Mature funnel UX. | Free tier capped at 20M events, but real cost kicks in fast at $25/mo. Default config is more aggressive on tracking than we want for App Store posture. |
+| Amplitude | Strong analytics. | Lifetime free tier capped lower than PostHog; pricing scales steeply. |
+| Segment + warehouse | Future-proof. | Overkill at launch volume. Adds a vendor + a warehouse + a query tool. Phase 6+ if at all. |
+
+PostHog wins on the 3-bar test. The free tier is generous enough that Durango beta + the first 6 months of organic growth fit easily.
+
+### Why use the SDK + abstraction layer, not the SDK directly
+
+`@biteworthy/analytics` (this PR) defines a `Tracker` interface that web + mobile call into. The SDK is injected at the app boundary. Reasons:
+
+1. **Provider portability.** If PostHog ever bites cost-wise, we swap the adapter at one place — every call site keeps working.
+2. **Compile-time event-name + payload safety.** Misspelled event names become TS errors instead of split funnels in the dashboard. Property keys are checked too.
+3. **Cheap testing.** Vitest + Jest test the abstraction with a fake `AnalyticsClient`; no need to mock posthog-js.
+
+### Why ship abstraction-only first
+
+This PR doesn't install `posthog-js` or `posthog-react-native`. The wrapper returns `noopTracker` even when an API key is set, until a follow-up PR injects a real client. Reasons:
+
+1. **`posthog-js` is ~60KB** at the time of writing (gzipped) and adds a real bundle-size hit on the SSR landing pages. Worth a dedicated review pass.
+2. **Wiring is a 9-call-site change** across web + mobile + api. Lumping it with the abstraction would make a 1500-line PR that's hard to review.
+3. **Phase 5.8 acceptance** ("a real beta tester completes the full funnel") needs the wiring + a real PostHog account. Both are deferred until launch is closer.
+
+The structural-only split mirrors:
+- Phase 4.11.2 (schema + prompt + materialize, cassette deferred)
+- Phase 5.1 (Dockerfile + fly.toml, fly auth login deferred)
+- Phase 5.2 (SMTP config, Postmark account deferred)
+- Phase 5.3 (storage.yml + backfill, Cloudflare R2 bucket deferred)
+- Phase 5.4 (vercel.json + sitemap, Vercel project deferred)
+
+Same playbook every time: loop ships wiring; humans drop credentials.
+
+## What this PR ships
+
+- `packages/analytics/` — new workspace package, zero deps, pure TS:
+  - `Tracker` interface + `AnalyticsClient` (the SDK contract)
+  - `EVENTS` map + `EventPropsMap` (type-safe per-event payload schema)
+  - `noopTracker` (safe default when key/DNT/opt-out fails)
+  - `createTracker({ client })` factory for injecting an SDK
+  - 6 vitest cases
+- `apps/web/src/lib/track.ts` — env + DNT + localStorage-opt-out aware wrapper. 5 vitest cases.
+- `apps/mobile/lib/track.ts` — env + opt-in aware wrapper (App Store privacy posture: opt IN, not OUT). 4 jest cases.
+- `docs/analytics.md` — human-readable taxonomy mirroring the type definitions.
+- This ADR.
+
+## What needs a human (Phase 5.8-wiring follow-up)
+
+1. Sign up for PostHog Cloud, create a "BiteWorthy" project. Pick the US or EU region based on user-data-residency preference (no strong constraint — beta is Durango-only).
+2. Generate a project API key.
+3. `fly secrets set NEXT_PUBLIC_POSTHOG_KEY=$KEY` for web (it's a public key so prefix with NEXT_PUBLIC; PostHog separates ingest from query by host).
+4. Set the same as `EXPO_PUBLIC_POSTHOG_KEY` in EAS / Vercel env (mobile bundle has no Fly).
+5. Open a follow-up PR (`claude/phase-5.8-wiring`):
+   - `pnpm add posthog-js -F @biteworthy/web`
+   - `pnpm add posthog-react-native -F @biteworthy/mobile`
+   - In `apps/web/src/lib/track.ts`, wrap the posthog-js instance into an `AnalyticsClient` adapter and pass it into `buildWebTracker`.
+   - Mirror in mobile.
+   - Instrument the 9 call sites listed in `docs/analytics.md`.
+
+## Trade-offs
+
+**Bundle cost on the SSR pages** — posthog-js is ~60KB gz. Defer it to a client-only entry once it lands; the SSR landing + `/durango/[diet]` pages should never load it server-side.
+
+**Single provider for analytics + recordings** — PostHog also does session replay. We won't enable that at launch (App Store posture; user trust); it's available later if useful.
+
+**Server-side fallback** — Phase 4.8's `RecordRestaurantVisitJob` already records authenticated visits as `restaurant_visits` rows. The wiring follow-up will additionally fire `restaurant_tap` to PostHog's HTTP endpoint server-side so ad-blockers don't break the funnel for authenticated users.
+
+## Consequences
+
+- **Cost** — projected $0/month at launch; ~$20/month if we somehow blow past 1M events.
+- **Privacy** — PostHog supports anonymous-only mode and respects DNT when wired; Phase 5.8-wiring's job is to wire those flags. The taxonomy explicitly excludes PII.
+- **Observability** — once wiring lands, the Phase 2.9 cost dashboard's "production health" tab (Phase 5.7 referenced this) can pull from PostHog's API instead of building bespoke charts.
+- **Vendor lock-in** — mild. The `Tracker` abstraction means we can swap providers in a day; the call sites stay unchanged.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,120 @@
+# Analytics — event taxonomy
+
+The 9 stable funnel events for Phase 5.8. Names + payload schemas are the contract between the call sites (web, mobile, api) and the dashboard. **Renaming any of these breaks downstream funnels** — add new optional fields freely; rename only with a coordinated dashboard update.
+
+The canonical type definitions live in `packages/analytics/src/index.ts` (`EVENTS` map + `EventPropsMap`). When this doc and that file disagree, the type definitions win — they're the compile-time contract.
+
+## Funnel
+
+The conversion path the launch dashboards measure:
+
+```
+app_open  →  profile_set  →  menu_filtered  →  restaurant_tap
+```
+
+Plus engagement events (review_posted, suggestion_submitted, restaurant_claimed, share_link_copied, filter_changed) that don't fit the linear funnel but matter for retention.
+
+## Events
+
+### `app_open`
+First event in every session. Fired by web on page load, by mobile on cold + warm app start.
+
+| Field | Type | Notes |
+|---|---|---|
+| `surface` | `"web" \| "ios" \| "android"` | Set by the app boundary. |
+| `distinct_id` | `string?` | Anonymous id, sticky across sessions until logout. |
+
+### `profile_set`
+Fired when the user finishes the 6-tap onboarding (Phase 3.2 / 3.8) OR updates their profile.
+
+| Field | Type | Notes |
+|---|---|---|
+| `preset_slug` | `string \| null` | One of the curated DietaryProfiles, or null when manual. |
+| `avoid_ingredient_count` | `number` | Final count after onboarding. |
+| `avoid_tag_count` | `number` | Final count after onboarding. |
+| `strictness` | `"relaxed" \| "balanced" \| "strict"` | The Phase 3.5 toggle value. |
+
+### `menu_filtered`
+Fired when the user lands on a filtered restaurant page and the items endpoint returns. Once per page render, not per item.
+
+| Field | Type | Notes |
+|---|---|---|
+| `restaurant_slug` | `string` | |
+| `visible_count` | `number` | Items the filter shows. |
+| `hidden_count` | `number` | Items the filter hides. |
+| `filter_source` | `string` | `"preset"`, `"user_profile"`, `"profile_token"`, or `"none"`. Mirrors the API's `filter.source`. |
+
+### `restaurant_tap`
+Fired when the user opens a restaurant page from a list. Server-side, the Phase 4.8 `RecordRestaurantVisitJob` doubles as this for authenticated users so the funnel works even when JS analytics is blocked.
+
+| Field | Type | Notes |
+|---|---|---|
+| `restaurant_slug` | `string` | |
+| `from` | `string` | Source list: `"home"`, `"search"`, `"durango_diet"`, `"history"`. |
+
+### `filter_changed`
+Fired when the user toggles strictness, switches preset, or manually adds/removes an avoid item.
+
+| Field | Type | Notes |
+|---|---|---|
+| `kind` | `string` | `"strictness" \| "preset" \| "manual_avoid" \| "manual_unavoid"`. |
+| `from` | `string?` | Old value. |
+| `to` | `string?` | New value. |
+
+### `review_posted`
+Fired on successful review submission (Phase 4.3 + 4.4 + 4.5).
+
+| Field | Type | Notes |
+|---|---|---|
+| `item_slug` | `string` | Item identifier. |
+| `restaurant_slug` | `string` | |
+| `rating` | `number` | 1–5. |
+| `has_photo` | `boolean` | |
+
+### `share_link_copied`
+Fired when the user shares a filtered URL (Phase 3.9 web + mobile).
+
+| Field | Type | Notes |
+|---|---|---|
+| `restaurant_slug` | `string` | |
+| `via` | `string` | `"native_share"` (mobile sheet), `"clipboard"` (web copy), `"prompt_fallback"` (web with blocked clipboard). |
+
+### `restaurant_claimed`
+Fired when a claim succeeds (Phase 4.9). Two outcomes possible.
+
+| Field | Type | Notes |
+|---|---|---|
+| `restaurant_slug` | `string` | |
+| `decision` | `string` | `"auto_acceptable"` (domain match) or `"admin_review"`. |
+
+### `suggestion_submitted`
+Fired when a Suggestion is submitted (Phase 4.10). The follow-up `decideSuggestion` path doesn't emit a separate event in v1 — admin moderation lives in /admin and isn't part of the public funnel.
+
+| Field | Type | Notes |
+|---|---|---|
+| `item_slug` | `string` | |
+| `restaurant_slug` | `string` | |
+| `kind` | `string` | `"add_ingredient"`, `"rename"`, etc. — see Phase 4.10. |
+
+## Privacy posture
+
+- **Web**: respects `navigator.doNotTrack === '1'`. Local opt-out via `localStorage.bw_analytics_opt_out = '1'` (set by /profile/settings).
+- **Mobile**: opt-IN by default-off. App Store privacy screens get the truth — the app doesn't track until the user explicitly accepts in /settings/analytics.
+- **No PII in props**: never put email, full name, address, or device IDs in the payload. Slugs + counts only. PostHog's standard anonymous-id model handles cross-session continuity.
+
+## What ships in Phase 5.8 vs Phase 5.8-wiring
+
+**Phase 5.8 (this PR)**:
+- `@biteworthy/analytics` package: typed Tracker interface, EVENTS map, noopTracker, createTracker factory
+- `apps/web/src/lib/track.ts` — env + DNT + opt-out aware wrapper that returns a tracker (currently always noop because no client is injected yet)
+- `apps/mobile/lib/track.ts` — env + opt-in aware wrapper (same)
+- This document
+- `docs/adr/0006-analytics.md`
+
+**Phase 5.8-wiring (follow-up)**:
+- `pnpm add posthog-js -F @biteworthy/web` and `posthog-react-native -F @biteworthy/mobile`
+- Construct the `AnalyticsClient` adapters around those SDKs and pass them into `buildWebTracker` / `buildMobileTracker`
+- Instrument all 9 events at their call sites: `app_open` in `app/layout.tsx` + `app/_layout.tsx`; `menu_filtered` in `RestaurantClient.tsx` + `[id].tsx`; etc.
+- Server-side `RecordRestaurantVisitJob` enrichment to also fire `restaurant_tap` to PostHog's server endpoint (so the funnel survives ad-blockers)
+
+The split keeps each PR small + reviewable. The abstraction shipping first means subsequent wiring PRs are call-site-only — no risk of taxonomy drift.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,9 +13,9 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.7 — seed 30 Durango restaurants** (`docs/plans/phase-5.md#57--seed-30-durango-restaurants-via-the-ingestion-pipeline`) — this PR. Loop ships the batch tooling; populating the CSV + actually running the seed is a human task.
-2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before the seed task from this PR mass-ingests real Durango menus.
-3. **Phase 5.8 — PostHog instrumentation** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`).
+1. **Phase 5.8 — analytics instrumentation (structural)** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`) — this PR. Ships the typed `@biteworthy/analytics` abstraction + event taxonomy + ADR; defers the posthog-js install + 9-call-site wiring to a follow-up PR (matches the Phase 4.11.2 structural-vs-cassette split).
+2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7's seed task mass-ingests real Durango menus.
+3. **Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to this PR; needs `posthog-js` + `posthog-react-native` installed and the call-site instrumentation.) Decoupled because each surface PR is small + reviewable on its own.
 4. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
 5. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
@@ -72,6 +72,7 @@ the merge / review / status rules.
 - ✅ Phase 5.4 — production web deploy wiring: vercel.json + sitemap + cookie domain (#175) — **Phase 5 production infrastructure structurally complete (5.1 API + 5.2 SMTP + 5.3 R2 + 5.4 web)**
 - ✅ Phase 5.5 — marketing landing page at / (#176)
 - ✅ Phase 5.6 — SEO city/diet pages at /durango/[diet] (#177)
+- ✅ Phase 5.7 — durango batch ingest task + csv template (#178)
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,48 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 21:19 — tick #85. PR #178 (Phase 5.7 Durango seed task)
+merged at 20:47 UTC, all CI green including title-lint this time.
+Anthropic still capped (~2.7h to reset); cassette PR stays
+BLOCKED. Picked the next unblocked item: **Phase 5.8 — analytics
+instrumentation (structural)**. Discovered Phase 4's
+"placeholder track() events" were never actually wired — the
+cross-cutting note in phase-4.md said they would be but no
+call-sites have track() calls today. So 5.8 is a from-scratch
+build of both abstraction + taxonomy. Shipped:
+- New **`@biteworthy/analytics`** workspace package, zero deps,
+  pure TS. Tracker interface + AnalyticsClient (the SDK contract
+  apps will inject) + EVENTS map (9 stable funnel + engagement
+  event names) + EventPropsMap (per-event payload type-safety
+  → misspellings become tsc errors not split funnels) +
+  noopTracker + createTracker factory. 6 vitest cases.
+- **Web wrapper** at `apps/web/src/lib/track.ts` — env + DNT +
+  `localStorage.bw_analytics_opt_out` aware. Returns noopTracker
+  unless ALL of: `NEXT_PUBLIC_POSTHOG_KEY` set, DNT off, not
+  opted out, AND a real AnalyticsClient injected. Phase 5.8
+  ships always-noop because no client is injected yet — wiring
+  follow-up adds posthog-js + the adapter. 5 vitest cases.
+- **Mobile wrapper** at `apps/mobile/lib/track.ts` — same
+  pattern but opt-IN by default (App Store privacy posture).
+  4 jest cases.
+- `docs/analytics.md` documents the 9 events + payload schemas +
+  privacy posture + the structural-vs-wiring split. Mirrors the
+  TS types so misspellings stay caught.
+- ADR 0006 captures PostHog pick over Plausible / Mixpanel /
+  Amplitude / Segment, why abstraction-first ship pattern,
+  bootstrap path for the wiring follow-up.
+Total: 15 new tests across 3 surfaces (web 87/87 +5; mobile
+60/60 +4; analytics package 6/6). rspec 365/0/1 unchanged
+(no API changes). pnpm typecheck (10 tasks) + lint (6 tasks)
+all green; turbo cache miss only on the new package. Roadmap:
+ticked 5.7 (#178); reordered Next-up so 5.8-structural is #1 and
+a new 5.8-wiring entry is queued at #3 (depends on PostHog
+credentials + posthog-js/RN install — operator task). **Phase 5
+playbook continues**: every Phase-5 PR has split honestly into
+loop-shippable wiring vs human-credential-gated hookup. Next
+tick: 5.9 (mobile app store submission) — OR if Anthropic cap
+clears at 00:00 UTC (~2.7h from now), retry the cassette PR.
+
 2026-04-30 20:46 — tick #84. PR #177 (Phase 5.6 SEO city/diet pages)
 merged at 20:19 UTC. Anthropic still capped (~3.2h to reset);
 cassette PR stays BLOCKED. **Title-lint failed** on #177

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@biteworthy/analytics",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist .turbo *.tsbuildinfo"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/analytics/src/__tests__/index.test.ts
+++ b/packages/analytics/src/__tests__/index.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  EVENTS,
+  createTracker,
+  noopTracker,
+  type AnalyticsClient,
+} from '../index';
+
+describe('EVENTS taxonomy', () => {
+  it('lists every funnel event the docs/analytics.md claims', () => {
+    expect(Object.keys(EVENTS).sort()).toEqual(
+      [
+        'app_open',
+        'profile_set',
+        'menu_filtered',
+        'restaurant_tap',
+        'filter_changed',
+        'review_posted',
+        'share_link_copied',
+        'restaurant_claimed',
+        'suggestion_submitted',
+      ].sort(),
+    );
+  });
+
+  it('values are the same as keys (no aliasing)', () => {
+    for (const [k, v] of Object.entries(EVENTS)) {
+      expect(v).toBe(k);
+    }
+  });
+});
+
+describe('noopTracker', () => {
+  it('never throws — safe to spread through hot paths', () => {
+    expect(() => {
+      noopTracker.track('app_open', { surface: 'web' });
+      noopTracker.track('menu_filtered', {
+        restaurant_slug: 's',
+        visible_count: 3,
+        hidden_count: 1,
+        filter_source: 'preset',
+      });
+      noopTracker.identify('u-1');
+      noopTracker.reset();
+    }).not.toThrow();
+  });
+});
+
+describe('createTracker', () => {
+  function fakeClient(): AnalyticsClient & {
+    captures: Array<[string, Record<string, unknown> | undefined]>;
+    identifies: Array<[string, Record<string, unknown> | undefined]>;
+    resets: number;
+  } {
+    const captures: Array<[string, Record<string, unknown> | undefined]> = [];
+    const identifies: Array<[string, Record<string, unknown> | undefined]> = [];
+    let resets = 0;
+    return {
+      captures,
+      identifies,
+      get resets() {
+        return resets;
+      },
+      capture: (name, props) => {
+        captures.push([name, props]);
+      },
+      identify: (id, props) => {
+        identifies.push([id, props]);
+      },
+      reset: () => {
+        resets += 1;
+      },
+    };
+  }
+
+  it('forwards track() to client.capture() with the canonical event name + props', () => {
+    const client = fakeClient();
+    const tracker = createTracker({ client });
+
+    tracker.track('menu_filtered', {
+      restaurant_slug: 'cream-bean-berry',
+      visible_count: 12,
+      hidden_count: 3,
+      filter_source: 'preset',
+    });
+
+    expect(client.captures).toHaveLength(1);
+    expect(client.captures[0]![0]).toBe('menu_filtered');
+    expect(client.captures[0]![1]).toEqual({
+      restaurant_slug: 'cream-bean-berry',
+      visible_count: 12,
+      hidden_count: 3,
+      filter_source: 'preset',
+    });
+  });
+
+  it('forwards identify() + reset() through the optional client methods', () => {
+    const client = fakeClient();
+    const tracker = createTracker({ client });
+
+    tracker.identify('user-123', { handle: 'skylar' });
+    tracker.reset();
+
+    expect(client.identifies).toEqual([['user-123', { handle: 'skylar' }]]);
+    expect(client.resets).toBe(1);
+  });
+
+  it('tolerates clients that omit identify / reset (only capture is required)', () => {
+    const captureOnly: AnalyticsClient = { capture: vi.fn() };
+    const tracker = createTracker({ client: captureOnly });
+
+    expect(() => {
+      tracker.identify('u');
+      tracker.reset();
+    }).not.toThrow();
+  });
+});

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,0 +1,189 @@
+/**
+ * BiteWorthy analytics — typed Tracker abstraction shared by web +
+ * mobile.
+ *
+ * Phase 5.8 ships the abstraction + the canonical event taxonomy;
+ * the actual posthog-js / posthog-react-native install + the 9
+ * call-site instrumentations are a follow-up PR (see
+ * `docs/analytics.md` + `docs/adr/0006-analytics.md`).
+ *
+ * Design choices that matter:
+ *
+ *   1. **No vendor SDK as a hard dep.** This package speaks only to
+ *      the `AnalyticsClient` interface — apps inject `posthog-js` or
+ *      `posthog-react-native` (or any other SDK; or `null`) at the
+ *      tracker boundary. Lets us swap providers in one place if
+ *      PostHog ever bites cost-wise.
+ *
+ *   2. **Stable event names live in `EVENTS`.** Adding a new event
+ *      means adding it to that map; misspelled call-sites become
+ *      compile errors instead of split funnels in the dashboard.
+ *
+ *   3. **Payload shape per event is type-checked.** `track('menu_filtered',
+ *      { restaurant_slug: ... })` enforces the prop names. The
+ *      `EVENT_PROPS` map below is the single source of truth, mirroring
+ *      `docs/analytics.md`.
+ *
+ *   4. **`noopTracker` is the safe default.** Returned when
+ *      `POSTHOG_KEY` is unset OR Do-Not-Track is on OR the user opted
+ *      out. Calls into it are zero-cost — never undefined-method-throws,
+ *      never sends bytes.
+ */
+
+// ─── Event taxonomy ────────────────────────────────────────────────
+
+/**
+ * Canonical event names. The funnel:
+ *
+ *   app_open → profile_set → menu_filtered → restaurant_tap
+ *
+ * Plus the per-engagement events (review_posted, suggestion_submitted,
+ * restaurant_claimed, share_link_copied, filter_changed).
+ *
+ * Names are snake_case to match PostHog's funnel-builder UI conventions.
+ */
+export const EVENTS = {
+  app_open:             'app_open',
+  profile_set:          'profile_set',
+  menu_filtered:        'menu_filtered',
+  restaurant_tap:       'restaurant_tap',
+  filter_changed:       'filter_changed',
+  review_posted:        'review_posted',
+  share_link_copied:    'share_link_copied',
+  restaurant_claimed:   'restaurant_claimed',
+  suggestion_submitted: 'suggestion_submitted',
+} as const;
+
+export type EventName = keyof typeof EVENTS;
+
+/**
+ * Per-event payload schemas. Keep these stable — the dashboard funnel
+ * + retention queries depend on field names. New optional fields are
+ * fine; renames break dashboards.
+ *
+ * Mirrored in `docs/analytics.md` (the human-readable doc); when one
+ * changes, change the other in the same PR.
+ */
+export interface EventPropsMap {
+  app_open: {
+    /** Web | iOS | Android. Set by the app boundary. */
+    surface: 'web' | 'ios' | 'android';
+    /** Sticky once set — same anonymous id across sessions until logout. */
+    distinct_id?: string;
+  };
+  profile_set: {
+    preset_slug: string | null;
+    avoid_ingredient_count: number;
+    avoid_tag_count: number;
+    strictness: 'relaxed' | 'balanced' | 'strict';
+  };
+  menu_filtered: {
+    restaurant_slug: string;
+    visible_count: number;
+    hidden_count: number;
+    /** preset | user_profile | profile_token | none */
+    filter_source: string;
+  };
+  restaurant_tap: {
+    restaurant_slug: string;
+    /** Where the tap came from: home, search, durango_diet, history. */
+    from: string;
+  };
+  filter_changed: {
+    /** What changed: strictness | preset | manual_avoid | manual_unavoid. */
+    kind: string;
+    /** Old + new values — strings so the funnel UI can groupby. */
+    from?: string;
+    to?: string;
+  };
+  review_posted: {
+    item_slug: string;
+    restaurant_slug: string;
+    rating: number;
+    has_photo: boolean;
+  };
+  share_link_copied: {
+    restaurant_slug: string;
+    /** Whether the user tapped Share or had to copy the URL. */
+    via: 'native_share' | 'clipboard' | 'prompt_fallback';
+  };
+  restaurant_claimed: {
+    restaurant_slug: string;
+    /** auto_acceptable (domain match) or admin_review. */
+    decision: string;
+  };
+  suggestion_submitted: {
+    item_slug: string;
+    restaurant_slug: string;
+    /** add_ingredient | rename | etc. — see Phase 4.10. */
+    kind: string;
+  };
+}
+
+// ─── Client interface (injected; not a hard dep) ───────────────────
+
+/**
+ * Minimum surface BiteWorthy needs from any analytics SDK. PostHog's
+ * web + RN clients both satisfy this naturally; switching providers
+ * means writing an adapter to this shape.
+ */
+export interface AnalyticsClient {
+  capture(eventName: string, props?: Record<string, unknown>): void;
+  identify?(distinctId: string, props?: Record<string, unknown>): void;
+  reset?(): void;
+}
+
+// ─── Tracker — the surface app code calls ──────────────────────────
+
+export interface Tracker {
+  /**
+   * Type-safe per-event capture. Use `EVENTS` keys; the props shape
+   * is enforced by `EventPropsMap`.
+   */
+  track<K extends EventName>(name: K, props: EventPropsMap[K]): void;
+
+  /** Same identity across sessions until reset(). */
+  identify(distinctId: string, props?: Record<string, unknown>): void;
+
+  /** Logout / signout — clears the distinct_id. */
+  reset(): void;
+}
+
+/**
+ * No-op tracker. Used when:
+ *   - POSTHOG_KEY is unset (dev/CI/no-credentials)
+ *   - Do-Not-Track is on (browser)
+ *   - User opted out via in-app analytics toggle
+ *
+ * Zero allocations on call; safe to spread through hot paths.
+ */
+export const noopTracker: Tracker = {
+  track: () => {},
+  identify: () => {},
+  reset: () => {},
+};
+
+interface CreateTrackerOptions {
+  client: AnalyticsClient;
+}
+
+/**
+ * Build a Tracker that delegates to an injected SDK. The app
+ * boundary (apps/web/src/lib/track.ts and apps/mobile/lib/track.ts)
+ * decides whether to construct one or fall back to `noopTracker`.
+ */
+export function createTracker({ client }: CreateTrackerOptions): Tracker {
+  return {
+    track(name, props) {
+      // Cast to the SDK's loose Record signature — the type narrowing
+      // happens at the call site via EventPropsMap.
+      client.capture(name, props as Record<string, unknown>);
+    },
+    identify(distinctId, props) {
+      client.identify?.(distinctId, props);
+    },
+    reset() {
+      client.reset?.();
+    },
+  };
+}

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@biteworthy/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
       '@biteworthy/api-types':
         specifier: workspace:*
         version: link:../../packages/api-types
@@ -109,6 +112,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@biteworthy/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
       '@biteworthy/api-types':
         specifier: workspace:*
         version: link:../../packages/api-types
@@ -161,6 +167,15 @@ importers:
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@25.6.0)(jsdom@20.0.3)(lightningcss@1.27.0)(terser@5.46.2)
+
+  packages/analytics:
+    devDependencies:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3


### PR DESCRIPTION
## Why

Phase 5.8 from `docs/plans/phase-5.md` — analytics funnel instrumentation. Phase 4's cross-cutting note implied `track()` placeholder events would already exist; they don't. So 5.8 is a from-scratch build.

Per the now-familiar Phase 5 split (4.11.2 / 5.1 / 5.2 / 5.3 / 5.4 all followed this pattern): this PR ships the **typed abstraction + canonical event taxonomy + ADR**; the `posthog-js` / `posthog-react-native` install + 9-call-site instrumentation is a follow-up wiring PR (gated on a human PostHog account + key).

## What

### New workspace package: `@biteworthy/analytics`

Zero deps, pure TS. Lives at `packages/analytics/`. Exports:

- **`Tracker`** interface — what web + mobile call into.
- **`AnalyticsClient`** interface — minimum surface SDKs need to satisfy. Apps inject the SDK at the boundary; the package speaks only the abstract interface.
- **`EVENTS`** map — 9 canonical event names: `app_open`, `profile_set`, `menu_filtered`, `restaurant_tap`, `filter_changed`, `review_posted`, `share_link_copied`, `restaurant_claimed`, `suggestion_submitted`.
- **`EventPropsMap`** — per-event payload type schemas. Wrong props or misspelled event names become **tsc errors at the call site** instead of split funnels in the dashboard.
- **`noopTracker`** — safe default for dev / no-key / DNT / opt-out paths. Zero-allocation calls.
- **`createTracker({ client })`** — factory that wraps an injected `AnalyticsClient`.

### Web wrapper (`apps/web/src/lib/track.ts`)

Reads `NEXT_PUBLIC_POSTHOG_KEY`. Returns `noopTracker` when:
- key unset (dev / CI / no credentials)
- `navigator.doNotTrack === '1'`
- `localStorage.bw_analytics_opt_out === '1'`
- no `AnalyticsClient` injected (always true in this PR — Phase 5.8-wiring follow-up adds it)

### Mobile wrapper (`apps/mobile/lib/track.ts`)

Reads `EXPO_PUBLIC_POSTHOG_KEY`. **App Store privacy posture: opt-IN by default-OFF.** User explicitly accepts in `/settings/analytics` (Phase 5.8-wiring also lands that screen).

### Documentation

- **`docs/analytics.md`** — human-readable taxonomy mirroring the type definitions. Documents the funnel, every event's payload, privacy posture, and what's left for the wiring follow-up.
- **`docs/adr/0006-analytics.md`** — captures PostHog pick (vs Plausible / Mixpanel / Amplitude / Segment), why abstraction-first ship, bootstrap path for wiring.

## Tests

15 new tests across 3 surfaces:

- **Analytics package** (6): event taxonomy completeness + non-aliasing; `noopTracker` doesn't throw on any call; `createTracker` forwards `track`/`identify`/`reset` to the client; tolerates clients missing optional methods.
- **Web wrapper** (5): noop on no key; noop on DNT; noop on opt-out; noop when no client injected (this PR's posture); real tracker when all conditions met.
- **Mobile wrapper** (4): noop on no key; noop without explicit opt-in (App Store posture); noop without injected client; real tracker when all conditions met.

`pnpm --filter @biteworthy/analytics test`: **6/6**. `pnpm --filter @biteworthy/web test`: **87/87** (+5). `pnpm --filter @biteworthy/mobile test`: **60/60** (+4). `pnpm typecheck` + `pnpm lint`: 10 + 6 tasks green. `bundle exec rspec`: 365/0/1 pending unchanged.

## What still needs a human (Phase 5.8-wiring follow-up)

```
1. Sign up for PostHog Cloud, create a "BiteWorthy" project,
   generate an API key.
2. Set NEXT_PUBLIC_POSTHOG_KEY (Vercel) +
       EXPO_PUBLIC_POSTHOG_KEY (EAS).
3. Open follow-up PR `claude/phase-5.8-wiring`:
   - pnpm add posthog-js -F @biteworthy/web
   - pnpm add posthog-react-native -F @biteworthy/mobile
   - Wrap each SDK in an AnalyticsClient adapter; inject into
     buildWebTracker / buildMobileTracker.
   - Instrument the 9 events at their call sites per
     docs/analytics.md.
   - Server-side RecordRestaurantVisitJob enrichment so
     restaurant_tap survives ad-blockers for authed users.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)