### PR TITLE
docs: add NEXT_PUBLIC_POSTHOG_KEY + NEXT_PUBLIC_SITE_URL + mobile .env.example

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,24 @@
+# BiteWorthy Mobile — environment variables.
+#
+# Local: copy to .env (gitignored). EAS: set in the project's secrets via
+# `eas secret:create --scope project --name <KEY> --value <VALUE>`.
+#
+# Expo only exposes vars to the runtime that start with `EXPO_PUBLIC_`.
+
+# --- API base --------------------------------------------------------------
+# Origin the mobile app calls for /api/v1/* requests. Defaults to
+# http://localhost:3000 in dev when unset. Production: https://api.bite-worthy.com.
+EXPO_PUBLIC_API_BASE=http://localhost:3000
+
+# --- PostHog (Phase 5.8-wiring) -------------------------------------------
+# WBW Cross-Product project (id 370116). Public client token; safe to
+# expose. When set + EXPO_PUBLIC_POSTHOG_OPT_IN=1, posthog-react-native
+# initializes at the root layout, registers `extension: "biteworthy"`,
+# and starts capturing the 9 funnel events (see docs/analytics.md).
+EXPO_PUBLIC_POSTHOG_KEY=phc_yourPostHogProjectKeyHere
+
+# --- PostHog opt-in (Phase 5.8-wiring) ------------------------------------
+# Mobile is opt-IN by default for App Store privacy posture. Set to "1"
+# for local smoke testing; in production the in-app /settings/analytics
+# toggle should drive this (followup wiring after the toggle ships).
+EXPO_PUBLIC_POSTHOG_OPT_IN=0

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,3 +17,18 @@ NEXT_PUBLIC_API_BASE=http://localhost:3000
 # Production: `.bite-worthy.com` (note leading dot).
 # Dev: leave UNSET — localhost cookies don't take a domain attribute.
 # NEXT_PUBLIC_COOKIE_DOMAIN=
+
+# --- Site origin (Phase 5.4) ----------------------------------------------
+# Public origin used by sitemap.ts + share-link generation. Falls back to
+# request URL in dev when unset. Production: https://bite-worthy.com.
+# NEXT_PUBLIC_SITE_URL=https://bite-worthy.com
+
+# --- PostHog (Phase 5.8-wiring) -------------------------------------------
+# WBW Cross-Product project (id 370116). Public client token; safe to
+# expose. When set, posthog-js initializes at the root layout, registers
+# `extension: "biteworthy"`, and starts capturing the 9 funnel events
+# (see docs/analytics.md). Leave UNSET to disable analytics — the
+# tracker falls back to noopTracker.
+#
+# Honors `navigator.doNotTrack === '1'` and `localStorage.bw_analytics_opt_out = '1'`.
+NEXT_PUBLIC_POSTHOG_KEY=phc_yourPostHogProjectKeyHere


### PR DESCRIPTION
## Why

Two `.env.example` templates were missing entries for vars that existing code already references:

- `NEXT_PUBLIC_SITE_URL` — used by Phase 5.4's `sitemap.ts` + share-link helper, was missing from the web template
- `NEXT_PUBLIC_POSTHOG_KEY` — Phase 5.8-wiring (PR #218 follow-up), needed at Vercel + locally
- `EXPO_PUBLIC_*` for mobile — the entire mobile app had no `.env.example`

Surfaced while doing the env audit you asked for. The actual values (incl. the WBW Cross-Product PostHog token) live in your gitignored `.env.local` (web) and `.env` (mobile), and in Vercel/EAS for deploys — only the templates land in this PR.

## What

**`apps/web/.env.example`** — adds:
- `NEXT_PUBLIC_SITE_URL` with `https://bite-worthy.com` example
- `NEXT_PUBLIC_POSTHOG_KEY` with WBW Cross-Product context + DNT/opt-out behavior documented

**`apps/mobile/.env.example`** (new file):
- `EXPO_PUBLIC_API_BASE` — defaults to localhost:3000 in dev
- `EXPO_PUBLIC_POSTHOG_KEY` — same WBW context as web
- `EXPO_PUBLIC_POSTHOG_OPT_IN` — defaults to "0" in template (App Store privacy posture); set to "1" for local smoke testing

## Test plan

- [x] No code changes; pure documentation.
- [x] Both files parse as standard env-syntax (no quoted multi-line strings).

## Notes

- No real tokens committed. The token from PR #218's chat thread stays in your gitignored `.env.local` / `.env`.
- After merge, future devs can `cp .env.example .env.local` (web) or `cp .env.example .env` (mobile) and fill in their own keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)