### PR TITLE
fix(api): block SSRF in UrlFetcher + enable CSRF protection on admin dashboard

### DIFF
--- a/apps/api/app/controllers/admin/dashboard_controller.rb
+++ b/apps/api/app/controllers/admin/dashboard_controller.rb
@@ -11,6 +11,8 @@ module Admin
   class DashboardController < ActionController::Base
     layout false # keep it self-contained — no app-wide layout file
 
+    protect_from_forgery with: :exception
+
     before_action :require_admin_basic_auth!
 
     def index

--- a/apps/api/app/services/url_fetcher.rb
+++ b/apps/api/app/services/url_fetcher.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "ipaddr"
+require "resolv"
+require "uri"
+
 # Phase 2.8 — fetch a remote menu URL (HTML or PDF) and return
 # enough info for the controller to attach as an ActiveStorage blob.
 #
@@ -11,11 +15,40 @@
 # Hard limits:
 #   * 10 MB max — protects the API server from accidentally fetching
 #     a multi-hundred-meg PDF.
-#   * Follows up to 3 redirects.
+#   * Follows up to 3 redirects, re-validating each hop against the
+#     SSRF blocklist (cloud metadata + RFC1918 + loopback + …).
 #   * 15-second timeout.
 class UrlFetcher
-  MAX_BYTES   = 10 * 1024 * 1024
-  TIMEOUT_SEC = 15
+  MAX_BYTES     = 10 * 1024 * 1024
+  TIMEOUT_SEC   = 15
+  MAX_REDIRECTS = 3
+
+  # Reject fetches whose resolved address falls in any of these
+  # ranges. Mitigates SSRF against cloud metadata (169.254.169.254),
+  # internal services, and the local network. Re-checked on every
+  # redirect hop. Best-effort only — DNS rebinding between this check
+  # and the socket connect is still possible, but raises the bar
+  # enough for menu URLs (user-supplied via /api/v1/ingestion_runs).
+  BLOCKED_IPV4 = [
+    IPAddr.new("0.0.0.0/8"),
+    IPAddr.new("10.0.0.0/8"),
+    IPAddr.new("100.64.0.0/10"),    # CGNAT
+    IPAddr.new("127.0.0.0/8"),
+    IPAddr.new("169.254.0.0/16"),   # link-local + cloud metadata
+    IPAddr.new("172.16.0.0/12"),
+    IPAddr.new("192.0.0.0/24"),
+    IPAddr.new("192.168.0.0/16"),
+    IPAddr.new("198.18.0.0/15"),
+    IPAddr.new("224.0.0.0/4"),      # multicast
+    IPAddr.new("240.0.0.0/4"),      # reserved
+  ].freeze
+
+  BLOCKED_IPV6 = [
+    IPAddr.new("::1/128"),
+    IPAddr.new("fc00::/7"),         # unique-local
+    IPAddr.new("fe80::/10"),        # link-local
+    IPAddr.new("ff00::/8"),         # multicast
+  ].freeze
 
   class FetchError < StandardError
     attr_reader :status, :reason
@@ -37,46 +70,73 @@ class UrlFetcher
   end
 
   def fetch(url)
-    raise FetchError.new("invalid_url") unless url.to_s.match?(/\Ahttps?:\/\//)
+    current_url = url.to_s
+    redirects   = 0
 
-    response = @conn.get(url)
-    unless (200..299).cover?(response.status)
-      raise FetchError.new("non_2xx", status: response.status)
+    loop do
+      raise FetchError.new("invalid_url") unless current_url.match?(/\Ahttps?:\/\//)
+      validate_safe_url!(current_url)
+
+      response = @conn.get(current_url)
+
+      if (300..399).cover?(response.status) && response.headers["location"].present?
+        raise FetchError.new("too_many_redirects") if redirects >= MAX_REDIRECTS
+        redirects += 1
+        current_url = URI.join(current_url, response.headers["location"]).to_s
+        next
+      end
+
+      unless (200..299).cover?(response.status)
+        raise FetchError.new("non_2xx", status: response.status)
+      end
+
+      body = response.body.to_s
+      raise FetchError.new("response_too_large") if body.bytesize > MAX_BYTES
+
+      return Result.new(
+        io:           StringIO.new(body),
+        content_type: detect_content_type(response, body),
+        filename:     filename_for(current_url, response),
+        byte_size:    body.bytesize
+      )
     end
-
-    body = response.body.to_s
-    if body.bytesize > MAX_BYTES
-      raise FetchError.new("response_too_large")
-    end
-
-    Result.new(
-      io:           StringIO.new(body),
-      content_type: detect_content_type(response, body),
-      filename:     filename_for(url, response),
-      byte_size:    body.bytesize
-    )
   end
 
   private
 
-  def default_connection
-    Faraday.new do |f|
-      f.request  :retry, max: 2,
-                          interval: 0.5,
-                          backoff_factor: 2,
-                          retry_statuses: [429, 500, 502, 503, 504],
-                          methods: %i[get]
-      f.response :follow_redirects, limit: 3
-      f.options.timeout = TIMEOUT_SEC
-      f.options.open_timeout = TIMEOUT_SEC
-      f.adapter Faraday.default_adapter
+  def validate_safe_url!(url)
+    host = URI.parse(url).host
+    raise FetchError.new("invalid_url") if host.nil? || host.empty?
+
+    addresses = resolve_addresses(host)
+    raise FetchError.new("dns_failed") if addresses.empty?
+
+    addresses.each do |addr|
+      ip      = IPAddr.new(addr)
+      blocked = ip.ipv4? ? BLOCKED_IPV4 : BLOCKED_IPV6
+      raise FetchError.new("blocked_address") if blocked.any? { |range| range.include?(ip) }
     end
-  rescue NameError, LoadError
-    # `follow_redirects` middleware is in faraday-follow_redirects (a
-    # separate gem). If unavailable, fall back to a plain connection;
-    # callers that need redirects can supply their own conn:.
+  rescue URI::InvalidURIError, IPAddr::InvalidAddressError
+    raise FetchError.new("invalid_url")
+  end
+
+  def resolve_addresses(host)
+    # Literal IP — skip DNS.
+    [IPAddr.new(host).to_s]
+  rescue IPAddr::InvalidAddressError
+    Resolv.getaddresses(host)
+  end
+
+  def default_connection
+    # No follow_redirects middleware: redirects are handled in #fetch
+    # so each hop re-runs validate_safe_url!.
     Faraday.new do |f|
-      f.options.timeout = TIMEOUT_SEC
+      f.request :retry, max: 2,
+                        interval: 0.5,
+                        backoff_factor: 2,
+                        retry_statuses: [429, 500, 502, 503, 504],
+                        methods: %i[get]
+      f.options.timeout      = TIMEOUT_SEC
       f.options.open_timeout = TIMEOUT_SEC
       f.adapter Faraday.default_adapter
     end

--- a/apps/api/spec/services/url_fetcher_spec.rb
+++ b/apps/api/spec/services/url_fetcher_spec.rb
@@ -73,5 +73,96 @@ RSpec.describe UrlFetcher do
 
       expect(described_class.fetch("https://example.com/").filename).to eq("menu.html")
     end
+
+    describe "SSRF guard" do
+      it "rejects literal loopback URLs" do
+        expect { described_class.fetch("http://127.0.0.1/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      it "rejects literal RFC1918 URLs" do
+        expect { described_class.fetch("http://10.0.0.5/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+        expect { described_class.fetch("http://192.168.1.1/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+        expect { described_class.fetch("http://172.16.0.1/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      it "rejects cloud metadata endpoint (link-local 169.254/16)" do
+        expect { described_class.fetch("http://169.254.169.254/latest/meta-data/") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      it "rejects IPv6 loopback" do
+        expect { described_class.fetch("http://[::1]/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      it "rejects hostnames that resolve to private addresses" do
+        allow(Resolv).to receive(:getaddresses).with("internal.example.com").and_return(["10.0.0.5"])
+
+        expect { described_class.fetch("https://internal.example.com/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      it "rejects hostnames whose any resolved address is private" do
+        # Mixed-resolution attack: one public + one private. We're strict — any private = block.
+        allow(Resolv).to receive(:getaddresses).with("dual.example.com").and_return(["93.184.215.14", "127.0.0.1"])
+
+        expect { described_class.fetch("https://dual.example.com/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      it "raises dns_failed when the host has no addresses" do
+        allow(Resolv).to receive(:getaddresses).with("nx.example.com").and_return([])
+
+        expect { described_class.fetch("https://nx.example.com/menu") }
+          .to raise_error(UrlFetcher::FetchError, /dns_failed/)
+      end
+    end
+
+    describe "redirects" do
+      it "follows a redirect to a public host" do
+        stub_request(:get, "https://example.com/menu").to_return(
+          status: 302, headers: { "Location" => "https://example.com/menus/dinner.pdf" }
+        )
+        stub_request(:get, "https://example.com/menus/dinner.pdf").to_return(
+          status: 200, body: "%PDF", headers: { "Content-Type" => "application/pdf" }
+        )
+
+        result = described_class.fetch("https://example.com/menu")
+
+        expect(result.content_type).to eq("application/pdf")
+        expect(result.filename).to eq("dinner.pdf")
+      end
+
+      it "rejects a redirect to a private address" do
+        stub_request(:get, "https://example.com/menu").to_return(
+          status: 302, headers: { "Location" => "http://169.254.169.254/latest/meta-data/" }
+        )
+
+        expect { described_class.fetch("https://example.com/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      it "raises too_many_redirects after MAX_REDIRECTS hops" do
+        stub_request(:get, "https://example.com/a").to_return(
+          status: 302, headers: { "Location" => "https://example.com/b" }
+        )
+        stub_request(:get, "https://example.com/b").to_return(
+          status: 302, headers: { "Location" => "https://example.com/c" }
+        )
+        stub_request(:get, "https://example.com/c").to_return(
+          status: 302, headers: { "Location" => "https://example.com/d" }
+        )
+        stub_request(:get, "https://example.com/d").to_return(
+          status: 302, headers: { "Location" => "https://example.com/e" }
+        )
+
+        expect { described_class.fetch("https://example.com/a") }
+          .to raise_error(UrlFetcher::FetchError, /too_many_redirects/)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `UrlFetcher` now resolves the target host and rejects any address in a private, loopback, link-local, or reserved range — including the AWS/GCP metadata endpoint at `169.254.169.254`.
- Redirect handling moved inline so **each hop is re-validated** against the SSRF blocklist (the old `follow_redirects` middleware did not). Hops capped at 3.
- `Admin::DashboardController` (which inherits from `ActionController::Base`) now has `protect_from_forgery with: :exception`. Action is currently read-only, but this satisfies the CodeQL rule and is forward-safe for any future state-changing actions.

## CodeQL alerts closed
- `rb/request-forgery` (critical) — `apps/api/app/services/url_fetcher.rb:42`
- `rb/csrf-protection-not-enabled` (high) — `apps/api/app/controllers/admin/dashboard_controller.rb:11`

## Notes
- DNS rebinding between validation and connect is still theoretically possible. Comment in code calls this out — the fix raises the bar substantially for menu URLs submitted via `/api/v1/ingestion_runs` without taking on the complexity of resolved-IP-pinning.
- `faraday-follow_redirects` is still in `Gemfile.lock` as a transitive dep — left alone.

## Test plan
- [ ] CI green (rspec + rubocop + brakeman)
- [ ] New specs cover: literal-IP rejection (loopback, RFC1918, link-local, IPv6), DNS-resolved-private rejection, mixed-resolution rejection, `dns_failed`, redirect-to-private rejection, redirect limit