### PR TITLE
docs: queue housekeeping + tick #90 (anthropic cap reset imminent)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,13 +11,14 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
-**Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`.
+**Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`. **Loop work complete** — every code-only PR is on master. The full state-of-the-world checklist for the human is at `docs/launch-readiness.md`.
 
-1. **Phase 5.10 — press kit + Durango outreach + waitlist** (`docs/plans/phase-5.md#510--press-kit--outreach-durango-launch`) — this PR. **Last code-only Phase-5 PR** — after it merges, every loop-shippable launch piece is on master.
-2. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Blocked on Anthropic daily-cap reset at 2026-05-01 00:00 UTC** — retry after that.
-3. **Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179; needs `posthog-js` + `posthog-react-native` installed and the call-site instrumentation.) Decoupled because each surface PR is small + reviewable on its own.
-4. **Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180; needs Apple/Google dev accounts + lawyer signoff on /privacy + /terms).
-5. **Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182; small. Manual deploys first; automate after first manual deploy is proven).
+Every Next-up item below is `[BLOCKED]` on a human action. The loop pauses here and pings; the next tick after a credential drop can pick the corresponding wiring item up.
+
+1. **[BLOCKED] Phase 4.11.0 / 4.11.2-cassette — Record the live AnthropicClient cassette** (combined: VCR's body matching means the 4.11.2 prompt change auto-supersedes the older cassette; one recording covers both). **Cap resets at 2026-05-01 00:00 UTC** — the loop's next tick after that will attempt the recording automatically. If still 4xx, requires a human with `ANTHROPIC_API_KEY` + Anthropic billing tier confirmed.
+2. **[BLOCKED] Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179). Needs PostHog account + project API key; then `pnpm add posthog-js -F @biteworthy/web` + `pnpm add posthog-react-native -F @biteworthy/mobile` + call-site instrumentation per `docs/analytics.md`.
+3. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
+4. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
 ### Done
 
@@ -78,6 +79,7 @@ the merge / review / status rules.
 - ✅ Phase 5.1.1 — plan: switch API hosting to Kamal + Hetzner + Neon (#181)
 - ✅ Phase 5.1.1 — implementation: deploy.yml + .kamal + ADR 0007 (#182) — **API hosting story rewritten; Fly.io retired before live deploy**
 - ✅ Phase 5.10 — press kit + waitlist + Durango outreach templates (#183) — **last code-only Phase 5 PR**
+- ✅ Launch-readiness checklist + loop pause (#184) — `docs/launch-readiness.md` is the human's linear path from "code complete" to launch.
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,29 @@ without spelunking GitHub.
 
 ---
 
+2026-04-30 23:41 — tick #90. **Queue housekeeping.** PR #184
+(launch-readiness checklist) merged at 23:16 UTC. Anthropic cap
+clears in ~19 min — too early to retry the cassette this tick
+without burning another failed attempt. Read the queue: it was
+stale (Phase 5.10 still listed as #1 even though it merged in
+tick #88) + the wiring items weren't `[BLOCKED]`-prefixed despite
+all needing human credentials. Cleanup-only PR:
+- Removed the merged Phase 5.10 entry from Next-up.
+- Marked the four remaining wiring items as `[BLOCKED]` with the
+  specific human action that unblocks each.
+- Added a "Loop work complete; see launch-readiness.md" banner
+  at the top of Next-up so future readers (or future loop ticks)
+  see the launch-readiness pointer immediately.
+- Ticked PR #184 in the Done section so the audit trail is
+  complete.
+No code, no test deltas (rspec 377/0/1, web vitest 99/99 unchanged
+since #183). The next loop tick lands ~1 minute after Anthropic's
+cap reset and will see the cassette item as the topmost
+`[BLOCKED]` with "cap resets at 00:00 UTC" — the loop should
+attempt the recording then. If still 4xx, pause + ping. If
+recording succeeds, the cassette PR fires (cassette + spec
+update flipping the `skip` block to `VCR.use_cassette`).
+
 2026-04-30 23:11 — tick #89. **Loop pauses for credentials.** PR #183
 (Phase 5.10) merged at 22:51 UTC. Anthropic cap clears in ~49 min;
 the next tick can attempt the cassette retry but THIS tick is too


### PR DESCRIPTION
## Why

PR #184 (launch-readiness) merged at 23:16 UTC. Anthropic cap resets at 2026-05-01 00:00 UTC — only ~19 min from this PR, too early to retry the cassette without burning another failed attempt. Honest tick: small queue cleanup so the post-cap-reset tick sees an ordered queue.

## What

`docs/roadmap.md` Next-up:
- Removed the merged Phase 5.10 entry (still listed as #1 even though #183 merged in tick #88).
- Marked all four remaining wiring items as `[BLOCKED]` with the specific human action that unblocks each (PostHog account; Apple/Google dev accounts + lawyer signoff; Hetzner+Neon+GHCR provisioning).
- Added a "Loop work complete; see `launch-readiness.md`" banner at the top of Next-up.

`docs/roadmap.md` Done: ticks PR #184.

`docs/status.md`: tick #90 entry noting why the loop did housekeeping rather than implementation work this tick.

## What's NOT in this PR

- Cassette retry (still 19 min too early — next tick handles it).
- Any code changes. rspec 377/0/1 + web vitest 99/99 unchanged since #183.

## What happens next

The next 30-min cron tick lands shortly after Anthropic's 00:00 UTC cap reset. The roadmap will then show the cassette item as the topmost `[BLOCKED]` (with "cap resets at 00:00 UTC" annotation) and the loop should attempt the recording.

If the recording succeeds, the next-tick PR contains the cassette + the spec change flipping `extract_menu_job_spec.rb`'s `skip` to `VCR.use_cassette`. If still 4xx, the loop pauses again and pings — Anthropic billing tier confirmation is the human action that unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)