### PR TITLE
fix(mobile): de-flake onboarding 'renders a chip per preset' test

### DIFF
--- a/apps/mobile/__tests__/screens/onboarding.render.test.tsx
+++ b/apps/mobile/__tests__/screens/onboarding.render.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../lib/auth', () => ({
   getJwt: jest.fn(() => Promise.resolve(null)),
 }));
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import OnboardingScreen from '../../app/onboarding/index';
 
 /**
@@ -90,11 +90,18 @@ describe('OnboardingScreen — Step 1: presets', () => {
   it('renders a chip per preset once the fetch resolves', async () => {
     render(<OnboardingScreen />);
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('presets-loading')).toBeNull();
-    });
+    // findBy* polls (default ~1000ms) for the chip — proves the fetch
+    // resolved AND React rendered the new state. Originally written
+    // as `waitFor(() => queryByTestId('presets-loading') is null)` +
+    // synchronous chip assertions, but that flaked under CI: setPresets
+    // (in `.then`) and setLoadingPresets(false) (in `.finally`) are
+    // separate promise callbacks, and React 18's automatic batching
+    // groups them inconsistently across runs — sometimes the spinner
+    // disappears in a render before the chips appear, sometimes after.
+    // findBy on the chip directly waits for the post-batched DOM.
+    await screen.findByLabelText('preset-vegan');
 
-    expect(screen.getByLabelText('preset-vegan')).toBeOnTheScreen();
+    expect(screen.queryByTestId('presets-loading')).toBeNull();
     expect(screen.getByText('Vegan')).toBeOnTheScreen();
     expect(screen.getByText('No animal products.')).toBeOnTheScreen();
     expect(screen.getByLabelText('preset-gluten-free')).toBeOnTheScreen();

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,39 @@ without spelunking GitHub.
 
 ---
 
+2026-05-01 18:30 — tick #125. **Loop unpaused to fix a CI flake I
+introduced.** ~13 hours of silent paused ticks (#104-#124) with no
+queue change. Then dependabot opened PR #198 (actions/setup-node
+v4→v6) and its `ci-js.yml` failed on `__tests__/screens/onboarding
+.render.test.tsx` test 2 ("renders a chip per preset once the fetch
+resolves") — 5s timeout. The test was introduced by my PR #193 in
+tick #99. Local + CI behavior diverged because the test combined
+`waitFor(() => queryByTestId('presets-loading') is null)` (polling
+for the spinner to disappear) with synchronous chip assertions —
+but `setPresets` (in `.then`) and `setLoadingPresets(false)` (in
+`.finally`) are separate promise callbacks, and React 18 batches
+them inconsistently across runs. Sometimes the spinner is gone
+before chips render, sometimes after.
+
+Switched to `findByLabelText('preset-vegan')` which polls for the
+chip directly — the post-batched DOM. Matches the pattern other
+tests in the file already use. Removed the now-unused `waitFor`
+import. Triple-ran the suite locally; stable at 8/8 each run.
+
+Result: mobile jest **80/80** unchanged; typecheck (10/10) + lint
+(6/6) green; web vitest 112/112 + rspec 377/0/0 unaffected.
+
+Notes from the silent window:
+- Dependabot PRs #196 (actions/labeler v5→v6) and #197 (actions/
+  checkout v4→v6) auto-merged cleanly during the pause; master
+  advanced to 395a301 without loop intervention.
+- PR #198 surfaced the flake. Once this PR (#199) merges, PR #198
+  should pass on its next CI re-run (or dependabot will re-roll on
+  its own schedule).
+
+After this PR merges, the loop returns to paused state — queue is
+still all credential-gated.
+
 2026-05-01 05:20 — tick #103. **Loop took initiative on third paused
 tick.** Three consecutive paused ticks (#100, #101 silent, #102
 silent) with no human direction since PR #194 at 04:43 UTC. Queue


### PR DESCRIPTION
## Why

PR #193's test 2 in `apps/mobile/__tests__/screens/onboarding.render.test.tsx` flaked under CI on dependabot PR #198 (actions/setup-node v4→v6) — `Exceeded timeout of 5000 ms` on "renders a chip per preset once the fetch resolves." Passed consistently locally; reproduced on CI.

## What

Root cause: the test combined `waitFor(() => queryByTestId('presets-loading') is null)` (polling for the spinner to disappear) with synchronous chip assertions. But `setPresets` (in `.then`) and `setLoadingPresets(false)` (in `.finally`) are separate promise callbacks. React 18 batches them inconsistently across runs — sometimes the spinner disappears in a render before the chips appear, sometimes after.

Fix: switch to `findByLabelText('preset-vegan')` which polls for the chip directly, waiting for the post-batched DOM. Matches the pattern other tests in the file (#3, #4, #5, #6) already use. Removed the now-unused `waitFor` import. Inline comment explains the race.

## Test plan

- [x] `pnpm --filter @biteworthy/mobile test` → 80/80 unchanged
- [x] Triple-ran the onboarding suite locally; stable at 8/8 each time
- [x] `pnpm typecheck` → 10/10
- [x] `pnpm lint` → 6/6

## Notes

Once this lands, dependabot PR #198 should pass on its next CI re-run (or it'll re-roll on its own schedule). Loop returns to paused state — queue still all credential-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)