### PR TITLE
feat(api,web): press kit + waitlist + durango outreach templates (phase 5.10)

### DIFF
--- a/apps/api/app/controllers/api/v1/waitlist_signups_controller.rb
+++ b/apps/api/app/controllers/api/v1/waitlist_signups_controller.rb
@@ -1,0 +1,44 @@
+module Api
+  module V1
+    # POST /api/v1/waitlist_signups
+    #   { waitlist_signup: { email:, source: } }
+    #
+    # Phase 5.10 — soft-launch waitlist endpoint.
+    #
+    # Public + unauthenticated (it's a marketing-page form). Returns
+    # 200 on both new and duplicate emails so a re-submitter doesn't
+    # leak whether the address was already in the list (and so the
+    # form just says "thanks" either way).
+    #
+    # 422 only on a malformed email (regex fails).
+    class WaitlistSignupsController < BaseController
+      skip_before_action :authenticate_user!, only: [:create]
+
+      def create
+        signup = WaitlistSignup.find_or_initialize_by(email: normalized_email)
+        signup.source = params.dig(:waitlist_signup, :source) || "landing"
+
+        if signup.persisted?
+          # Re-submit — silently no-op (no second confirmation mail).
+          render json: { ok: true, duplicate: true }, status: :ok
+          return
+        end
+
+        if signup.save
+          # Best-effort send; Postmark queueing failures shouldn't
+          # block the response (the user is already on the list).
+          WaitlistMailer.confirm(signup.id).deliver_later rescue nil
+          render json: { ok: true, duplicate: false }, status: :ok
+        else
+          render json: { ok: false, errors: signup.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def normalized_email
+        params.dig(:waitlist_signup, :email).to_s.strip.downcase
+      end
+    end
+  end
+end

--- a/apps/api/app/mailers/waitlist_mailer.rb
+++ b/apps/api/app/mailers/waitlist_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Phase 5.10 — confirmation mailer for soft-launch waitlist signups.
+#
+# Fires once per signup. Goes through the Phase 5.2 SMTP pipeline
+# (production: Postmark; dev/test: :test adapter so deliveries land
+# in ActionMailer::Base.deliveries for inspection).
+#
+# Informational, not a double-opt-in gate. The signup is already on
+# the list when this mail fires.
+class WaitlistMailer < ApplicationMailer
+  def confirm(signup_id)
+    @signup = WaitlistSignup.find(signup_id)
+    mail(
+      to:      @signup.email,
+      subject: "You're on the BiteWorthy waitlist"
+    )
+  end
+end

--- a/apps/api/app/models/waitlist_signup.rb
+++ b/apps/api/app/models/waitlist_signup.rb
@@ -1,0 +1,22 @@
+class WaitlistSignup < ApplicationRecord
+  # Phase 5.10 — soft-launch waitlist signups.
+  #
+  # Email validation is intentionally lenient: a regex that catches
+  # the obvious typos (no `@`, no `.`, whitespace) but doesn't try
+  # to enforce RFC 5322. Postmark's bounce handling is the real
+  # filter. The citext column ensures dupes match case-insensitively.
+  EMAIL_REGEX = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+
+  SOURCES = %w[landing press footer mobile_app].freeze
+
+  validates :email, presence: true, format: { with: EMAIL_REGEX }
+  validates :source, inclusion: { in: SOURCES }
+
+  before_validation :normalize_email
+
+  private
+
+  def normalize_email
+    self.email = email.to_s.strip.downcase if email.present?
+  end
+end

--- a/apps/api/app/views/waitlist_mailer/confirm.html.erb
+++ b/apps/api/app/views/waitlist_mailer/confirm.html.erb
@@ -1,0 +1,14 @@
+<h1>You&rsquo;re on the BiteWorthy waitlist</h1>
+
+<p>
+  We&rsquo;re seeding the launch with 30 independent Durango restaurants and a
+  real dietary filter. You&rsquo;ll get an &ldquo;early access&rdquo; email 48 hours before
+  public release &mdash; that&rsquo;s the only message we&rsquo;ll send between now and then.
+</p>
+
+<p>If you didn&rsquo;t sign up, just ignore this. We don&rsquo;t send a second one.</p>
+
+<p>
+  &mdash; BiteWorthy<br>
+  <a href="https://bite-worthy.com/">https://bite-worthy.com/</a>
+</p>

--- a/apps/api/app/views/waitlist_mailer/confirm.text.erb
+++ b/apps/api/app/views/waitlist_mailer/confirm.text.erb
@@ -1,0 +1,10 @@
+You're on the BiteWorthy waitlist!
+
+We're seeding the launch with 30 independent Durango restaurants and a
+real dietary filter. You'll get an "early access" email 48 hours before
+public release — that's the only message we'll send between now and then.
+
+If you didn't sign up, just ignore this. We don't send a second one.
+
+— BiteWorthy
+https://bite-worthy.com/

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -84,6 +84,8 @@ Rails.application.routes.draw do
         resources :suggestions, only: [:create]
       end
       resources :reviews, only: [:update, :destroy]
+      # Phase 5.10 — soft-launch waitlist; public + unauthenticated.
+      resources :waitlist_signups, only: [:create]
       # Phase 4.10 — owner accepts/rejects a suggestion.
       resources :suggestions, only: [:update]
       # Phase 4.7 — public profile by handle. Constraint allows

--- a/apps/api/db/migrate/20260430164500_create_waitlist_signups.rb
+++ b/apps/api/db/migrate/20260430164500_create_waitlist_signups.rb
@@ -1,0 +1,24 @@
+class CreateWaitlistSignups < ActiveRecord::Migration[8.1]
+  # Phase 5.10 — soft-launch waitlist for the marketing landing.
+  #
+  # Single column doing real work: `email` (citext for case-insensitive
+  # uniqueness — cIteXt@Foo.com and citext@foo.com are the same row).
+  #
+  # `source` lets us split conversion by referrer eventually
+  # (`landing_hero`, `press_page`, etc.) without a schema change.
+  #
+  # `confirmed_at` left for a future double-opt-in if Postmark
+  # deliverability ever requires it; for v1 every signup is
+  # immediately on the list (the confirmation email is informational,
+  # not a gate).
+  def change
+    create_table :waitlist_signups, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.citext   :email,   null: false
+      t.string   :source,  null: false, default: "landing"
+      t.datetime :confirmed_at
+      t.timestamps
+    end
+
+    add_index :waitlist_signups, :email, unique: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_144509) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_164500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -398,6 +398,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_144509) do
     t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "waitlist_signups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "confirmed_at"
+    t.datetime "created_at", null: false
+    t.citext "email", null: false
+    t.string "source", default: "landing", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_waitlist_signups_on_email", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/apps/api/spec/models/waitlist_signup_spec.rb
+++ b/apps/api/spec/models/waitlist_signup_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+# Phase 5.10 — soft-launch waitlist signups.
+RSpec.describe WaitlistSignup, type: :model do
+  it "accepts a normal email + default source" do
+    s = described_class.new(email: "skylar@example.com")
+    expect(s).to be_valid
+    expect(s.source).to eq("landing")
+  end
+
+  it "is invalid without an email" do
+    expect(described_class.new(email: nil)).not_to be_valid
+  end
+
+  it "rejects obviously malformed emails (no @, no ., whitespace)" do
+    %w[skylar nope@ @nope skylar@ @example.com hello\ there@example.com].each do |bad|
+      expect(described_class.new(email: bad)).not_to be_valid, "expected '#{bad}' to be rejected"
+    end
+  end
+
+  it "normalizes email to lowercase + strips whitespace before validation" do
+    s = described_class.create!(email: "  Skylar@Example.COM  ")
+    expect(s.reload.email).to eq("skylar@example.com")
+  end
+
+  it "treats duplicate emails as case-insensitive (citext column)" do
+    described_class.create!(email: "skylar@example.com")
+    expect {
+      # No uniqueness validation on the model — the citext + unique
+      # index pair handles dedup at the DB level. The controller
+      # uses find_or_initialize_by so end users never see this; the
+      # spec just confirms the index does its job.
+      described_class.create!(email: "SKYLAR@EXAMPLE.COM")
+    }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it "rejects unknown source values" do
+    s = described_class.new(email: "ok@example.com", source: "twitter_dm")
+    expect(s).not_to be_valid
+    expect(s.errors[:source]).to be_present
+  end
+
+  it "accepts every documented source" do
+    %w[landing press footer mobile_app].each do |src|
+      sequence = SecureRandom.hex(4)
+      s = described_class.new(email: "ok-#{sequence}@example.com", source: src)
+      expect(s).to be_valid, "expected source '#{src}' to be valid"
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/waitlist_signups_spec.rb
+++ b/apps/api/spec/requests/api/v1/waitlist_signups_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "POST /api/v1/waitlist_signups", type: :request do
+  let(:url) { "/api/v1/waitlist_signups" }
+
+  before { ActionMailer::Base.deliveries.clear }
+
+  it "creates the signup + fires the confirmation mailer (anonymous)" do
+    expect {
+      post url, params: { waitlist_signup: { email: "skylar@example.com" } }, as: :json
+    }.to change(WaitlistSignup, :count).by(1)
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+    expect(body["ok"]).to be true
+    expect(body["duplicate"]).to be false
+
+    perform_enqueued_jobs
+    expect(ActionMailer::Base.deliveries.size).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.to).to eq(["skylar@example.com"])
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("You're on the BiteWorthy waitlist")
+  end
+
+  it "is idempotent on a duplicate email — 200 + duplicate=true, no second mail" do
+    WaitlistSignup.create!(email: "skylar@example.com")
+    expect {
+      post url, params: { waitlist_signup: { email: "Skylar@Example.com" } }, as: :json
+    }.not_to change(WaitlistSignup, :count)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["duplicate"]).to be true
+    perform_enqueued_jobs
+    expect(ActionMailer::Base.deliveries).to be_empty
+  end
+
+  it "422s on a malformed email" do
+    post url, params: { waitlist_signup: { email: "not-an-email" } }, as: :json
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body["errors"]).to be_present
+  end
+
+  it "honors the optional source param" do
+    post url, params: { waitlist_signup: { email: "press@example.com", source: "press" } }, as: :json
+    expect(response).to have_http_status(:ok)
+    expect(WaitlistSignup.find_by(email: "press@example.com").source).to eq("press")
+  end
+
+  it "rejects an unknown source value" do
+    post url, params: { waitlist_signup: { email: "ok@example.com", source: "twitter_dm" } }, as: :json
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+end

--- a/apps/web/src/app/_waitlist-form.tsx
+++ b/apps/web/src/app/_waitlist-form.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState, type FormEvent, type ReactElement } from 'react';
+import { isValidEmail, submitWaitlist, WaitlistError } from '../lib/waitlist';
+
+/**
+ * Phase 5.10 — soft-launch waitlist form on the marketing landing.
+ *
+ * Client island so the form can submit without a full page reload.
+ * Lives in `apps/web/src/app/_waitlist-form.tsx` (underscore prefix
+ * keeps Next from registering it as a route).
+ *
+ * Disables itself + shows a thank-you when submitWaitlist resolves.
+ * Inline error message on a 422 (e.g. malformed email the
+ * client-side regex didn't catch).
+ */
+export default function WaitlistForm(): ReactElement {
+  const [email, setEmail] = useState('');
+  const [state, setState] = useState<'idle' | 'sending' | 'done' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const trimmed = email.trim();
+    if (!isValidEmail(trimmed)) {
+      setError('That email looks off — typo?');
+      return;
+    }
+
+    try {
+      setState('sending');
+      await submitWaitlist(trimmed, 'landing');
+      setState('done');
+    } catch (e) {
+      setState('error');
+      setError(
+        e instanceof WaitlistError
+          ? `Couldn't sign you up (${e.status}). Try again in a sec?`
+          : 'Network hiccup — try again?',
+      );
+    }
+  };
+
+  if (state === 'done') {
+    return (
+      <p
+        data-testid="waitlist-thanks"
+        className="mt-bw-2 inline-block rounded-bw-md bg-bite-light px-bw-4 py-bw-3 text-bw-base font-semibold text-bite-dark"
+      >
+        ✓ You&rsquo;re on the list. We&rsquo;ll send one email 48 hours before public release.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} data-testid="waitlist-form" className="mt-bw-2 flex flex-wrap items-center gap-bw-3">
+      <input
+        type="email"
+        required
+        inputMode="email"
+        placeholder="you@example.com"
+        aria-label="Email address"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={state === 'sending'}
+        className="rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base text-zinc-900 placeholder:text-zinc-400 focus:border-bite focus:outline-none disabled:opacity-60"
+      />
+      <button
+        type="submit"
+        disabled={state === 'sending'}
+        data-testid="waitlist-submit"
+        className="rounded-bw-md bg-bite px-bw-4 py-bw-2 text-bw-base font-bold text-white hover:bg-bite-dark disabled:opacity-60"
+      >
+        {state === 'sending' ? 'Adding…' : 'Get early access'}
+      </button>
+      {error && (
+        <p className="basis-full text-bw-sm text-bite-dark" data-testid="waitlist-error">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/apps/web/src/app/api/waitlist/route.ts
+++ b/apps/web/src/app/api/waitlist/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Phase 5.10 — Next proxy for the waitlist signup endpoint.
+ *
+ * `POST /api/waitlist` from the marketing landing form forwards
+ * to the Rails `POST /api/v1/waitlist_signups` with the same body.
+ * Keeps `NEXT_PUBLIC_API_BASE` server-side so the browser sees only
+ * a same-origin request (no CORS preflight needed for this form).
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+interface SignupBody {
+  email?: string;
+  source?: string;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = (await request.json().catch(() => ({}))) as SignupBody;
+
+  const upstream = await fetch(`${API_BASE}/api/v1/waitlist_signups`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({
+      waitlist_signup: {
+        email: body.email ?? '',
+        source: body.source ?? 'landing',
+      },
+    }),
+  });
+
+  const responseBody = await upstream.json().catch(() => ({}));
+  return NextResponse.json(responseBody, { status: upstream.status });
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
 import { buildLandingMetadata } from '../lib/landing-meta';
+import WaitlistForm from './_waitlist-form';
 
 /**
  * Phase 5.5 — marketing landing.
@@ -69,6 +70,14 @@ function Hero(): ReactElement {
       <p className="mt-bw-4 text-bw-xs text-zinc-500">
         Free during the Durango beta. No ads, no email signup until you choose to save a profile.
       </p>
+
+      <div className="mt-bw-8 rounded-bw-lg border border-zinc-200 bg-zinc-50 p-bw-4">
+        <p className="text-bw-sm font-bold text-zinc-900">Want a heads-up when the apps drop?</p>
+        <p className="mt-bw-1 text-bw-sm text-zinc-600">
+          One email, 48 hours before public release. Nothing else.
+        </p>
+        <WaitlistForm />
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/press/page.tsx
+++ b/apps/web/src/app/press/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import { buildLegalMetadata } from '../../lib/legal-meta';
+
+/**
+ * Phase 5.10 — press kit page.
+ *
+ * One-page resource for journalists + bloggers covering the launch.
+ * Pure SSR. Logo files (PNG + SVG) live at `/logo-*.png|svg` in
+ * `apps/web/public/` once Phase 5.9-wiring renders them; the page
+ * references them by URL today + degrades gracefully (broken-image
+ * placeholders) until they exist.
+ */
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bite-worthy.com';
+
+export const metadata: Metadata = buildLegalMetadata({
+  pageTitle: 'Press kit',
+  description:
+    'Logo, screenshots, founder bio, blurbs, and contact for press covering the BiteWorthy Durango launch.',
+  path: '/press',
+  siteUrl: SITE_URL,
+});
+
+export default function PressPage(): ReactElement {
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 pt-bw-12 pb-bw-16">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">Press</p>
+      <h1 className="mt-bw-3 text-bw-3xl font-bold text-zinc-900 md:text-bw-4xl">Press kit</h1>
+      <p className="mt-bw-2 text-bw-sm text-zinc-500">
+        For journalists, bloggers, and outlets covering the BiteWorthy Durango launch.
+      </p>
+
+      <Section title="One-line">
+        <p className="text-bw-lg text-zinc-800">
+          BiteWorthy is a pocket food filter for celiac, allergies, vegan, and every other dietary
+          need &mdash; scan any restaurant menu, see only the dishes you can actually eat.
+        </p>
+      </Section>
+
+      <Section title="50 words">
+        <p className="text-bw-base text-zinc-800">
+          BiteWorthy is a free dietary filter for restaurant menus. Pick a preset (Celiac, Tree
+          Nut, Vegan, &hellip;) or build your own avoid list. Scan a menu with the camera or paste
+          a link. Hidden dishes each say <em>why</em>. Built for independent restaurants, launched
+          in Durango, Colorado.
+        </p>
+      </Section>
+
+      <Section title="200 words">
+        <p className="text-bw-base text-zinc-800">
+          BiteWorthy turns the question &ldquo;is there anything I can eat here?&rdquo; into a
+          glanceable answer. The app reads any restaurant menu &mdash; from a phone-camera scan, a
+          PDF, or an online link &mdash; and applies a dietary filter you set in six taps. Items
+          you can&rsquo;t eat get hidden, with a transparent label explaining
+          <em> why</em> (&ldquo;Contains dairy (cheese)&rdquo;, &ldquo;Contains gluten
+          (wheat)&rdquo;). Tap &ldquo;show anyway&rdquo; to override one for tonight; flag
+          &ldquo;never hide this dish&rdquo; to teach the filter your nuance.
+        </p>
+        <p className="mt-bw-3 text-bw-base text-zinc-800">
+          The launch beta seeds 30 independent Durango restaurants &mdash; not chains, not
+          delivery aggregators. Reviews are by real diners with the same dietary needs as you;
+          owners can claim their listings to fix mistakes; everyone can suggest fixes through a
+          community moderation queue. Free, no ads, opt-in analytics. Built in Durango, Colorado,
+          with the same dietary-filter logic running identically on web and mobile.
+        </p>
+      </Section>
+
+      <Section title="Logo + screenshots">
+        <p className="text-bw-sm text-zinc-700">
+          High-res logo files + marketing screenshots (per device class) ship via Phase 5.9-wiring.
+          Until then, contact <a href="mailto:press@bite-worthy.com">press@bite-worthy.com</a> for
+          assets.
+        </p>
+        <ul className="mt-bw-3 list-disc pl-bw-6 text-bw-sm text-zinc-700">
+          <li>
+            <a href="/logo.svg" data-testid="press-logo-svg">Logo &mdash; SVG</a>
+            {' '}(coming with Phase 5.9-wiring)
+          </li>
+          <li>
+            <a href="/logo.png" data-testid="press-logo-png">Logo &mdash; PNG (1024&times;1024)</a>
+            {' '}(coming with Phase 5.9-wiring)
+          </li>
+          <li>App Store + Play Store listing copy lives in
+            {' '}<code>apps/mobile/store-listing/</code> (open-source, see GitHub).
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="Founder">
+        <p className="text-bw-base text-zinc-800">
+          Skylar Bolton &mdash; software engineer based in Durango, Colorado.
+          {' '}<a href="https://github.com/Sky-Fox-Studios" className="underline">Sky-Fox-Studios</a>.
+        </p>
+      </Section>
+
+      <Section title="Contact">
+        <p className="text-bw-base text-zinc-800">
+          Press inquiries: <a href="mailto:press@bite-worthy.com">press@bite-worthy.com</a>.
+          {' '}General: <a href="mailto:hello@bite-worthy.com">hello@bite-worthy.com</a>.
+        </p>
+      </Section>
+    </main>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactElement | ReactElement[];
+}): ReactElement {
+  return (
+    <section className="mt-bw-8">
+      <h2 className="text-bw-xl font-bold text-zinc-900">{title}</h2>
+      <div className="mt-bw-3">{children}</div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/__tests__/waitlist.test.ts
+++ b/apps/web/src/lib/__tests__/waitlist.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isValidEmail, submitWaitlist, WaitlistError } from '../waitlist';
+
+type FetchArgs = Parameters<typeof fetch>;
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (..._args: FetchArgs) =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'ERR',
+        json: async () => body,
+      }) as unknown as Response,
+  );
+}
+
+describe('isValidEmail', () => {
+  it('accepts a normal email', () => {
+    expect(isValidEmail('skylar@example.com')).toBe(true);
+  });
+
+  it('rejects obvious malformed inputs (no @, no ., whitespace)', () => {
+    for (const bad of ['', 'skylar', 'skylar@', '@example.com', 'sky lar@a.com', 'skylar@example']) {
+      expect(isValidEmail(bad)).toBe(false);
+    }
+  });
+
+  it('strips whitespace before checking', () => {
+    expect(isValidEmail('  skylar@example.com  ')).toBe(true);
+  });
+});
+
+describe('submitWaitlist', () => {
+  it('POSTs JSON to the Next proxy at /api/waitlist with email + source', async () => {
+    const fetchImpl = fakeFetch(200, { ok: true, duplicate: false });
+    const res = await submitWaitlist('skylar@example.com', 'landing', { fetchImpl });
+    expect(res.duplicate).toBe(false);
+
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/waitlist');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toEqual({
+      email: 'skylar@example.com',
+      source: 'landing',
+    });
+  });
+
+  it('defaults source to "landing" when not specified', async () => {
+    const fetchImpl = fakeFetch(200, { ok: true, duplicate: false });
+    await submitWaitlist('s@e.com', undefined, { fetchImpl });
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string).source).toBe('landing');
+  });
+
+  it('returns the duplicate=true flag when the API reports it', async () => {
+    const fetchImpl = fakeFetch(200, { ok: true, duplicate: true });
+    const res = await submitWaitlist('s@e.com', 'press', { fetchImpl });
+    expect(res.duplicate).toBe(true);
+  });
+
+  it('throws WaitlistError preserving the upstream status on 422', async () => {
+    const fetchImpl = fakeFetch(422, { ok: false, errors: ['Email is invalid'] });
+    await expect(submitWaitlist('garbage', 'landing', { fetchImpl })).rejects.toMatchObject({
+      name: 'WaitlistError',
+      status: 422,
+    });
+  });
+});

--- a/apps/web/src/lib/waitlist.ts
+++ b/apps/web/src/lib/waitlist.ts
@@ -1,0 +1,59 @@
+/**
+ * Phase 5.10 — soft-launch waitlist client.
+ *
+ * Browser-side calls hit the Next proxy at `/api/waitlist`, which
+ * forwards to the Rails endpoint with `Content-Type: application/json`.
+ * Direct API access (e.g. mobile, server-side) can call
+ * `submitWaitlistViaApi` against the API base.
+ */
+
+const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+export type WaitlistSource = 'landing' | 'press' | 'footer' | 'mobile_app';
+
+export class WaitlistError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    this.name = 'WaitlistError';
+  }
+}
+
+export interface WaitlistResult {
+  ok: true;
+  duplicate: boolean;
+}
+
+/**
+ * Lenient email check — catches the obvious typos (no `@`, no `.`,
+ * whitespace) but doesn't try to enforce RFC 5322. Server-side
+ * validation is the real filter; this just keeps form submits
+ * snappy by failing trivially-bad input without a roundtrip.
+ */
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim());
+}
+
+export interface SubmitOptions {
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Browser-friendly path: posts to the Next proxy at /api/waitlist,
+ * which tucks NEXT_PUBLIC_API_BASE in server-side.
+ */
+export async function submitWaitlist(
+  email: string,
+  source: WaitlistSource = 'landing',
+  opts: SubmitOptions = {},
+): Promise<WaitlistResult> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/waitlist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ email, source }),
+  });
+  if (!res.ok) {
+    throw new WaitlistError(res.status, `submitWaitlist failed: ${res.status}`);
+  }
+  return (await res.json()) as WaitlistResult;
+}

--- a/docs/outreach/README.md
+++ b/docs/outreach/README.md
@@ -1,0 +1,21 @@
+# Press outreach templates
+
+Phase 5.10 — short, customizable email templates for the Durango press contacts we'll pitch on launch.
+
+**One template per outlet**, shaped to that outlet's beat. Don't blast all four with the same body — Durango's press scene is small enough that they'll notice and discount the pitch.
+
+## Files
+
+- `durango-telegraph.md` — Durango Telegraph (weekly, dining + culture beat).
+- `durango-herald.md` — Durango Herald (daily, business + tech beat).
+- `la-plata-mountaineer.md` — La Plata Mountaineer (weekly, community-events angle).
+- `ksut.md` — KSUT FM (NPR affiliate, human-interest segments).
+- `launch-day.md` — staged social posts for launch day (Twitter/X, Bluesky, Instagram, LinkedIn).
+
+## Send order
+
+Cold outreach 7 days before public launch. Follow-up after 3 days if no reply. The subject lines below all start with the outlet's name so the journalist sees an obviously-customized pitch in their inbox preview.
+
+## Press kit URL
+
+Every template links to https://bite-worthy.com/press for the long-form copy + assets. That page already documents the 50-word + 200-word blurbs + contact + (eventual) logo files.

--- a/docs/outreach/durango-herald.md
+++ b/docs/outreach/durango-herald.md
@@ -1,0 +1,35 @@
+# Durango Herald — pitch
+
+**Beat:** daily paper. Business + technology + community coverage.
+**Best contact:** business desk (Hannah Brown was the editor as of last masthead check; verify before send).
+
+---
+
+**Subject:** Durango Herald: AI menu-reader app launches here in [N] days
+
+Hi [Editor first name],
+
+Quick pitch from a local: I built a Durango-first dietary-filter app called BiteWorthy and the launch beta lands in [N] days. Wanted to give the Herald a heads-up since the AI-on-menus angle and the local-tech-launch angle could both work for the business desk.
+
+What it does, plain English: snap a photo of any restaurant menu and the app hides the dishes that don't work for your dietary needs — celiac, allergies, vegan, etc. AI does the OCR and ingredient parsing in seconds; the user picks a filter once and the app does the math on every menu they see.
+
+Two angles that might fit the Herald:
+- **Local-tech**: solo build, hosted on a $5/mo Hetzner box (not Big Tech), free to users, opt-in analytics. Different shape than the typical "VC-backed app" story.
+- **Dining accessibility**: 30 Durango restaurants seeded for launch. Independent, not chains. The launch beta is essentially "can people with dietary restrictions eat at more local restaurants if the menu is filterable."
+
+Press kit (logo, screenshots, longer blurbs, contact): https://bite-worthy.com/press
+
+Happy to do an interview, share early access, or just answer questions over email. Embargo lifts [DATE].
+
+Thanks for considering,
+Skylar Bolton
+hello@bite-worthy.com
++1 (970) [phone]
+
+---
+
+**Follow-up after 3 days, if no reply:**
+
+> Subject: Re: Durango Herald: AI menu-reader app launches here in [N] days
+>
+> Hi [Editor first name] — quick follow-up; happy to send specifics or screenshots if helpful. Launch is [N] days out. — Skylar

--- a/docs/outreach/durango-telegraph.md
+++ b/docs/outreach/durango-telegraph.md
@@ -1,0 +1,35 @@
+# Durango Telegraph — pitch
+
+**Beat:** weekly local paper, strong dining + culture coverage.
+**Best contact:** dining editor (find current name in masthead).
+
+---
+
+**Subject:** Durango Telegraph: a local-built dietary filter for our restaurant scene
+
+Hi [Editor first name],
+
+Long-time reader. I built a free app called BiteWorthy and the Durango beta launches in [N] days — wanted to give the Telegraph the first look since dining is your beat and this is built specifically around our restaurant scene.
+
+The pitch is short: scan any menu (camera, photo library, or paste a link to a PDF) and BiteWorthy hides the dishes that aren't safe for your dietary needs — celiac, allergies, vegan, whatever. Each hidden dish says *why* ("Contains dairy (cheese)"), so people aren't guessing.
+
+What might be Telegraph-shaped:
+- The seed beta covers 30 independent Durango restaurants — Ninis Taqueria, Cream Bean & Berry, Olde Tymer's, etc. Not chains. The point is the indie scene.
+- It's free, no ads, no data resale. Built solo, in town.
+- The local-first framing matches a "Durango makes its own software" angle if you want one.
+
+Press kit (logo, screenshots, blurbs, contact): https://bite-worthy.com/press
+
+Happy to walk you through it on a call, demo on real menus, or just send screenshots — whatever's easiest. Embargo lifts [DATE].
+
+Thanks for considering it,
+Skylar Bolton
+hello@bite-worthy.com
+
+---
+
+**Follow-up after 3 days, if no reply:**
+
+> Subject: Re: Durango Telegraph: a local-built dietary filter for our restaurant scene
+>
+> Hi [Editor first name] — quick bump in case the original got buried. Launch is [N] days out; happy to share early access if it's useful for a pre-launch piece. — Skylar

--- a/docs/outreach/ksut.md
+++ b/docs/outreach/ksut.md
@@ -1,0 +1,36 @@
+# KSUT FM — pitch
+
+**Beat:** local NPR affiliate. Human-interest + community-arts segments.
+**Best contact:** Tami Graham (programming director, last verified) OR producer of the local segment.
+
+---
+
+**Subject:** KSUT: a human-interest segment on a Durango app for diners with allergies
+
+Hi Tami,
+
+I'm a long-time KSUT listener and wanted to pitch something that might fit a human-interest spot on the local segment.
+
+I built a free app called BiteWorthy that helps people with dietary restrictions eat out more easily. You scan a restaurant menu with your phone and the app hides the dishes you can't eat — celiac, allergies, vegan, whatever. Built solo here in Durango; the launch beta covers 30 local restaurants.
+
+What might be radio-shaped:
+- It started because watching someone with celiac navigate a menu in Durango is genuinely stressful — the answer is a lot of "let me ask the kitchen" + a lot of bowls of rice.
+- The app is free, no ads, opt-in analytics. The launch is here because Durango is where I live and where I tested it.
+- I can talk to the dietary-accessibility angle, the local-software-built-by-a-resident angle, or both.
+
+Happy to come in and record a short segment, or just do a phone interview if that's lighter lift. Launch is [N] days out.
+
+Press kit (logo, blurbs, contact): https://bite-worthy.com/press
+
+Thanks for considering,
+Skylar Bolton
+hello@bite-worthy.com
++1 (970) [phone]
+
+---
+
+**Follow-up after 5 days, if no reply** (KSUT scheduling cycle is slower):
+
+> Subject: Re: KSUT: a human-interest segment on a Durango app for diners with allergies
+>
+> Hi Tami — bumping this; happy to push the launch date a couple days if it lines up better with a recording window. — Skylar

--- a/docs/outreach/la-plata-mountaineer.md
+++ b/docs/outreach/la-plata-mountaineer.md
@@ -1,0 +1,32 @@
+# La Plata Mountaineer — pitch
+
+**Beat:** weekly community paper. Community events + locally-made things.
+**Best contact:** general editor (community-events focus).
+
+---
+
+**Subject:** La Plata Mountaineer: a Durango-built app that makes eating out easier
+
+Hi [Editor first name],
+
+Wanted to share something I'm launching for the local community: BiteWorthy, a free app that lets people with dietary restrictions — celiac, allergies, vegan, etc. — scan any restaurant menu and see only what they can eat. Built it in Durango, launch beta covers 30 local restaurants.
+
+The community angle that might fit the Mountaineer: dining out is hard for a lot of people in town with allergies or specific diets, and a lot of independent restaurants don't have the bandwidth to maintain detailed allergen menus. BiteWorthy meets in the middle — the app reads the menu, applies the filter, shows what's safe with a *why*.
+
+Free, no ads, opt-in analytics. I built it solo here.
+
+Press kit (logo, screenshots, blurbs): https://bite-worthy.com/press
+
+Happy to share early access, send screenshots, or do a quick call. Launch is [N] days out.
+
+Thanks,
+Skylar Bolton
+hello@bite-worthy.com
+
+---
+
+**Follow-up after 3 days, if no reply:**
+
+> Subject: Re: La Plata Mountaineer: a Durango-built app that makes eating out easier
+>
+> Hi [Editor first name] — bumping this in case it got buried. Launch is [N] days; would love to be in the launch issue if there's space. — Skylar

--- a/docs/outreach/launch-day.md
+++ b/docs/outreach/launch-day.md
@@ -1,0 +1,62 @@
+# Launch-day social posts
+
+Stage these the night before. Post on the morning of the launch — Tuesday or Wednesday tend to land best for Durango-area engagement (Friday gets buried in weekend planning).
+
+## Twitter / X
+
+> BiteWorthy is live in Durango.
+>
+> Free dietary filter for restaurant menus — celiac, allergies, vegan, build-your-own. Scan any menu, see only what you can eat. Hidden dishes each say *why*.
+>
+> 30 local restaurants seeded. No ads.
+>
+> 🔗 https://bite-worthy.com
+>
+> #Durango #GlutenFree #Allergies #Vegan
+
+**Image:** the hero screenshot from `apps/mobile/store-listing/screenshots-plan.md` #1 (filtered restaurant page with a dish hidden + the "Contains dairy (cheese)" chip).
+
+**Reply with:** the App Store + Play Store deep links once they're real (Phase 5.9-wiring).
+
+## Bluesky
+
+Same body as Twitter. Bluesky's character ceiling is higher (300) so add one extra line:
+
+> Built solo, in Durango, on cheap independent infrastructure. The whole launch costs less per month than dinner for two.
+
+## Instagram
+
+Single-image post (the hero screenshot). Caption:
+
+> BiteWorthy is live in Durango.
+>
+> A free dietary filter for restaurant menus. Scan any menu — camera, photo, link — and see only the dishes you can eat. Hidden ones tell you *why*.
+>
+> Built for celiac, allergies, vegan, and every other dietary need. Built for our independent restaurant scene specifically.
+>
+> Link in bio.
+>
+> #Durango #DurangoColorado #DurangoFood #GlutenFree #CeliacLife #Vegan #FoodAllergies
+
+**Stories:** five-frame walkthrough (Scan → Filter → Hidden chip → Show anyway → Reviews) using the same screenshots from the store-listing plan.
+
+## LinkedIn
+
+Audience here is more "founders / techies who happen to live in southwest Colorado":
+
+> BiteWorthy is live in Durango.
+>
+> A free dietary filter for restaurant menus — built solo, on cheap independent infrastructure (Hetzner CX22, Neon, Cloudflare R2, Vercel for the web — total ~$5/mo all-in), open-sourced.
+>
+> Free, no ads, opt-in analytics. The dietary filter is byte-identical between web and mobile because it's a single TypeScript package both apps import.
+>
+> If you build app-shaped products and want to see how this is wired, the repo is at https://github.com/Sky-Fox-Studios/biteworthy. The decision records (ADR 0001–0007) walk through the stack picks honestly.
+>
+> Launch beta covers 30 Durango restaurants. Scaling-up city-by-city if the funnel proves out.
+
+## Day-of timing
+
+- **Morning** (8–9am MT): post Twitter + Bluesky + Instagram + LinkedIn in that order.
+- **+2 hours**: reply to Twitter post with the press-page URL + a "we'd love coverage; press kit at /press" line, in case it gets retweet velocity.
+- **+4 hours**: send "we're live" follow-up email to the 4 outreach outlets — short, just confirming the embargo is up + including the App Store / Play Store links.
+- **End of day**: thank-you reply to anyone who shared/quoted/responded. Personal, not template.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,11 +13,11 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
 
-1. **Phase 5.1.1 — migrate API hosting from Fly.io to Kamal + Hetzner CX22 + Neon Postgres** (`docs/plans/phase-5.md#511--migrate-api-hosting-to-kamal--hetzner-cx22--neon-postgres`) — this PR (the next loop tick picks it up). Reverses the original 5.1 Fly.io pick at human request. Ships the deploy.yml + ADR 0007 + README rewrite + secrets template; the Hetzner box, Neon project, GHCR token, and DNS A-record are the human bootstrap. Reuses unchanged: Dockerfile, docker-entrypoint, smoke task, and every Phase 5.2+ wiring.
-2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that. Holdover from Phase 4.11; not a launch blocker (the structural code is on master) but should land before Phase 5.7's seed task mass-ingests real Durango menus.
-3. **Phase 5.10 — press kit + Durango outreach** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`).
-4. **Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179; needs `posthog-js` + `posthog-react-native` installed and the call-site instrumentation.) Decoupled because each surface PR is small + reviewable on its own.
-5. **Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180; needs Apple/Google dev accounts + lawyer signoff on /privacy + /terms).
+1. **Phase 5.10 — press kit + Durango outreach + waitlist** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`) — this PR. **Last code-only Phase-5 PR** — after it merges, every loop-shippable launch piece is on master.
+2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that.
+3. **Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179; needs `posthog-js` + `posthog-react-native` installed and the call-site instrumentation.) Decoupled because each surface PR is small + reviewable on its own.
+4. **Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180; needs Apple/Google dev accounts + lawyer signoff on /privacy + /terms).
+5. **Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182; small. Manual deploys first; automate after first manual deploy is proven).
 
 ### Done
 
@@ -75,7 +75,8 @@ the merge / review / status rules.
 - ✅ Phase 5.7 — durango batch ingest task + csv template (#178)
 - ✅ Phase 5.8 — analytics abstraction + event taxonomy (#179) — **structural; wiring follow-up queued at Next-up #4**
 - ✅ Phase 5.9 — privacy + terms + app store listing templates (#180) — **structural; wiring follow-up queued at Next-up #5**
-- ✅ Phase 5.1.1 — plan: switch API hosting to Kamal + Hetzner + Neon (#181) — implementation lands in this PR
+- ✅ Phase 5.1.1 — plan: switch API hosting to Kamal + Hetzner + Neon (#181)
+- ✅ Phase 5.1.1 — implementation: deploy.yml + .kamal + ADR 0007 (#182) — **API hosting story rewritten; Fly.io retired before live deploy**
 
 After Phase 4 ships, the loop will draft `docs/plans/phase-5.md` (Durango launch) the same way.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,41 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 22:50 — tick #88. PR #182 (Phase 5.1.1 Kamal+Hetzner+Neon
+migration) merged at 22:23 UTC. Anthropic still capped (~1.2h to
+reset); cassette PR stays BLOCKED. Picked the next unblocked
+item: **Phase 5.10 — press kit + waitlist + Durango outreach** —
+the last code-only Phase-5 PR. Shipped:
+- **Waitlist** (API): `create_waitlist_signups` migration with
+  citext email + unique idx; WaitlistSignup model with lenient
+  EMAIL_REGEX + source allowlist; WaitlistMailer.confirm via the
+  Phase 5.2 SMTP pipeline; POST /api/v1/waitlist_signups
+  (anonymous, 200 on new+duplicate, 422 on malformed email). 12
+  specs (7 model + 5 request) covering normalize, citext dedup,
+  source allowlist, controller idempotence, mailer fires once.
+- **Waitlist** (web): /api/waitlist Next proxy + lib/waitlist.ts
+  (fetcher + isValidEmail) + _waitlist-form.tsx client island on
+  the marketing landing under the existing CTAs. Idle/sending/
+  done/error states inline; no full-page reload. 7 vitest cases.
+- **/press page**: SSR with 50-word + 200-word blurbs, founder
+  line, contact, placeholder logo links (Phase 5.9-wiring renders
+  binaries). Reuses buildLegalMetadata.
+- **docs/outreach/**: 5 templates calibrated per outlet — Durango
+  Telegraph (dining beat), Durango Herald (business + tech), La
+  Plata Mountaineer (community-events), KSUT (NPR human-interest,
+  slower follow-up cycle), launch-day.md (Twitter/Bluesky/IG/
+  LinkedIn posts + day-of timing). README cross-references the
+  press page + send order.
+Total: rspec 377/0/1 (+12); web vitest 99/99 (+7); pnpm typecheck
++ lint full-turbo green. Roadmap: ticked 5.1.1 (#182) + 5.1.1
+plan (#181); reordered Next-up — this 5.10 PR at #1, then the
+human-credential-gated wiring PRs (5.8/5.9/5.1.1) + the BLOCKED
+cassette. **Phase 5 status after #183 merges**: every loop-
+shippable launch piece is on master. Remaining work is entirely
+human-gated (Anthropic cap retry, PostHog/Apple/Google accounts,
+lawyer signoff, the actual `kamal deploy` from a laptop).
+Anthropic cap clears in ~1.2h.
+
 2026-04-30 22:21 — tick #87. PR #181 (Phase 5.1.1 plan) merged at
 22:14 UTC; PR #180 (Phase 5.9 structural) also merged earlier.
 Anthropic still capped (~1.6h to reset); cassette PR stays


### PR DESCRIPTION
## Why

Phase 5.10 from `docs/plans/phase-5.md` — **last code-only Phase-5 PR.** Ships the press page, the soft-launch waitlist (form + API + confirmation mailer), and the four Durango-press outreach email templates + launch-day social posts.

After this merges, every loop-shippable launch piece is on master. Remaining work is entirely human-gated.

## What

### API — waitlist signup

- **Migration** `create_waitlist_signups`: citext `email` + unique idx (case-insensitive dedup), `source` string with allowlist (`landing` / `press` / `footer` / `mobile_app`), `confirmed_at` left for a future double-opt-in if Postmark deliverability requires it.
- **`WaitlistSignup`** model: lenient `EMAIL_REGEX` (Postmark's bounce handling is the real filter), source allowlist, `normalize_email` (lowercase + strip) before validation.
- **`WaitlistMailer.confirm`** — single informational mail through the Phase 5.2 SMTP pipeline. Text + HTML templates.
- **`POST /api/v1/waitlist_signups`** — public + unauthenticated. **200 on both new and duplicate** (don't leak whether the address was already in the list); 422 only on malformed email. Mailer is best-effort (`deliver_later rescue nil`) so Postmark queueing failures never block the response.

### Web — press page + waitlist form

- **`/press`** SSR page: 50-word + 200-word blurbs, founder line, contact, placeholder logo links (Phase 5.9-wiring renders the binaries). Reuses `buildLegalMetadata`.
- **`_waitlist-form.tsx`** client island (underscore-prefix keeps Next from registering it as a route) on the marketing landing under the existing CTAs. Idle/sending/done/error states inline; no full-page reload.
- **`apps/web/src/lib/waitlist.ts`** — `isValidEmail` (lenient regex matching the API's), `submitWaitlist` fetcher, `WaitlistError`.
- **`apps/web/src/app/api/waitlist/route.ts`** — Next proxy keeping `NEXT_PUBLIC_API_BASE` server-side.

### docs/outreach/ — 5 templates

Calibrated per outlet — same product, different angle:

- **`durango-telegraph.md`** — dining beat
- **`durango-herald.md`** — business + tech beat  
- **`la-plata-mountaineer.md`** — community-events angle
- **`ksut.md`** — NPR human-interest (slower scheduling cycle, follow-up bumped to 5 days)
- **`launch-day.md`** — Twitter/Bluesky/Instagram/LinkedIn posts + day-of timing
- **`README.md`** — cross-references the press page + send order

## Tests

- **API**: 12 new specs (7 model + 5 request) covering email normalization, citext dedup at the DB level, source allowlist, controller idempotence on duplicates, mailer fires once. **rspec 377/0/1 pending** (+12).
- **Web**: 7 new vitest cases for the helpers (email validation branches, fetcher URL/headers/body, default source, duplicate flag, `WaitlistError` on 422). **Web vitest 99/99** (+7).
- `pnpm typecheck` + `pnpm lint`: full-turbo cached green.

## Phase 5 status after this merges

**Every loop-shippable Phase 5 piece is on master.** Remaining queue is entirely human-gated:

- **[BLOCKED]** Phase 4.11.0/4.11.2-cassette — Anthropic cap clears at 2026-05-01 00:00 UTC (~1.2h from this PR).
- **Phase 5.8-wiring** — needs PostHog credentials + `posthog-js` install.
- **Phase 5.9-wiring** — needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on /privacy + /terms + binary asset generation.
- **Phase 5.1.1-wiring** — CI deploy automation (small follow-up after first manual `kamal deploy` proves out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)