### PR TITLE
chore: add compose.yaml for local Postgres 16

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,30 @@
+# Local-dev Postgres for the Rails API.
+#
+# Web / mobile / API run natively; only the database is containerized.
+# Usage:
+#   docker compose up -d postgres
+#   cd apps/api && bin/rails db:create db:schema:load db:seed
+#
+# Auth: POSTGRES_HOST_AUTH_METHOD=trust matches database.yml defaults
+# (host=localhost, user=postgres, password=""). Safe because the port
+# is bound to localhost only. Dev use only.
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: biteworthy-postgres
+    ports:
+      - '127.0.0.1:5432:5432'
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Adds a single-service `compose.yaml` at the repo root running Postgres 16 for local dev. Web/mobile/API still run natively.
- Uses `POSTGRES_HOST_AUTH_METHOD=trust` so the existing `database.yml` defaults (host=localhost, user=postgres, empty password) connect with zero `.env` changes. Port bound to `127.0.0.1:5432` only.
- Named volume (`pgdata`) persists data across `docker compose down`; `pg_isready` healthcheck included.

## Test plan
- [ ] `docker compose up -d postgres` brings the container up healthy
- [ ] From `apps/api/`: `bin/rails db:create db:schema:load db:seed` succeeds against the container (verifies `ltree`/`pg_trgm`/`pgcrypto`/`citext` extensions can be created)
- [ ] `bundle exec rspec` passes against the container
- [ ] `docker compose down` stops it; data survives a restart; `docker compose down -v` clears the volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)