### PR TITLE
feat(mobile): wire jest-expo + @testing-library/react-native for component render tests

### DIFF
--- a/apps/mobile/__tests__/screens/restaurant-screen.render.test.tsx
+++ b/apps/mobile/__tests__/screens/restaurant-screen.render.test.tsx
@@ -1,0 +1,88 @@
+// Mock expo-router so importing the screen module doesn't pull the
+// full Stack/Tabs runtime — we only need its named exports here.
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+  useLocalSearchParams: () => ({}),
+  Link: 'Link',
+}));
+
+import { render, screen } from '@testing-library/react-native';
+import { HiddenReasonChip, StrictnessToggle } from '../../app/restaurants/[id]';
+
+/**
+ * Phase post-5 — first JSX render tests for the mobile app.
+ *
+ * Targets the already-exported helpers (HiddenReasonChip,
+ * StrictnessToggle) on the restaurant screen — same as the web
+ * counterpart in PR #189. Proves the jest-expo + testing-library/
+ * react-native infra works end-to-end on Expo SDK 52.
+ *
+ * The Phase 4.11.4 ItemRow photo_url contract on mobile isn't
+ * covered here — ItemRow is a file-private component inside
+ * `app/restaurants/[id].tsx`, and extracting it is a separate
+ * scoped follow-up (mirrors the web pattern from PR #190).
+ */
+
+describe('HiddenReasonChip (mobile)', () => {
+  it('renders the avoid_ingredient label with name + family', () => {
+    render(
+      <HiddenReasonChip
+        reason={{
+          kind: 'avoid_ingredient',
+          ingredient_id: 'ing-1',
+          ingredient_name: 'Cheddar',
+          ingredient_family: 'dairy',
+        }}
+      />,
+    );
+    expect(screen.getByTestId('chip-avoid_ingredient')).toBeOnTheScreen();
+    expect(screen.getByText('Contains dairy (Cheddar)')).toBeOnTheScreen();
+  });
+
+  it('renders the avoid_tag label with name + family', () => {
+    render(
+      <HiddenReasonChip
+        reason={{
+          kind: 'avoid_tag',
+          tag_id: 'tag-1',
+          tag_name: 'Contains Dairy',
+          tag_family: 'allergen',
+        }}
+      />,
+    );
+    expect(screen.getByText('Tagged allergen: Contains Dairy')).toBeOnTheScreen();
+  });
+
+  it('renders the unconfirmed_strict label with the confidence value', () => {
+    render(
+      <HiddenReasonChip
+        reason={{ kind: 'unconfirmed_strict', confidence: 'inferred' }}
+      />,
+    );
+    expect(screen.getByText(/inferred/)).toBeOnTheScreen();
+  });
+});
+
+describe('StrictnessToggle (mobile)', () => {
+  it('renders all three strictness modes with the active one selected', () => {
+    render(
+      <StrictnessToggle active="balanced" loading={false} onChange={() => {}} />,
+    );
+
+    const balanced = screen.getByLabelText('strictness-balanced');
+    expect(balanced).toBeOnTheScreen();
+    expect(balanced.props.accessibilityState).toMatchObject({ selected: true, disabled: false });
+
+    const strict = screen.getByLabelText('strictness-strict');
+    expect(strict.props.accessibilityState).toMatchObject({ selected: false, disabled: false });
+  });
+
+  it('disables every Pressable + shows the spinner while loading', () => {
+    render(
+      <StrictnessToggle active="strict" loading={true} onChange={() => {}} />,
+    );
+    const relaxed = screen.getByLabelText('strictness-relaxed');
+    expect(relaxed.props.accessibilityState).toMatchObject({ selected: false, disabled: true });
+    expect(screen.getByTestId('strictness-spinner')).toBeOnTheScreen();
+  });
+});

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,0 +1,26 @@
+/**
+ * Phase post-5 — jest config for the mobile app.
+ *
+ * jest-expo is the canonical preset for Expo SDK 52. Without it,
+ * importing any screen module fails with "Cannot use import
+ * statement outside a module" (the issue the Discovered note has
+ * flagged since Phase 3.5).
+ *
+ * Override `transformIgnorePatterns` because pnpm's nested layout
+ * — `node_modules/.pnpm/@react-native+js-polyfills@.../node_modules/...`
+ * — doesn't match the upstream pattern that assumes a flat npm
+ * layout. The override permits transformation for any path that
+ * mentions react-native, expo, or @react-native, regardless of
+ * pnpm's package directory naming.
+ *
+ * Existing pure-TS tests under __tests__/lib/ continue to pass —
+ * they don't import react-native modules directly (they mock
+ * expo-secure-store / fetch at the boundary).
+ */
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEach: ['./jest.setup.ts'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(?:.pnpm/)?(?:(jest-)?react-native|@react-native|@react-native-community|expo|@expo|react-native-.+|@react-navigation/.+))',
+  ],
+};

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -1,0 +1,11 @@
+/**
+ * Phase post-5 — jest setup file.
+ *
+ * @testing-library/react-native v12.4+ ships built-in matchers
+ * (toBeOnTheScreen, toHaveTextContent, etc.) — no separate
+ * jest-native import needed.
+ *
+ * The jest-expo preset handles RN globals + transformer config;
+ * this file is for future per-test-suite extensions.
+ */
+import '@testing-library/react-native/extend-expect';

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@biteworthy/eslint-config": "workspace:*",
+    "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/node": "^25.6.0",
     "@types/react": "~18.3.12",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,13 +13,13 @@ the merge / review / status rules.
 
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`. **Loop work complete** — every code-only Phase-5 PR is on master. The full state-of-the-world checklist for the human is at `docs/launch-readiness.md`.
 
-Web test-infra wiring shipped in PR #189; ItemRow extraction + Phase 4.11.4 photo_url snapshot ships in this PR. Mobile test-infra wiring (jest-expo + `@testing-library/react-native`) remains queued as the next loop-shippable item.
+Test-infra wiring shipped both sides (web in #189, mobile in this PR). Two outstanding test-infra followups remain.
 
-1. **Extract ItemRow + Phase 4.11.4 photo_url snapshot** — this PR. Pulls the file-private ItemRow out of `RestaurantClient.tsx` into its own file, lands the deferred render test asserting `<img>` appears with `src=photo_url` when set + doesn't render when null. Closes the original 4.11.4 deferral.
-2. **Mobile test-infra wiring (jest-expo + `@testing-library/react-native`)** — same Discovered note as the web wiring; deferred to its own PR because the configs differ enough that combining would muddy review. Once landed, retroactively add the deferred snapshots from Phases 3.2 / 3.3 / 3.4 / 3.5 / 4.11.4.
-2. **[BLOCKED] Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179). Needs PostHog account + project API key; then `pnpm add posthog-js -F @biteworthy/web` + `pnpm add posthog-react-native -F @biteworthy/mobile` + call-site instrumentation per `docs/analytics.md`.
-3. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
-4. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
+1. **Extract mobile ItemRow + Phase 4.11.4 photo `<Image>` snapshot** — mirrors web's PR #190. Small scoped refactor pulling the file-private ItemRow out of `apps/mobile/app/restaurants/[id].tsx`, plus the dish-photo render test asserting the `<Image>` renders with `source.uri = photo_url` when set + doesn't render when null.
+2. **Backfill Phase 3.x deferred snapshots** — Phases 3.2 / 3.3 / 3.4 / 3.5 each had a deferred mobile UI snapshot (the `jest-expo`-not-wired excuse from the original Discovered note). The infra is now in place; one PR (or a few) can backfill them.
+3. **[BLOCKED] Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179). Needs PostHog account + project API key; then `pnpm add posthog-js -F @biteworthy/web` + `pnpm add posthog-react-native -F @biteworthy/mobile` + call-site instrumentation per `docs/analytics.md`.
+4. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
+5. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
 ### Done
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,40 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 03:48 — tick #97. **Mobile test-infra wired.** PR #190
+(ItemRow + Phase 4.11.4 snapshot) merged at 03:16 UTC. Picked
+the mobile counterpart of the web test-infra work. Closes the
+mobile half of the long-standing Discovered followup. Shipped:
+- `apps/mobile/jest.config.js` — first jest config for mobile.
+  preset: jest-expo + a custom `transformIgnorePatterns` that
+  fixes the pnpm + jest-expo path mismatch (the upstream pattern
+  assumes a flat npm layout and skips files under
+  `node_modules/.pnpm/@react-native+js-polyfills@.../node_modules/`,
+  causing react-native's Flow-typed polyfill to not get
+  transformed → `SyntaxError: Unexpected identifier 'ErrorHandler'`
+  on every test). The override matches react-native, @react-native,
+  expo, @expo, and react-native-* whether or not under .pnpm/.
+- `pnpm add -D @testing-library/react-native -F @biteworthy/mobile`.
+  jest-expo@~52.0.2 was already installed since SDK 52 setup.
+- `apps/mobile/jest.setup.ts` registers v12.4+ matchers.
+- `apps/mobile/__tests__/screens/restaurant-screen.render.test.tsx`
+  — 5 cases mirroring web's PR #189: HiddenReasonChip with all
+  three reason kinds, StrictnessToggle's three modes + active
+  accessibilityState + loading state. Mocks expo-router at the
+  module boundary so importing the screen doesn't pull the full
+  Stack/Tabs runtime.
+Caught two real issues during setup:
+- pnpm + jest-expo transformIgnorePatterns mismatch (above).
+- @testing-library/react-native dropped `toHaveAccessibilityState`
+  in v12+; switched to direct prop assertions
+  (`expect(node.props.accessibilityState).toMatchObject(...)`).
+Result: mobile jest **65/65** (was 60/60; +5); typecheck (10/10)
++ lint (6/6) green; web vitest 112/112 + rspec 377/0/0 unchanged.
+Roadmap: ticked the stale Next-up #1; queued mobile ItemRow
+extraction (mirrors web PR #190) + Phase 3.x snapshot backfills
+as the next two test-infra followups; credential-gated wiring
+PRs at #3-#5.
+
 2026-05-01 03:15 — tick #96. **Phase 4.11.4 deferred snapshot landed.**
 PR #189 (test-infra wiring) merged at 02:47 UTC. Picked the
 finish-what-we-started followup: extract ItemRow from

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@biteworthy/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@testing-library/react-native':
+        specifier: ^13.3.3
+        version: 13.3.3(jest@29.7.0(@types/node@25.6.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -1539,6 +1542,10 @@ packages:
     resolution: {integrity: sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/diff-sequences@30.3.0':
+    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/environment@29.7.0':
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1554,6 +1561,10 @@ packages:
   '@jest/fake-timers@29.7.0':
     resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/globals@29.7.0':
     resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
@@ -1571,6 +1582,10 @@ packages:
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/source-map@29.6.3':
     resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
@@ -2002,6 +2017,9 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -2026,6 +2044,18 @@ packages:
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react-native@13.3.3':
+    resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      jest: '>=29.0.0'
+      react: '>=18.2.0'
+      react-native: '>=0.71'
+      react-test-renderer: '>=18.2.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
 
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
@@ -4310,6 +4340,10 @@ packages:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-diff@30.3.0:
+    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-docblock@29.7.0:
     resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4353,6 +4387,10 @@ packages:
   jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@30.3.0:
+    resolution: {integrity: sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-message-util@29.7.0:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
@@ -5303,6 +5341,10 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  pretty-format@30.3.0:
+    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
@@ -8249,6 +8291,8 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
 
+  '@jest/diff-sequences@30.3.0': {}
+
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -8275,6 +8319,8 @@ snapshots:
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
+
+  '@jest/get-type@30.1.0': {}
 
   '@jest/globals@29.7.0':
     dependencies:
@@ -8317,6 +8363,10 @@ snapshots:
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
+
+  '@jest/schemas@30.0.5':
+    dependencies:
+      '@sinclair/typebox': 0.34.49
 
   '@jest/source-map@29.6.3':
     dependencies:
@@ -8867,6 +8917,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@sinclair/typebox@0.34.49': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -8910,6 +8962,18 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.6.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      jest-matcher-utils: 30.3.0
+      picocolors: 1.1.1
+      pretty-format: 30.3.0
+      react: 18.3.1
+      react-native: 0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@18.3.1)
+      react-test-renderer: 18.3.1(react@18.3.1)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@25.6.0)
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -10400,8 +10464,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 10.2.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.2.1(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.1(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.2.1(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@10.2.1(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.2.1(jiti@1.21.7))
@@ -10423,7 +10487,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.2.1(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
@@ -10434,22 +10498,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.1(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.1(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3)
       eslint: 10.2.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.2.1(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.1(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10460,7 +10524,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.2.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.1(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@10.2.1(jiti@1.21.7))(typescript@5.9.3))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7)))(eslint@10.2.1(jiti@1.21.7))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11596,6 +11660,13 @@ snapshots:
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
 
+  jest-diff@30.3.0:
+    dependencies:
+      '@jest/diff-sequences': 30.3.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.3.0
+
   jest-docblock@29.7.0:
     dependencies:
       detect-newline: 3.1.0
@@ -11694,6 +11765,13 @@ snapshots:
       jest-diff: 29.7.0
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
+
+  jest-matcher-utils@30.3.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.3.0
+      pretty-format: 30.3.0
 
   jest-message-util@29.7.0:
     dependencies:
@@ -12826,6 +12904,12 @@ snapshots:
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  pretty-format@30.3.0:
+    dependencies:
+      '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
 


### PR DESCRIPTION
## Why

Companion to PR #189's web wiring. Closes the **mobile half of the long-standing Discovered followup** (jest-expo not wired; UI snapshots impossible across Phases 3.2 / 3.3 / 3.4 / 3.5 / 4.11.4). Mobile UI snapshots are now possible; this PR ships the infra + 5 sample render tests.

## What

### Deps + config

- `pnpm add -D @testing-library/react-native -F @biteworthy/mobile`. `jest-expo@~52.0.2` was already installed since SDK 52 setup.
- **`apps/mobile/jest.config.js`** — first jest config for mobile. `preset: 'jest-expo'` + a custom `transformIgnorePatterns` that fixes the **pnpm + jest-expo path mismatch**: the upstream pattern assumes a flat npm layout and skips files under `node_modules/.pnpm/@react-native+js-polyfills@.../node_modules/`, causing react-native's Flow-typed polyfill to never get transformed → `SyntaxError: Unexpected identifier 'ErrorHandler'` on every test. The override matches `react-native`, `@react-native`, `expo`, `@expo`, and `react-native-*` whether or not they sit under `.pnpm/`.
- **`apps/mobile/jest.setup.ts`** — registers `@testing-library/react-native@v12.4+`'s built-in matchers.

### Render tests

`apps/mobile/__tests__/screens/restaurant-screen.render.test.tsx` — 5 cases mirroring PR #189's web pattern:

- `HiddenReasonChip` for all three reason kinds (`avoid_ingredient`, `avoid_tag`, `unconfirmed_strict`).
- `StrictnessToggle`'s three modes with active accessibilityState + loading state with spinner + disabled pressables.

Mocks `expo-router` at the module boundary so importing `app/restaurants/[id]` doesn't pull the full Stack/Tabs runtime — same pattern `auth.test.ts` uses for `expo-secure-store`.

## Tests

- **Mobile jest: 65/65** (was 60/60; +5).
- `pnpm typecheck`: 10/10 green.
- `pnpm lint`: 6/6 green.
- Web vitest 112/112 + rspec 377/0/0 unchanged.

## Caught two real issues during setup

1. **pnpm + jest-expo `transformIgnorePatterns` mismatch** (above). Fixed in this PR; the override is documented inline in the jest config so future readers understand why the upstream preset alone isn't enough.
2. **`@testing-library/react-native` dropped `toHaveAccessibilityState`** in v12+. Switched to direct prop assertions (`expect(node.props.accessibilityState).toMatchObject(...)`).

## Out of scope (separate follow-ups)

- **Mobile ItemRow extraction + Phase 4.11.4 dish-photo `<Image>` snapshot** — mirrors web's PR #190. Small scoped refactor; logged for next.
- **Backfill Phase 3.x deferred snapshots** — Phases 3.2 / 3.3 / 3.4 / 3.5 each had a deferred mobile UI snapshot blocked on this preset wiring. Now possible; one PR (or a few) can backfill them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)