### PR TITLE
docs: tick #92 — loop fully paused on credential-gated wiring queue

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,32 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 00:42 — tick #92. **Loop paused — no actionable code work.**
+PR #186 (cassette recording) merged at 00:16 UTC. Phase 4.11 is
+fully complete; every code-only Phase-5 PR is on master; the
+cassette is recorded. Re-read the Next-up queue: every remaining
+item is `[BLOCKED]` on a human credential drop the loop cannot
+make:
+- Phase 5.8-wiring → PostHog account + project API key
+- Phase 5.9-wiring → Apple Developer ($99/yr) + Google Play
+  Console ($25 one-time) + lawyer signoff on /privacy + /terms
+- Phase 5.1.1-wiring → Hetzner CX22 + Neon project + GHCR PAT +
+  DNS A-record (this one unblocks step 1 of the chain)
+None of these have moved since tick #89 noted the same pause.
+The loop has nothing new to ship. **Posture unchanged**: the
+human's playbook is `docs/launch-readiness.md`; the next loop
+tick will see the same all-blocked queue and pause again. Most
+useful thing the loop can do now is stop noisy PRs and wait
+for a credential-drop signal in the form of a roadmap edit
+(human promotes a Discovered followup → Next-up, OR a wiring
+item gets unblocked).
+**Discovered followups still open** (not promoted to Next-up):
+- jest-expo + web `@testing-library/react` wiring — would
+  unlock UI-snapshot tests across web + mobile.
+- Auto-merge race (third occurrence not yet observed since #172).
+- Restaurant `neighborhood` column for Phase 5.6 SEO pages.
+None of these are launch blockers; humans triage when ready.
+
 2026-05-01 00:15 — tick #91. **Cassette recorded.** PR #185
 (housekeeping) merged at 23:45 UTC. Anthropic cap reset at
 00:00 UTC happened cleanly; the loop's first post-reset attempt


### PR DESCRIPTION
## Why

Per playbook §7 stop conditions: every Next-up item is `[BLOCKED]`. The loop has nothing code-shippable to do.

PR #186 (cassette recording) merged at 00:16 UTC and that was the last loop-shippable line item. Phase 4.11 is fully complete; every code-only Phase-5 PR is on master. The only remaining work is human-credential-gated.

## What

`docs/status.md` tick #92 entry documenting:
- The continuing pause posture.
- Which credentials unblock which wiring item.
- The Discovered followups still open but not promoted to Next-up (jest-expo + RTL wiring; auto-merge race; restaurant neighborhood column).

No code, no test deltas. `pnpm typecheck` + `pnpm lint`: full-turbo cached green.

## What happens next

The 30-min cron will keep firing. Each tick will:
1. Confirm there's no open `claude-cd` PR.
2. Read the queue — see only `[BLOCKED]` items.
3. Append a status entry noting the continuing pause.
4. Re-ping if anything new is worth flagging.

This will be repetitive until something unblocks. The most useful response is to **stop opening status-only PRs** unless something material changes — let the loop go quiet and wait for a signal from the human side.

@shadoath — three things would unblock material progress, in roughly the order that compounds:

1. **Hetzner CX22 + Neon project + GHCR PAT + DNS** — see `docs/launch-readiness.md` step 1. Unblocks the actual API at `api.bite-worthy.com`, which then unblocks the seed task, which lights up `/durango/[diet]` with real data.
2. **PostHog account + key** — independent of #1. Unblocks the Phase 5.8-wiring PR (~30 min of work once the key exists).
3. **Apple Developer + Google Play Console + lawyer** — independent of #1 and #2. Unblocks the Phase 5.9-wiring PR (binary asset render, screenshot routes, EAS submit).

Or: promote a Discovered followup into Next-up if you'd rather have the loop work on test-infra (jest-expo + web RTL wiring) instead of waiting for credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)