### PR TITLE
docs: sync CLAUDE.md, READMEs, and roadmap with shipped state

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@ Repository automation. Each file's purpose:
 
 | File | Purpose |
 |---|---|
-| `workflows/ci-js.yml`     | Typecheck, lint, test for `apps/web`, `apps/mobile`, `packages/*`. Path-filtered. |
+| `workflows/ci-js.yml`     | Typecheck, lint, test + api-types codegen drift check for `apps/web`, `apps/mobile`, `packages/*`. Path-filtered. |
 | `workflows/ci-api.yml`    | RSpec + Brakeman + Rubocop for `apps/api`. Path-filtered. Postgres 16 service. |
 | `workflows/codeql.yml`    | Weekly CodeQL scans for JS/TS and Ruby. |
 | `workflows/pr-title.yml`  | Conventional-commit format check on every PR title. |
@@ -23,7 +23,7 @@ Repository automation. Each file's purpose:
    API-only PR doesn't run JS checks. Faster, cheaper, less noise.
 3. **Concurrency groups** cancel in-progress runs when a new commit
    lands. The newest commit's CI is the only one that matters.
-4. **Pinned major versions** (`@v4`, `@v5`) on every action — no
+4. **Pinned major versions** (e.g. `@v6`) on every action — no
    floating `@latest`, no SHA-pinning churn.
 5. **Required checks** for merge to master: `CI · JS / check`,
    `CI · API / rspec`, `CodeQL / javascript-typescript`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Stack at a glance
 
-Pnpm + Turborepo monorepo. Three apps + four shared packages:
+Pnpm + Turborepo monorepo. Three apps + five shared packages:
 
 - `apps/api` — Rails 8 (Ruby 3.3.6) JSON API on Postgres 16. **Not** part of the pnpm workspace; lives as its own Bundler tree.
 - `apps/web` — Next.js 15 App Router + Tailwind. Dev port `:3001`.
 - `apps/mobile` — Expo SDK 52 + expo-router.
-- `packages/api-types` — TS types (currently hand-written; OpenAPI codegen lands in Phase 1.6).
+- `packages/api-types` — TS types codegen'd from `docs/openapi.json` (see Cross-package contracts below).
 - `packages/filter-engine` — pure-TS dietary filter, shared by web + mobile, with Vitest tests. Mirrors the server-side SQL.
+- `packages/analytics` — the 9-event funnel taxonomy (`EVENTS` map + `EventPropsMap`). Event names/payloads are a contract with the launch dashboards — **renaming an event breaks downstream funnels**; add optional fields freely. `docs/analytics.md` documents each event; when doc and types disagree, the types win.
 - `packages/ui-tokens` — design tokens consumed by Tailwind (web) and `StyleSheet.create` (mobile).
 - `packages/eslint-config` — minimal flat config; framework rules live per-app.
 
@@ -38,6 +39,7 @@ pnpm mobile <script>       # alias for: pnpm --filter @biteworthy/mobile ...
 The API has its own toolchain — run from `apps/api/`:
 
 ```bash
+docker compose up -d postgres           # (from repo root) local Postgres 16, localhost-only, trust auth
 bundle install
 bin/rails db:create db:schema:load db:seed
 bin/rails s -p 3000                     # API on :3000 (web is on :3001)
@@ -47,6 +49,7 @@ bundle exec rspec spec/requests/foo_spec.rb     # one file
 bundle exec rspec spec/requests/foo_spec.rb:42  # one example by line
 bundle exec rubocop --parallel
 bundle exec brakeman --no-pager --quiet --format plain
+bin/openapi-export                      # regenerate docs/openapi.json from the rswag specs
 ```
 
 Per-app test runners (use these for narrow runs instead of `pnpm test`):
@@ -88,7 +91,7 @@ See `docs/schema.md` for the 60-second tour of all 25-ish tables, and `docs/inge
 
 ## Cross-package contracts
 
-- The Rails OpenAPI spec → `packages/api-types/src/generated.ts` codegen pipeline is **not yet wired up** (Phase 1.6). For now, `packages/api-types/src/index.ts` is hand-written. When you add an endpoint, update the hand-written types in the same PR. Once 1.6 lands, the hand-written file is deleted and only `generated.ts` is re-exported.
+- **API types are generated, not hand-written.** The chain: rswag specs in `apps/api/spec/integration/` → `bin/openapi-export` writes `docs/openapi.json` → `pnpm --filter @biteworthy/api-types build:codegen` writes `src/generated.ts`. When you add or change an endpoint, write/update its rswag spec and re-run both steps in the same PR — CI (`codegen:check` in `ci-js.yml`) fails if `generated.ts` drifts from the checked-in spec. A few hand-written read-model types (Ingredient, Tag, Restaurant, Item) remain in `packages/api-types/src/index.ts` until their endpoints get rswag specs.
 - `@biteworthy/filter-engine` consumes `@biteworthy/api-types`. If you change the shape of an `Item`, fix both.
 - `@biteworthy/ui-tokens` is consumed by `apps/web/tailwind.config.ts` (as Tailwind theme extensions) and `apps/mobile` (mapped into `StyleSheet.create`). Token renames touch all three.
 
@@ -110,13 +113,15 @@ See `docs/schema.md` for the 60-second tour of all 25-ish tables, and `docs/inge
 - `docs/status.md` — running log, newest first; what the previous tick left mid-flight.
 - `docs/schema.md` — the data model in 60 seconds.
 - `docs/ingestion.md` — how Claude vision + prompt-cached taxonomy turns a menu photo into staged `IngestionItem`s.
-- `docs/adr/0001-stack.md` — why every stack pick is what it is. Read before proposing alternatives.
+- `docs/analytics.md` — the funnel-event contract behind `packages/analytics`.
+- `docs/launch-readiness.md` — the human-action launch checklist (provisioning, store accounts, deploy).
+- `docs/adr/` — why every pick is what it is (0001 stack, 0007 hosting = Kamal + Hetzner + Neon, 0006 analytics = PostHog, plus email/blob/web-hosting). Read the relevant ADR before proposing alternatives.
 
 ## CI
 
 Two workflows gate PRs:
 
-- `ci-js.yml` — runs on changes to `apps/web/`, `apps/mobile/`, `packages/`, or root config. Steps: `pnpm typecheck` → `pnpm lint` → `pnpm test`.
-- `ci-api.yml` — runs on changes to `apps/api/`. Boots Postgres 16, then `bin/rails db:create db:schema:load`, then `bin/rspec`. Brakeman + Rubocop run with `continue-on-error: true` (informational, not blocking).
+- `ci-js.yml` — runs on changes to `apps/web/`, `apps/mobile/`, `packages/`, `docs/openapi.json`, or root config. Steps: `pnpm typecheck` → `pnpm lint` → `pnpm test` → api-types codegen drift check.
+- `ci-api.yml` — runs on changes to `apps/api/`. Boots Postgres 16 + ImageMagick (dish-photo cropping shells out to it), then `bin/rails db:create db:schema:load`, then `bin/rspec`. Brakeman + Rubocop run with `continue-on-error: true` (informational, not blocking).
 
 Both are required for auto-merge. Don't request human review on red.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ biteworthy/
 ├── packages/
 │   ├── api-types/       TS types generated from the Rails OpenAPI spec
 │   ├── filter-engine/   Shared dietary-filter logic (web + mobile)
+│   ├── analytics/       Funnel-event taxonomy (web + mobile + api)
 │   ├── ui-tokens/       Shared design tokens
 │   └── eslint-config/
 ├── _legacy/         Frozen 2020 Rails 4.2 codebase (read-only)
@@ -27,16 +28,25 @@ biteworthy/
 
 ## Quickstart
 
-Requires Ruby 3.3+, Node 22+, pnpm 10+, Postgres 16+.
+Requires Ruby 3.3+, Node 22+, pnpm 10+, Docker (or a local Postgres 16+).
 
 ```bash
 pnpm install
-pnpm dev          # boots api, web, and mobile concurrently via Turborepo
+docker compose up -d postgres    # local Postgres 16 for the API
+pnpm dev                         # boots web + mobile concurrently via Turborepo
+
+# The Rails API is not part of the pnpm workspace — boot it separately:
+cd apps/api
+bundle install
+bin/rails db:create db:schema:load db:seed
+bin/rails s -p 3000              # web dev server is on :3001
 ```
 
 Each app also has its own README under `apps/<name>/`.
 
 ## Status
 
-Pre-MVP. See `docs/adr/0001-stack.md` for the architectural picks and
+Phase 5 (launch prep): all loop-shippable code is on master; remaining
+items need human provisioning — see `docs/launch-readiness.md`. See
+`docs/adr/0001-stack.md` for the architectural picks and
 `docs/roadmap.md` for the phase plan.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -5,6 +5,7 @@ Rails 8 JSON API. Lives at `apps/api/` inside the monorepo.
 ## Local setup
 
 ```bash
+docker compose up -d postgres   # from the repo root; or use your own local Postgres 16
 cd apps/api
 bundle install
 bin/rails db:create db:schema:load db:seed
@@ -18,7 +19,12 @@ privilege the first time).
 ## Routes
 
 All app traffic lives under `/api/v1`. `/up` is the health check.
-`/api-docs` renders the OpenAPI spec via rswag (Phase 1 work-in-progress).
+`/api-docs` renders the OpenAPI spec via rswag.
+
+The spec is built from the rswag specs in `spec/integration/` —
+`bin/openapi-export` dumps it to `docs/openapi.json`, which feeds the
+`@biteworthy/api-types` codegen. Re-run both after any endpoint change;
+CI fails on drift.
 
 ## Background jobs
 
@@ -124,22 +130,17 @@ Useful aliases (all in `config/deploy.yml`):
 
 Production SMTP is wired in `config/environments/production.rb`. Decision + trade-offs in `docs/adr/0003-email-provider.md` (Postmark via plain SMTP). Dev + test use the `:test` adapter — no real delivery — so specs don't open sockets.
 
-**One-time bootstrap (human):** sign up for Postmark, create a "BiteWorthy" server, verify the `bite-worthy.com` sender domain (DKIM + Return-Path DNS records), generate a Server API token, then:
+**One-time bootstrap (human):** sign up for Postmark, create a "BiteWorthy" server, verify the `bite-worthy.com` sender domain (DKIM + Return-Path DNS records), generate a Server API token, then put the Postmark token into `SMTP_USERNAME` / `SMTP_PASSWORD` in `.kamal/secrets` (template at `.kamal/secrets.example`) and:
 
 ```bash
-fly secrets set \
-    SMTP_ADDRESS=smtp.postmarkapp.com \
-    SMTP_PORT=587 \
-    SMTP_USERNAME=$POSTMARK_TOKEN \
-    SMTP_PASSWORD=$POSTMARK_TOKEN \
-    SMTP_DOMAIN=bite-worthy.com \
-    MAILER_HOST=https://bite-worthy.com
+kamal env push
+kamal deploy
 ```
 
 **Confirm delivery:**
 
 ```bash
-fly ssh console -C 'bin/rails biteworthy:email:smoke EMAIL=you@example.com'
+kamal app exec 'bin/rails biteworthy:email:smoke EMAIL=you@example.com'
 ```
 
 Reports the SMTP Message-ID per delivery; `EXIT_CODE=1` makes it fail loudly for CI.
@@ -155,18 +156,16 @@ Production blobs (review photos, dish photos, ingestion menu pages) live on **Cl
 ```bash
 # 1. Cloudflare → R2 → create bucket "biteworthy-blobs", generate
 #    an API token with Object Read & Write on the bucket.
-fly secrets set \
-    R2_ACCESS_KEY_ID=<token-id> \
-    R2_SECRET_ACCESS_KEY=<token-secret> \
-    R2_BUCKET=biteworthy-blobs \
-    R2_ENDPOINT=https://<accountid>.r2.cloudflarestorage.com
-fly deploy
+# 2. Fill in R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET /
+#    R2_ENDPOINT in .kamal/secrets (template at .kamal/secrets.example).
+kamal env push
+kamal deploy
 ```
 
 **(Optional) Migrate any pre-existing blobs to R2:**
 
 ```bash
-fly ssh console -C 'bin/rails biteworthy:storage:backfill EXIT_CODE=1'
+kamal app exec 'bin/rails biteworthy:storage:backfill EXIT_CODE=1'
 ```
 
 The backfill task is **idempotent** — blobs already on the configured service are no-ops, so it's safe to re-run after every deploy or any future service flip (R2 → S3 or back). Logs `[ok] / [skip] / [FAIL]` per blob.

--- a/apps/api/app/services/biteworthy/email_smoke.rb
+++ b/apps/api/app/services/biteworthy/email_smoke.rb
@@ -9,8 +9,9 @@
 #
 #   * **production** — `delivery_method = :smtp` from
 #     `config/environments/production.rb` opens a real SMTP connection.
-#     Useful right after `fly secrets set SMTP_*=...` to confirm
-#     Postmark (or whichever provider) accepts the credentials.
+#     Useful right after setting SMTP_* in `.kamal/secrets` (then
+#     `kamal env push`) to confirm Postmark (or whichever provider)
+#     accepts the credentials.
 #
 #   * **dev / test** — `:test` adapter captures the message in
 #     `ActionMailer::Base.deliveries`. The runner reports the Message-ID

--- a/apps/api/config/environments/production.rb
+++ b/apps/api/config/environments/production.rb
@@ -27,13 +27,13 @@ Rails.application.configure do
 
   # Phase 5.2 — production SMTP. Provider-agnostic: any SMTP-capable
   # service (Postmark, SES, SendGrid, Mailgun) works by setting the
-  # SMTP_* env vars via `fly secrets set`. ADR 0003 documents the
+  # SMTP_* env vars in `.kamal/secrets`. ADR 0003 documents the
   # Postmark pick + alternatives.
   #
   # Fail loudly if delivery raises — Solid Queue retries the mailer
   # job on transient errors, but a misconfigured server should NOT
   # silently swallow signups. Disable raise_delivery_errors only
-  # if a hosted-by-Fly outage requires it (rare).
+  # if a provider outage requires it (rare).
   config.action_mailer.delivery_method   = :smtp
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries    = true

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -15,6 +15,9 @@ pnpm mobile android           # Android emulator
 Use the Expo Go app on a physical device for the fastest iteration loop —
 the camera capture flow needs a real camera anyway.
 
+Env vars (`EXPO_PUBLIC_*`) are documented in `.env.example` (copy to
+`.env`, gitignored).
+
 ## Why Expo
 
 - Camera, secure-store, OAuth, push, OTA updates — all built in.
@@ -24,6 +27,6 @@ the camera capture flow needs a real camera anyway.
 
 ## Shared with web
 
-`@biteworthy/api-types`, `@biteworthy/filter-engine`, `@biteworthy/ui-tokens`
-live in `packages/` and feed both apps. Mobile maps tokens into
-`StyleSheet.create`; web maps the same tokens into Tailwind.
+`@biteworthy/api-types`, `@biteworthy/filter-engine`, `@biteworthy/analytics`,
+and `@biteworthy/ui-tokens` live in `packages/` and feed both apps. Mobile
+maps tokens into `StyleSheet.create`; web maps the same tokens into Tailwind.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -6,7 +6,7 @@
 # --- API base ---------------------------------------------------------------
 # Origin the web app calls for /api/v1/* requests via its server-side
 # proxy routes. Defaults to http://localhost:3000 in dev when unset.
-# Production: https://api.bite-worthy.com (Phase 5.1's Fly.io app).
+# Production: https://api.bite-worthy.com (Kamal-deployed API on Hetzner, ADR 0007).
 NEXT_PUBLIC_API_BASE=http://localhost:3000
 
 # --- Cookie domain (Phase 5.4) ---------------------------------------------

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -10,7 +10,8 @@ pnpm install         # from repo root
 pnpm web dev         # alias for: pnpm --filter @biteworthy/web dev
 ```
 
-Set `NEXT_PUBLIC_API_BASE` to override the Rails URL.
+Set `NEXT_PUBLIC_API_BASE` to override the Rails URL. All env vars are
+documented in `.env.example` (copy to `.env.local`).
 
 ## Why Next + Tailwind
 
@@ -33,6 +34,7 @@ Hosted on Vercel. Decision + trade-offs in `docs/adr/0005-web-hosting.md`.
    - `NEXT_PUBLIC_API_BASE=https://api.bite-worthy.com`
    - `NEXT_PUBLIC_COOKIE_DOMAIN=.bite-worthy.com` (cookie scoped across subdomains)
    - `NEXT_PUBLIC_SITE_URL=https://bite-worthy.com` (sitemap base URL)
+   - `NEXT_PUBLIC_POSTHOG_KEY=phc_…` (Phase 5.8 funnel analytics; leave unset to disable — see `docs/analytics.md`)
 4. Add `bite-worthy.com` + `www.bite-worthy.com` as custom domains. Vercel emits the DNS records to add at the registrar.
 
 **Every deploy:** push to `master` → Vercel auto-deploys to production. Push to a feature branch → Vercel emits a preview URL (`<branch>--biteworthy.vercel.app`) which is useful for codex review of UX changes.

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -40,7 +40,7 @@ The loop pauses here. The next tick (post-Anthropic-cap-reset at 2026-05-01 00:0
 - Onboarding (6-tap profile) — Phase 3.8.
 - /privacy, /terms, /press — Phases 5.9, 5.10.
 - Sitemap + robots, Vercel config, cookie-domain helper — Phase 5.4.
-- Analytics abstraction wired (no-op until Phase 5.8-wiring injects posthog-js) — Phase 5.8.
+- Analytics wired: posthog-js into the 9 funnel events (#218); no-op until `NEXT_PUBLIC_POSTHOG_KEY` is set — Phases 5.8, 5.8-wiring.
 - 99 vitest passing.
 
 ### Mobile (Expo SDK 52, `apps/mobile/`)
@@ -51,12 +51,12 @@ The loop pauses here. The next tick (post-Anthropic-cap-reset at 2026-05-01 00:0
 - Reviews UX, history, public user pages — Phases 4.4, 4.7, 4.8.
 - Suggestion submission flow — Phase 4.10.
 - Store-listing markdown templates + eas.json + assets/README — Phase 5.9.
-- Analytics abstraction wired (no-op until Phase 5.8-wiring injects posthog-react-native) — Phase 5.8.
+- Analytics wired: posthog-react-native into the 9 funnel events (#218); no-op until `EXPO_PUBLIC_POSTHOG_KEY` is set + the user opts in — Phases 5.8, 5.8-wiring.
 - 60 jest passing (all lib-only — UI snapshots gated on the jest-expo Discovered followup).
 
 ### Shared packages (`packages/`)
 
-- `@biteworthy/api-types` — handwritten until Phase 1.6's codegen lands.
+- `@biteworthy/api-types` — codegen'd from `docs/openapi.json` (Phase 1.6); CI drift-checked.
 - `@biteworthy/filter-engine` — pure-TS dietary filter, mirrors the SQL — Phase 3.7.
 - `@biteworthy/ui-tokens` — design tokens for Tailwind + RN StyleSheet.
 - `@biteworthy/eslint-config` — minimal flat config.
@@ -176,14 +176,12 @@ Subsequent deploys: `kamal deploy`. CI automation is a small follow-up after thi
 
 **Unlocks:** funnel measurement (`app_open` → `profile_set` → `menu_filtered` → `restaurant_tap`).
 
-- Sign up for PostHog Cloud, create a "BiteWorthy" project, generate a project API key.
-- Vercel: set `NEXT_PUBLIC_POSTHOG_KEY=<key>`.
-- EAS: set `EXPO_PUBLIC_POSTHOG_KEY=<key>` in the project's env.
-- Open follow-up PR `claude/phase-5.8-wiring`:
-  - `pnpm add posthog-js -F @biteworthy/web`
-  - `pnpm add posthog-react-native -F @biteworthy/mobile`
-  - Wrap each SDK in an `AnalyticsClient` adapter; inject into `buildWebTracker` / `buildMobileTracker`.
-  - Instrument the 9 events at their call sites per `docs/analytics.md`.
+- ~~Code side~~ — **done in #218**: posthog-js + posthog-react-native installed, wrapped in `AnalyticsClient` adapters, all 9 events instrumented per `docs/analytics.md`. Env vars documented in each app's `.env.example`.
+- Remaining (human):
+  - Generate a project API key (WBW Cross-Product project, id 370116).
+  - Vercel: set `NEXT_PUBLIC_POSTHOG_KEY=<key>`.
+  - EAS: set `EXPO_PUBLIC_POSTHOG_KEY=<key>` in the project's env (mobile capture is additionally opt-in via `EXPO_PUBLIC_POSTHOG_OPT_IN` / the in-app toggle).
+  - Verify events arrive: load the prod site, confirm `app_open` in the PostHog live-events view.
 
 ### 8. App Store + Play Store submission (Phase 5.9-wiring)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,9 +15,8 @@ the merge / review / status rules.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **[BLOCKED] Phase 5.8-wiring — instrument 9 funnel events end-to-end** (followup to #179). Needs PostHog account + project API key; then `pnpm add posthog-js -F @biteworthy/web` + `pnpm add posthog-react-native -F @biteworthy/mobile` + call-site instrumentation per `docs/analytics.md`.
-2. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
-3. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
+1. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
+2. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
 ### Done
 
@@ -80,6 +79,7 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 5.10 — press kit + waitlist + Durango outreach templates (#183) — **last code-only Phase 5 PR**
 - ✅ Launch-readiness checklist + loop pause (#184) — `docs/launch-readiness.md` is the human's linear path from "code complete" to launch.
 - ✅ Phase 4.11.0 / 4.11.2-cassette — recorded against Simply Tasty Thai appetizers; ExtractMenuJob integration smoke now real (this PR) — **Phase 4.11 fully complete**
+- ✅ Phase 5.8-wiring — posthog-js + posthog-react-native wired into the 9 funnel events (#218) — code side complete; setting the real `*_POSTHOG_KEY` in Vercel/EAS is launch-readiness step 7
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,25 @@ without spelunking GitHub.
 
 ---
 
+2026-06-11 22:13 — tick #127 (interactive session, not the cron loop).
+**Docs sync after ~5 weeks of drift.** Since tick #126, master advanced
+through #218-#225 without status/roadmap updates:
+- #218 shipped Phase 5.8-wiring (posthog-js + posthog-react-native →
+  9 funnel events) — the roadmap still listed it as BLOCKED Next-up #1.
+  Ticked it into Done; launch-readiness step 7 now shows only the
+  human key-setting steps.
+- #221 thai-menu test fixtures; #222 .env.example docs; #223 SSRF +
+  CSRF fixes; #224 security dep bumps; #225 compose.yaml for local
+  Postgres.
+This PR also refreshes CLAUDE.md + all READMEs against shipped
+reality (Phase 1.6 codegen is live, packages/analytics exists, local
+Postgres via compose.yaml, ci-api installs ImageMagick) and finishes
+the Fly.io → Kamal/Hetzner reference sweep the owner confirmed
+("Kamal Hetzner is the new standard"): apps/api README email/blob
+sections, production.rb + email_smoke.rb comments, web .env.example.
+Queue state: both remaining Next-up items (5.9-wiring, 5.1.1-wiring)
+stay credential-gated; loop remains paused.
+
 2026-05-06 17:30 — tick #126. **Repo moved to whiteboard-works org.**
 ~5 days of mostly silent paused ticks since #125 (the onboarding
 flake fix at PR #199). Two relevant non-loop changes during the


### PR DESCRIPTION
## Why

Five weeks of drift between the docs and master. The roadmap still listed Phase 5.8-wiring as `[BLOCKED]` Next-up #1 even though #218 shipped it; CLAUDE.md still described the Phase 1.6 OpenAPI codegen as "not yet wired up"; and several files still documented Fly.io commands after ADR 0007 made Kamal + Hetzner the standard (owner confirmed: "Kamal Hetzner is the new standard").

## What

- **CLAUDE.md / root README** — codegen pipeline documented as live (rswag → `bin/openapi-export` → `docs/openapi.json` → `generated.ts`, CI drift-checked); `packages/analytics` added; `compose.yaml` Postgres quickstart; corrected `pnpm dev` claim (boots web + mobile only — the API is outside the pnpm workspace).
- **Fly.io → Kamal sweep** — `apps/api/README.md` email/blob bootstrap now uses `.kamal/secrets` + `kamal env push` / `kamal app exec`; comment-only updates in `production.rb` + `email_smoke.rb`; `apps/web/.env.example` hosting note.
- **Roadmap / status / launch-readiness** — ticked Phase 5.8-wiring (#218) into Done; status.md entry covering #218–#225; launch-readiness step 7 reduced to the remaining human key-setting steps.
- **Web/mobile READMEs** — PostHog env vars, `.env.example` pointers, `@biteworthy/analytics` in the shared-package list.
- **.github/README** — ci-js row mentions the codegen drift check; action pin example `@v4/@v5` → `@v6`.

## Test plan

- [x] Docs/comments-only diff — no behavior change anywhere.
- [x] `bundle exec rubocop` on the two touched Ruby files: no new offenses (all reported offenses are pre-existing file-wide style findings; Rubocop is informational in CI).
- [x] Verified every updated claim against the tree: `packages/api-types/src/generated.ts` + `codegen:check` CI step, `packages/analytics`, `compose.yaml`, `.kamal/secrets.example` SMTP_*/R2_* keys, PR #218 in `git log`.

## Notes

Queue state after this PR: both remaining Next-up items (5.9-wiring, 5.1.1-wiring) are credential-gated on human steps per `docs/launch-readiness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)