### PR TITLE
feat(web,mobile): privacy + terms + app store listing templates (phase 5.9 structural)

### DIFF
--- a/apps/mobile/assets/README.md
+++ b/apps/mobile/assets/README.md
@@ -1,0 +1,41 @@
+# BiteWorthy mobile — assets
+
+Binary assets the app bundle ships. Phase 5.9 documents the specs;
+Phase 5.9-wiring follow-up generates the actual PNGs from the
+ui-tokens-derived SVG sources.
+
+## Required for store submission
+
+| File | Size | Notes |
+|---|---|---|
+| `icon.png` | 1024×1024 | App icon. No transparency. Apple expects square corners; the OS rounds them. Background must be a solid color (`colors.bite` = `#E14E2A` is the brand pick — see `packages/ui-tokens`). |
+| `adaptive-icon.png` | 1024×1024 | Android adaptive icon foreground. Center logo within the safe zone (66% of the canvas). Background color set via `app.json`'s `expo.android.adaptiveIcon.backgroundColor` to `colors.bite`. |
+| `splash.png` | 1284×2778 | iOS launch screen + Android splash. Centered logo lockup on `colors.bite`. |
+| `favicon.png` | 48×48 | Web fallback (Expo router web). |
+
+## Generation flow (Phase 5.9-wiring)
+
+1. **Source vector:** `apps/mobile/assets/icon-source.svg`
+   - "BW" monogram or full lockup, depending on size.
+   - Single fill: `var(--bite, #E14E2A)`.
+   - 1024×1024 viewBox so all PNG variants downscale cleanly.
+
+2. **Render pipeline:** an `apps/mobile/scripts/render-assets.mjs` script
+   uses `sharp` to convert the SVG into the four PNG sizes above.
+   Run with `pnpm --filter @biteworthy/mobile run render:assets`.
+
+3. **Commit the rendered PNGs.** They're tiny (under 50KB each).
+   The SVG source is the master; the PNGs are derived but checked in
+   so EAS builds don't need a render step.
+
+## Color reference (from `@biteworthy/ui-tokens`)
+
+```
+bite:        #E14E2A   (primary brand red)
+biteDark:    #A8351A   (hover / pressed state)
+biteLight:   #FFE9E1   (background / chip fill)
+bg:          #FFFFFF   (white surface)
+text:        #1A1A1A   (near-black)
+```
+
+The icon should use `bite` as the hero color. Don't introduce new colors here; ui-tokens is the single source of truth (Phase 0 ADR 0001).

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json.schemastore.org/eas.json",
+  "cli": {
+    "version": ">= 11.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal",
+      "channel": "preview",
+      "ios": { "simulator": true },
+      "android": { "buildType": "apk" }
+    },
+    "production": {
+      "channel": "production",
+      "autoIncrement": true,
+      "ios": { "buildConfiguration": "Release" },
+      "android": { "buildType": "app-bundle" }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "REPLACE_WITH_APPLE_ID@bite-worthy.com",
+        "ascAppId": "REPLACE_WITH_ASC_APP_ID",
+        "appleTeamId": "REPLACE_WITH_TEAM_ID"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./play-service-account.json",
+        "track": "internal",
+        "releaseStatus": "draft"
+      }
+    }
+  }
+}

--- a/apps/mobile/store-listing/README.md
+++ b/apps/mobile/store-listing/README.md
@@ -1,0 +1,19 @@
+# BiteWorthy mobile — store listing
+
+The metadata Apple and Google show on the App Store and Play Store. Phase 5.9 ships these as drafts; the wiring follow-up tightens copy + uploads them.
+
+## Files
+
+- `app-store.md` — App Store Connect metadata (iOS).
+- `play-store.md` — Google Play Console metadata (Android).
+- `screenshots-plan.md` — what each marketing screenshot needs to show, plus the expo-router test routes that drive them.
+
+## Update flow
+
+1. Edit the markdown here.
+2. Re-run `eas submit --platform=all` after the next build (Phase 5.9-wiring follow-up automates this on tag).
+3. The Phase 5.10 press kit references the same copy verbatim — keep them in sync.
+
+## Source of truth
+
+The hero copy on `apps/web/src/app/page.tsx` (Phase 5.5) is canonical for the **value prop sentence** ("Scan any menu, see only what you can eat."). When that changes, propagate here + on the website's OG card.

--- a/apps/mobile/store-listing/app-store.md
+++ b/apps/mobile/store-listing/app-store.md
@@ -1,0 +1,81 @@
+# App Store metadata (iOS)
+
+App Store Connect → My Apps → BiteWorthy → App Store tab.
+
+## App name (30 char limit)
+
+> BiteWorthy
+
+## Subtitle (30 char limit)
+
+> Scan menus, dine without worry
+
+## Promotional text (170 char limit, can be updated without app review)
+
+> Free during the Durango beta. Now with restaurant photos for items that have them.
+
+## Description (4000 char limit)
+
+```
+BiteWorthy is a pocket food filter for celiac, allergies, vegan, and every other dietary need. Snap a photo of a menu — or paste a link — and BiteWorthy hides the dishes that aren't safe for you. With *why*, every time.
+
+How it works:
+1. Pick a filter — Celiac, Tree Nut, Vegan, Diabetes-friendly, or build your own avoid list.
+2. Scan a menu — camera, photo library, or paste a link to a PDF / online menu.
+3. See only safe dishes — hidden items each say *why*. Tap "show anyway" to override one for this meal.
+
+Built for independent restaurants, not just chains. Reviews are by real diners with the same dietary needs as you. The owner of a restaurant can claim their listing to fix mistakes; everyone else can suggest fixes through a community moderation queue.
+
+Privacy: BiteWorthy keeps the data we need to make the filter work and not much more. We don't sell your data, we don't share with advertisers, and analytics are opt-in. See the full privacy policy at bite-worthy.com/privacy.
+
+The dietary filter is a planning tool, not a medical device. Always confirm with the restaurant before ordering anything that triggers a serious allergy.
+
+Built in Durango, Colorado, with the launch beta serving 30 independent local restaurants. More cities to follow as the model proves out.
+```
+
+## Keywords (100 char limit, comma-separated)
+
+```
+celiac,gluten free,vegan,allergy,allergies,menu,restaurant,dining,food,diet,intolerance,vegetarian
+```
+
+## Support URL
+
+> https://bite-worthy.com/
+
+## Marketing URL
+
+> https://bite-worthy.com/
+
+## Privacy Policy URL
+
+> https://bite-worthy.com/privacy
+
+## Category
+
+- **Primary:** Food & Drink
+- **Secondary:** Health & Fitness
+
+## Age rating
+
+- **4+** (no objectionable content; restaurants menus only)
+
+## App Privacy answers
+
+- **Data collected:** email address, user content (reviews + photos), usage data (anonymous, opt-in only).
+- **Used to track you:** No.
+- **Linked to you:** Email + reviews + photos are linked to your BiteWorthy account.
+- **Not linked to you:** Anonymous funnel events (when opted in).
+
+The full data-flow narrative lives in the privacy policy. The questionnaire's checkboxes follow from that page — do not let the two diverge.
+
+## What's New (changelog template)
+
+```
+The Durango beta is live!
+- 30 local restaurants seeded with full menus
+- Dish photos now appear inline where the source menu had them
+- Faster filter recompute when you toggle strictness
+```
+
+(Updated per app version. Keep it concrete; users skim.)

--- a/apps/mobile/store-listing/play-store.md
+++ b/apps/mobile/store-listing/play-store.md
@@ -1,0 +1,54 @@
+# Play Store metadata (Android)
+
+Google Play Console → BiteWorthy → Main store listing.
+
+## App name (30 char limit)
+
+> BiteWorthy
+
+## Short description (80 char limit)
+
+> Scan any restaurant menu, see only the dishes you can actually eat.
+
+## Full description (4000 char limit)
+
+(Same body as `app-store.md` Description section — keep them in lockstep. Google's listing renders Markdown line breaks differently from Apple's, but the copy itself is identical.)
+
+## Graphics
+
+- **App icon** — 512×512 PNG (no transparency on Play). Generated from `apps/mobile/assets/icon-source.svg` (Phase 5.9-wiring follow-up); see `apps/mobile/assets/README.md`.
+- **Feature graphic** — 1024×500 PNG. The hero panel ("Scan any menu...") with the BiteWorthy logo lockup.
+- **Phone screenshots** — minimum 2, recommended 8. See `screenshots-plan.md`.
+- **7-inch tablet** — optional; skip for v1 (mobile-only beta).
+- **10-inch tablet** — optional; skip for v1.
+
+## Categorization
+
+- **Application type:** App
+- **Category:** Food & Drink
+- **Tags:** Healthy Lifestyle, Restaurant Finder
+
+## Contact details
+
+- **Email:** hello@bite-worthy.com
+- **Phone:** _omit until we have a support number_
+- **Website:** https://bite-worthy.com/
+- **Privacy Policy:** https://bite-worthy.com/privacy
+
+## Content rating
+
+- **IARC questionnaire:** Everyone (no violence, no drugs, no purchases inside the app, no user-generated content visible to all)
+  - User-generated content: Yes (reviews) — moderated through Phase 4.6's queue. The questionnaire asks about UGC visibility; reviews are visible to all signed-in users.
+
+## Data safety
+
+Mirrors `app-store.md`'s App Privacy answers. The Play data-safety form has separate questions for "data collected" vs "data shared"; we **collect** the data listed in the privacy policy and **share** none of it (Anthropic + Postmark + R2 + PostHog are processors, not third-party recipients in the Play sense — the form has a "service provider" exception).
+
+## Pricing & distribution
+
+- **Price:** Free
+- **Countries:** US-only at launch (Phase 6+ adds others as the funnel proves out).
+- **In-app purchases:** No.
+- **Ads:** No.
+- **Content guidelines:** Family-friendly; no restricted content.
+- **US export laws:** App does not contain encryption requiring a registration. (Standard HTTPS to our API only.)

--- a/apps/mobile/store-listing/screenshots-plan.md
+++ b/apps/mobile/store-listing/screenshots-plan.md
@@ -1,0 +1,47 @@
+# Screenshot plan
+
+5 screenshots per device class, captured against the seeded Durango restaurants from Phase 5.7. Produced in Phase 5.9-wiring (this PR ships only the plan).
+
+## Required device classes
+
+- **iOS 6.7" (iPhone 15 Pro Max)** — Apple's primary marketing surface. Required.
+- **iOS 6.1" (iPhone 14 Pro)** — fallback. Required.
+- **Android phone, portrait, 16:9 or 9:16** — required.
+
+iPad screenshots are optional and skipped for v1 (mobile-only beta).
+
+## The 5 shots, in order (the App Store Connect "App Previews" carousel renders them this way)
+
+1. **Hero — restaurant page filtered.**
+   "Cream, Bean & Berry" with a Celiac filter applied. 7 visible dishes, 4 hidden with "Contains gluten (wheat)" chips. Caption: *Find what you can eat.*
+
+2. **Onboarding — 6 taps.**
+   The preset picker mid-tap (Celiac highlighted). Caption: *Six taps to a working filter.*
+
+3. **Hidden item explainer.**
+   Detail view of a hidden dish with the chip expanded ("Contains shellfish — Crab Rangoon"). Caption: *Every hidden dish says why.*
+
+4. **Show anyway override.**
+   Same restaurant page after tapping "show anyway" on one item. Caption: *Override per meal, or set permanent rules.*
+
+5. **Reviews + dish photo.**
+   An item detail screen with a 4-star review + a real cropped dish photo (Phase 4.11 / Phase 5.7 seed produces these). Caption: *Real reviews from people who eat the way you do.*
+
+## How to capture
+
+Phase 5.9-wiring follow-up adds expo-router test routes at `/screenshots/<id>` that drive each screen with deterministic seed data. Capture flow:
+
+```bash
+# in apps/mobile
+EXPO_USE_DEV_SERVER=false eas build --profile preview --platform all
+# install the build on the simulator/emulator
+xcrun simctl io booted recordVideo /tmp/cap.mov
+# navigate via deep link: biteworthy://screenshots/1, /2, etc.
+# extract frames at each route's stable position
+```
+
+Or just take real screenshots at the routes — the test routes guarantee the dishes shown are the same across builds.
+
+## Localization
+
+US English only at launch. Spanish + others ride the next round once the funnel proves out (Durango itself has a meaningful Spanish-speaking population — worth doing in Phase 6 even if the city stays the same).

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,190 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import { buildLegalMetadata } from '../../lib/legal-meta';
+
+/**
+ * Phase 5.9 — privacy policy template.
+ *
+ * **DRAFT — needs lawyer review before App Store submission.**
+ *
+ * Fills the App Privacy disclosures with BiteWorthy's actual data
+ * flows (Phases 1–5). The boilerplate sections (cookies, GDPR
+ * rights, CCPA, contact) are written for what we DO collect; if a
+ * lawyer adds collection paths we don't yet have, they update both
+ * this page AND the App Store privacy questionnaire to match.
+ *
+ * Resolves the Phase 5.5 marketing landing footer's `/privacy`
+ * placeholder href.
+ */
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bite-worthy.com';
+
+export const metadata: Metadata = buildLegalMetadata({
+  pageTitle: 'Privacy Policy',
+  description:
+    'How BiteWorthy handles user data: dietary profiles, review photos, restaurant visits, and the small list of third-party services we use.',
+  path: '/privacy',
+  siteUrl: SITE_URL,
+});
+
+const LAST_UPDATED = '2026-04-30';
+
+export default function PrivacyPage(): ReactElement {
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 pt-bw-12 pb-bw-16">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">Legal</p>
+      <h1 className="mt-bw-3 text-bw-3xl font-bold text-zinc-900 md:text-bw-4xl">
+        Privacy Policy
+      </h1>
+      <p className="mt-bw-2 text-bw-sm text-zinc-500">Last updated: {LAST_UPDATED}</p>
+
+      <DraftBanner />
+
+      <article className="prose prose-zinc mt-bw-8 max-w-none text-zinc-800">
+        <Section title="The short version">
+          <p>
+            BiteWorthy keeps the data we need to make the dietary filter work and not much more.
+            We don&rsquo;t sell your data. We don&rsquo;t share it with advertisers. The list of
+            third-party services we use is short and named below.
+          </p>
+        </Section>
+
+        <Section title="What we collect">
+          <ul>
+            <li>
+              <strong>Account:</strong> email address, hashed password, OAuth identifier (if you
+              sign in with Apple or Google), display handle. Optional photo.
+            </li>
+            <li>
+              <strong>Dietary profile:</strong> the ingredients and tags you mark &ldquo;avoid,&rdquo;
+              the dietary preset (e.g. <em>Celiac</em>) you picked, your strictness setting. Stored
+              against your account so it follows you across devices.
+            </li>
+            <li>
+              <strong>Reviews:</strong> the rating, body, and optional photo you submit on a dish.
+              Photos are stored on Cloudflare R2 (see &ldquo;Where data lives&rdquo;).
+            </li>
+            <li>
+              <strong>Restaurant visits:</strong> when you open a filtered restaurant page while
+              signed in, we record one row per (user, restaurant, day) so you can find it again in{' '}
+              <em>My filtered menus</em>. Anonymous browsing creates no such row.
+            </li>
+            <li>
+              <strong>Suggested edits:</strong> if you submit a fix to a dish (e.g. &ldquo;this
+              actually contains dairy&rdquo;), we keep the suggestion + its decision history for the
+              moderation queue.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="What we do NOT collect">
+          <ul>
+            <li>Real name (unless you put it in your display handle).</li>
+            <li>Phone number.</li>
+            <li>Address or GPS coordinates.</li>
+            <li>Device fingerprints, advertising IDs, or cross-app tracking signals.</li>
+          </ul>
+        </Section>
+
+        <Section title="Where data lives">
+          <ul>
+            <li>
+              <strong>Postgres on Fly.io</strong> (region: Denver, USA): your account, profile,
+              reviews text, suggestions.
+            </li>
+            <li>
+              <strong>Cloudflare R2</strong>: review photos and the cropped per-dish photos that the
+              ingestion pipeline extracts from menu images.
+            </li>
+            <li>
+              <strong>Anthropic</strong>: when a menu is being ingested, the menu image is sent to
+              Anthropic Claude for OCR + structuring. The image leaves our servers but is not used
+              to train the model. We do not send your reviews or profile to Anthropic.
+            </li>
+            <li>
+              <strong>Postmark</strong>: outbound email (claim verification, password reset). The
+              recipient address and message body pass through Postmark; we don&rsquo;t store the
+              message itself.
+            </li>
+            <li>
+              <strong>PostHog</strong> (optional, if you opt in): anonymous funnel events like{' '}
+              <em>app_open</em>, <em>menu_filtered</em>. No content of reviews or profile fields is
+              sent. See <a href="/terms#analytics">Terms § Analytics</a> for the opt-in flow.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Your controls">
+          <ul>
+            <li>
+              <strong>Export your data:</strong> email <a href="mailto:privacy@bite-worthy.com">privacy@bite-worthy.com</a>{' '}
+              and we&rsquo;ll send a JSON archive within 30 days.
+            </li>
+            <li>
+              <strong>Delete your account:</strong> same email, same response window. Reviews are
+              anonymized (set to <em>removed_user</em>) by default; let us know if you want them
+              hard-deleted instead.
+            </li>
+            <li>
+              <strong>Opt out of analytics:</strong> on web, set the toggle in{' '}
+              <em>/profile/settings</em>. On mobile, analytics are off by default — they only fire
+              if you explicitly enable them in <em>Settings → Analytics</em>. We honor browser
+              Do-Not-Track on the web side automatically.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Children">
+          <p>
+            BiteWorthy is for adults — restaurants, allergens, dining out. If we learn we&rsquo;ve
+            collected data from someone under 13, we delete it. (BiteWorthy is not directed at
+            children.)
+          </p>
+        </Section>
+
+        <Section title="Changes">
+          <p>
+            We&rsquo;ll update the date at the top when this page changes. Material changes get a
+            highlighted note on the homepage and an email to active accounts.
+          </p>
+        </Section>
+
+        <Section title="Contact">
+          <p>
+            <a href="mailto:privacy@bite-worthy.com">privacy@bite-worthy.com</a> for anything in
+            this policy. Questions about specific data, takedowns, or legal requests.
+          </p>
+        </Section>
+      </article>
+    </main>
+  );
+}
+
+function DraftBanner(): ReactElement {
+  return (
+    <div
+      role="note"
+      className="mt-bw-6 rounded-bw-md border border-warn/40 bg-warn/10 p-bw-4 text-bw-sm text-zinc-800"
+      data-testid="draft-banner"
+    >
+      <strong>Draft.</strong> This template fills the App Privacy disclosures with BiteWorthy&rsquo;s
+      actual data flows but has not yet had final lawyer review. The launch checklist (Phase 5.9)
+      requires that pass before App Store / Play Store submission.
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactElement | ReactElement[];
+}): ReactElement {
+  return (
+    <section className="mt-bw-8">
+      <h2 className="text-bw-xl font-bold text-zinc-900">{title}</h2>
+      <div className="mt-bw-3">{children}</div>
+    </section>
+  );
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import { buildLegalMetadata } from '../../lib/legal-meta';
+
+/**
+ * Phase 5.9 — terms of service template.
+ *
+ * **DRAFT — needs lawyer review before App Store submission.**
+ *
+ * Resolves the Phase 5.5 marketing landing footer's `/terms`
+ * placeholder href.
+ */
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bite-worthy.com';
+
+export const metadata: Metadata = buildLegalMetadata({
+  pageTitle: 'Terms of Service',
+  description:
+    'Acceptable use, content ownership, restaurant claims, and the limits of how much we can promise about a third-party menu being safe for you.',
+  path: '/terms',
+  siteUrl: SITE_URL,
+});
+
+const LAST_UPDATED = '2026-04-30';
+
+export default function TermsPage(): ReactElement {
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 pt-bw-12 pb-bw-16">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">Legal</p>
+      <h1 className="mt-bw-3 text-bw-3xl font-bold text-zinc-900 md:text-bw-4xl">
+        Terms of Service
+      </h1>
+      <p className="mt-bw-2 text-bw-sm text-zinc-500">Last updated: {LAST_UPDATED}</p>
+
+      <DraftBanner />
+
+      <article className="prose prose-zinc mt-bw-8 max-w-none text-zinc-800">
+        <Section title="The bargain">
+          <p>
+            BiteWorthy is a free dietary filter for restaurant menus. By using it you agree to use
+            it in good faith and to understand what it can and can&rsquo;t promise (see &ldquo;The
+            allergen disclaimer&rdquo; below). If those don&rsquo;t work for you, please don&rsquo;t
+            use the service.
+          </p>
+        </Section>
+
+        <Section title="The allergen disclaimer">
+          <p>
+            <strong>BiteWorthy is a planning tool, not a medical device.</strong> We use AI to read
+            menus and apply your dietary filter. AI gets things wrong. Restaurants change their
+            recipes without telling us. Cross-contamination in the kitchen is invisible to any
+            menu-text source.
+          </p>
+          <ul>
+            <li>
+              Always confirm with the restaurant before ordering anything that triggers a serious
+              allergy.
+            </li>
+            <li>
+              The &ldquo;hidden — contains dairy (cheese)&rdquo; chip is our best guess. The
+              &ldquo;visible&rdquo; chip is also our best guess.
+            </li>
+            <li>
+              We do not recommend BiteWorthy as the sole tool for managing anaphylactic allergies.
+              Carry your prescribed treatment.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Content you submit">
+          <ul>
+            <li>
+              <strong>Reviews:</strong> you keep ownership; you grant BiteWorthy a license to host +
+              display them on the platform. We may hide reviews that trip the moderation heuristics
+              (Phase 4.6).
+            </li>
+            <li>
+              <strong>Suggested edits</strong> (Phase 4.10): you grant BiteWorthy a license to merge
+              accepted suggestions into the underlying ingredient and tag rows. The merge is
+              attributed to your handle when accepted.
+            </li>
+            <li>
+              <strong>Photos:</strong> you grant BiteWorthy a license to display them alongside the
+              dish or restaurant. Don&rsquo;t upload anything you don&rsquo;t have rights to.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Restaurant claims">
+          <p>
+            Phase 4.9&rsquo;s claim flow lets a restaurant owner verify ownership via a domain-email
+            check. Once verified, the owner can edit menu items and respond to reviews. Verifying
+            doesn&rsquo;t grant the owner the right to delete unfavorable reviews — moderation
+            still goes through the queue.
+          </p>
+        </Section>
+
+        <Section title="Acceptable use">
+          <ul>
+            <li>No spam, abuse, harassment, or bot-driven submissions.</li>
+            <li>Don&rsquo;t scrape the API at a rate that affects other users.</li>
+            <li>
+              Don&rsquo;t pretend to be a restaurant owner you&rsquo;re not. The claim flow exists
+              for a reason.
+            </li>
+            <li>
+              Don&rsquo;t upload menu images you don&rsquo;t have permission to share. Most public
+              menus are fine; some restaurants explicitly forbid republication.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Analytics" id="analytics">
+          <p>
+            On web, BiteWorthy uses PostHog for funnel analytics (anonymous events like{' '}
+            <em>app_open</em>, <em>menu_filtered</em>; never review text or profile fields). We
+            honor browser <em>Do-Not-Track</em> automatically and a per-user opt-out at{' '}
+            <em>/profile/settings</em>.
+          </p>
+          <p>
+            On mobile, analytics are <strong>off by default</strong>. They only fire if you
+            explicitly enable them in <em>Settings → Analytics</em>. The App Store privacy
+            questionnaire reflects this.
+          </p>
+        </Section>
+
+        <Section title="Termination">
+          <p>
+            You can delete your account at any time (see <a href="/privacy">Privacy Policy</a>). We
+            can suspend accounts that violate these terms; we&rsquo;ll explain why if it happens.
+          </p>
+        </Section>
+
+        <Section title="Governing law">
+          <p>
+            These terms are governed by the laws of the State of Colorado, USA. Disputes go to the
+            state or federal courts located in La Plata County, Colorado.
+          </p>
+        </Section>
+
+        <Section title="Contact">
+          <p>
+            <a href="mailto:hello@bite-worthy.com">hello@bite-worthy.com</a> for anything in these
+            terms. Legal notices to{' '}
+            <a href="mailto:legal@bite-worthy.com">legal@bite-worthy.com</a>.
+          </p>
+        </Section>
+      </article>
+    </main>
+  );
+}
+
+function DraftBanner(): ReactElement {
+  return (
+    <div
+      role="note"
+      className="mt-bw-6 rounded-bw-md border border-warn/40 bg-warn/10 p-bw-4 text-bw-sm text-zinc-800"
+      data-testid="draft-banner"
+    >
+      <strong>Draft.</strong> Has not yet had final lawyer review; the launch checklist (Phase 5.9)
+      requires that pass before App Store / Play Store submission.
+    </div>
+  );
+}
+
+function Section({
+  title,
+  id,
+  children,
+}: {
+  title: string;
+  id?: string;
+  children: ReactElement | ReactElement[];
+}): ReactElement {
+  return (
+    <section className="mt-bw-8" id={id}>
+      <h2 className="text-bw-xl font-bold text-zinc-900">{title}</h2>
+      <div className="mt-bw-3">{children}</div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/__tests__/legal-meta.test.ts
+++ b/apps/web/src/lib/__tests__/legal-meta.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildLegalMetadata } from '../legal-meta';
+
+describe('buildLegalMetadata', () => {
+  it('composes the canonical title with the BiteWorthy suffix', () => {
+    const meta = buildLegalMetadata({
+      pageTitle: 'Privacy Policy',
+      description: 'How we handle your data.',
+      path: '/privacy',
+      siteUrl: 'https://bite-worthy.com',
+    });
+    expect(meta.title).toBe('Privacy Policy — BiteWorthy');
+    expect(meta.description).toBe('How we handle your data.');
+  });
+
+  it('sets canonical + OG url against the page path, not just the origin', () => {
+    const meta = buildLegalMetadata({
+      pageTitle: 'Terms of Service',
+      description: '...',
+      path: '/terms',
+      siteUrl: 'https://bite-worthy.com',
+    });
+    expect(meta.alternates?.canonical).toBe('/terms');
+    expect((meta.openGraph as { url?: string } | undefined)?.url).toBe(
+      'https://bite-worthy.com/terms',
+    );
+  });
+
+  it('strips trailing slashes from the siteUrl when composing OG url', () => {
+    const meta = buildLegalMetadata({
+      pageTitle: 'Privacy Policy',
+      description: '...',
+      path: '/privacy',
+      siteUrl: 'https://bite-worthy.com////',
+    });
+    expect((meta.openGraph as { url?: string } | undefined)?.url).toBe(
+      'https://bite-worthy.com/privacy',
+    );
+  });
+
+  it('emits Twitter "summary" card (text-only — legal pages have no hero image)', () => {
+    const meta = buildLegalMetadata({
+      pageTitle: 'Privacy Policy',
+      description: '...',
+      path: '/privacy',
+      siteUrl: 'https://bite-worthy.com',
+    });
+    expect((meta.twitter as { card?: string } | undefined)?.card).toBe('summary');
+  });
+
+  it('marks the page indexable + follow (legal pages should appear in search)', () => {
+    const meta = buildLegalMetadata({
+      pageTitle: 'Privacy Policy',
+      description: '...',
+      path: '/privacy',
+      siteUrl: 'https://bite-worthy.com',
+    });
+    expect((meta.robots as { index?: boolean; follow?: boolean } | undefined)?.index).toBe(true);
+    expect((meta.robots as { index?: boolean; follow?: boolean } | undefined)?.follow).toBe(true);
+  });
+});

--- a/apps/web/src/lib/legal-meta.ts
+++ b/apps/web/src/lib/legal-meta.ts
@@ -1,0 +1,50 @@
+/**
+ * Phase 5.9 — metadata composition for the legal pages
+ * (`/privacy`, `/terms`). Pure-TS so the title / description /
+ * canonical / OG strings are unit-testable without spinning up
+ * Next.
+ */
+
+import type { Metadata } from 'next';
+
+export interface LegalPageInput {
+  /** "Privacy Policy" or "Terms of Service" — used as the page title prefix. */
+  pageTitle: string;
+  /** One-sentence SEO description. */
+  description: string;
+  /** Path under the site, e.g. "/privacy". */
+  path: string;
+  /** Public canonical origin (defaults to NEXT_PUBLIC_SITE_URL at the call site). */
+  siteUrl: string;
+}
+
+export function buildLegalMetadata({
+  pageTitle,
+  description,
+  path,
+  siteUrl,
+}: LegalPageInput): Metadata {
+  const base = siteUrl.replace(/\/+$/, '');
+  const fullTitle = `${pageTitle} — BiteWorthy`;
+  return {
+    title: fullTitle,
+    description,
+    metadataBase: new URL(base),
+    alternates: { canonical: path },
+    openGraph: {
+      title: fullTitle,
+      description,
+      url: `${base}${path}`,
+      type: 'article',
+      siteName: 'BiteWorthy',
+    },
+    twitter: {
+      card: 'summary',
+      title: fullTitle,
+      description,
+    },
+    // Legal pages are stable; tell crawlers to index but not to weight
+    // them as "fresh" content above the funnel pages.
+    robots: { index: true, follow: true },
+  };
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,10 +13,10 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.8 — analytics instrumentation (structural)** (`docs/plans/phase-5.md#58--posthog-funnel-wiring-real-instrumentation`) — this PR. Ships the typed `@biteworthy/analytics` abstraction + event taxonomy + ADR; defers the posthog-js install + 9-call-site wiring to a follow-up PR (matches the Phase 4.11.2 structural-vs-cassette split).
+1. **Phase 5.9 — app store submission (structural)** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`) — this PR. Ships privacy + terms pages, app-store-listing markdown templates, eas.json profiles, asset spec docs. Defers binary asset generation, screenshot capture, and the actual TestFlight / Play Internal upload to a wiring follow-up gated on Apple Developer ($99/yr) + Google Play Console ($25 one-time) accounts.
 2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7's seed task mass-ingests real Durango menus.
-3. **Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to this PR; needs `posthog-js` + `posthog-react-native` installed and the call-site instrumentation.) Decoupled because each surface PR is small + reviewable on its own.
-4. **Phase 5.9 — mobile app store submission** (`docs/plans/phase-5.md#59--mobile-app-store-submission-testflight--play-store`).
+3. **Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179; needs `posthog-js` + `posthog-react-native` installed and the call-site instrumentation.) Decoupled because each surface PR is small + reviewable on its own.
+4. **Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to this PR; needs Apple/Google dev accounts + EAS credentials).
 5. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
 
 ### Done
@@ -73,6 +73,7 @@ the merge / review / status rules.
 - ✅ Phase 5.5 — marketing landing page at / (#176)
 - ✅ Phase 5.6 — SEO city/diet pages at /durango/[diet] (#177)
 - ✅ Phase 5.7 — durango batch ingest task + csv template (#178)
+- ✅ Phase 5.8 — analytics abstraction + event taxonomy (#179) — **structural; wiring follow-up queued at Next-up #3**
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,50 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 21:47 — tick #86. PR #179 (Phase 5.8 analytics structural)
+merged at 21:20 UTC, all CI green. Anthropic still capped (~2.2h
+to reset); cassette PR stays BLOCKED. Picked the next unblocked
+item: **Phase 5.9 — app store submission (structural)**. Same
+ship-the-wiring-first split — loop ships everything that doesn't
+need a paid Apple Developer or Google Play Console account.
+Shipped:
+- **Web privacy + terms** at `/privacy` and `/terms` (resolves
+  the Phase 5.5 footer placeholder hrefs). Pure SSR templates
+  filled with BiteWorthy's actual data flows: account, profile,
+  reviews, restaurant_visits, suggestions; named services
+  (Postgres+Fly.io / Cloudflare R2 / Anthropic / Postmark /
+  PostHog). Both marked DRAFT with a banner — needs final
+  lawyer pass before App Store submission. Allergen disclaimer
+  is up top in /terms ("planning tool, not a medical device").
+- `apps/web/src/lib/legal-meta.ts` extracted metadata helper +
+  5 vitest cases (canonical title, OG url path joining,
+  trailing-slash stripping, Twitter summary card, robots
+  index/follow). Same testable shape as Phase 5.5's
+  landing-meta.
+- **Mobile store-listing**: `eas.json` with development /
+  preview / production build profiles + a submit profile with
+  placeholder values marking where Apple ID / ASC App ID / team
+  ID / Play service-account path go.
+  `apps/mobile/store-listing/` — App Store Connect metadata
+  (name/subtitle/description/keywords/URLs/category/App Privacy
+  answers/What's New template), Play Console metadata (short
+  description/feature graphic/data safety/distribution), and a
+  screenshots-plan.md naming the 5 marketing shots + the
+  expo-router test-route flow Phase 5.9-wiring will use.
+- `apps/mobile/assets/README.md` — required asset specs (icon,
+  adaptive-icon, splash, favicon) + ui-tokens-derived design
+  guidance + the sharp render pipeline 5.9-wiring follows.
+Tests: 5 new vitest cases (web 92/92, +5). Typecheck + lint full-
+turbo green; rspec 365/0/1 unchanged. Roadmap: ticked 5.8 (#179);
+reordered Next-up so 5.9-structural is #1 and a new 5.9-wiring
+entry is #4 (BLOCKED on dev accounts + lawyer review). **Phase
+5 status**: every code-only PR has now shipped its structural
+half. Remaining loop work: 5.10 (press kit + waitlist). The
+human-credential-gated wiring queue: 5.1 deploy, 5.2 SMTP, 5.3
+R2, 5.4 Vercel, 5.8-wiring (PostHog), 5.9-wiring (App Stores),
+plus the long-blocked cassette PR. Anthropic cap clears at
+00:00 UTC (~2.2h from now).
+
 2026-04-30 21:19 — tick #85. PR #178 (Phase 5.7 Durango seed task)
 merged at 20:47 UTC, all CI green including title-lint this time.
 Anthropic still capped (~2.7h to reset); cassette PR stays


### PR DESCRIPTION
## Why

Phase 5.9 from `docs/plans/phase-5.md` — mobile app store submission. Splits cleanly into the **loop-shippable structural pieces** (this PR) vs the **human-credential-gated wiring** (deferred to a follow-up PR after Apple Developer ($99/yr) + Google Play Console ($25 one-time) accounts are set up + lawyer signs off on `/privacy` and `/terms`).

Same pattern as Phase 5.1 / 5.2 / 5.3 / 5.4 / 5.8: humans drop credentials, the loop ships the rest.

## What

### Web — privacy + terms (resolves Phase 5.5 footer placeholders)

- **`apps/web/src/app/privacy/page.tsx`** — privacy policy template, filled with BiteWorthy's actual data flows: account, profile, reviews, restaurant_visits, suggestions. Names the third-party services we actually use (Postgres + Fly.io, Cloudflare R2, Anthropic, Postmark, PostHog). Marked **DRAFT** with a visible banner — needs lawyer review before App Store submission.
- **`apps/web/src/app/terms/page.tsx`** — terms with the **allergen disclaimer up front** ("planning tool, not a medical device"), acceptable use, claim flow, analytics opt-in/out, governing law (Colorado), contact. Same draft banner.
- **`apps/web/src/lib/legal-meta.ts`** + 5 vitest cases — extracted metadata helper (canonical title, OG/Twitter card, robots index/follow). Same testable shape as Phase 5.5's `landing-meta`.

### Mobile — store-listing + EAS config

- **`apps/mobile/eas.json`** — `development` / `preview` / `production` build profiles + a `submit` profile with placeholder values (`REPLACE_WITH_APPLE_ID@bite-worthy.com`, `REPLACE_WITH_ASC_APP_ID`, `REPLACE_WITH_TEAM_ID`, `./play-service-account.json`) marking exactly where credentials go in 5.9-wiring.
- **`apps/mobile/store-listing/`** — markdown templates:
  - `app-store.md` — App Store Connect metadata (name, subtitle, description, keywords, support/marketing/privacy URLs, category, App Privacy answers, What's New template).
  - `play-store.md` — Play Console metadata (short description, feature graphic, content rating, data safety, distribution).
  - `screenshots-plan.md` — the 5 marketing screenshots + the expo-router test-route flow that 5.9-wiring will use to drive them.
  - `README.md` — update flow + source-of-truth notes.
- **`apps/mobile/assets/README.md`** — required asset specs (icon, adaptive-icon, splash, favicon) + the ui-tokens-derived design guidance + the Phase 5.9-wiring render pipeline (sharp from a single SVG source).

## Tests

5 new vitest cases for `buildLegalMetadata`:

- Canonical title composes with the BiteWorthy suffix.
- OG `url` is the full path (origin + page path), not just origin.
- Trailing slashes stripped from `siteUrl`.
- Twitter `summary` card (text-only legal pages, no hero image).
- Robots `index` + `follow` set true (legal pages indexable).

`pnpm --filter @biteworthy/web test`: **92/92** (+5). `pnpm typecheck` + `pnpm lint`: full-turbo cached green. `bundle exec rspec`: 365/0/1 pending unchanged.

## What still needs a human (Phase 5.9-wiring follow-up)

```
1. Lawyer reviews + signs off on /privacy and /terms.
2. Sign up for Apple Developer Program ($99/yr) +
   Google Play Console ($25 one-time).
3. Replace eas.json placeholders with real Apple ID +
   ASC App ID + Team ID; commit a play-service-account.json
   (gitignored).
4. Generate binary assets (icon-source.svg → sharp render
   pipeline). Commit the rendered PNGs.
5. Wire expo-router /screenshots/[id] test routes that drive
   each marketing screenshot deterministically against the
   Phase 5.7 seeded restaurants.
6. eas build --profile production --platform all
   eas submit --profile production --platform all
   (Apple review 1–7 days; Google Play Internal track typically
   minutes.)
```

## Phase 5 status after this PR

Every code-only Phase-5 PR has now shipped its structural half. Remaining loop work: **5.10** (press kit + waitlist). The human-credential-gated wiring queue at this point: 5.1 deploy, 5.2 SMTP, 5.3 R2, 5.4 Vercel, 5.8-wiring (PostHog), 5.9-wiring (App Stores), plus the long-blocked cassette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)