### PR TITLE
fix(api): restore green rspec — explicit mini_magick + DNS stub in URL specs

### DIFF
--- a/apps/api/Gemfile
+++ b/apps/api/Gemfile
@@ -28,6 +28,9 @@ gem "omniauth-apple"
 
 # --- Storage / files ---------------------------------------------------------
 gem "image_processing", "~> 2.0"
+# image_processing 2.0 dropped mini_magick as a hard dependency, but
+# Ingestion::DishPhotoCropper requires it directly — keep it explicit.
+gem "mini_magick", "~> 5.3"
 gem "aws-sdk-s3", require: false
 
 # --- AI ingestion ------------------------------------------------------------

--- a/apps/api/Gemfile.lock
+++ b/apps/api/Gemfile.lock
@@ -236,6 +236,8 @@ GEM
     marcel (1.1.0)
     meta-tags (2.23.0)
       actionpack (>= 6.0.0)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -529,6 +531,7 @@ DEPENDENCIES
   image_processing (~> 2.0)
   jbuilder
   json-schema (~> 6.2)
+  mini_magick (~> 5.3)
   omniauth (~> 2.1)
   omniauth-apple
   omniauth-google-oauth2
@@ -582,7 +585,6 @@ CHECKSUMS
   bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
@@ -631,6 +633,7 @@ CHECKSUMS
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   meta-tags (2.23.0) sha256=ffe78b5bee398de4ff5ac3316f5a786049538a651643b8476def06c3acc762c1
+  mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe "Ingestion runs API", type: :request do
     context "with source_url (Phase 2.8)" do
       let(:menu_url) { "https://durango-restaurants.example/cream-bean-berry/menu" }
 
+      before do
+        # UrlFetcher's SSRF guard (#223) resolves DNS before fetching;
+        # WebMock only intercepts the HTTP layer. Resolve the spec host
+        # to a public address so the guard passes.
+        allow(Resolv).to receive(:getaddresses)
+          .with("durango-restaurants.example").and_return(["93.184.215.14"])
+      end
+
       it "fetches the URL, attaches the response, and 201s with input_kind=url for HTML" do
         allow(ExtractMenuJob).to receive(:perform_later)
         stub_request(:get, menu_url).to_return(

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,6 +208,19 @@ phase or "Next up" queue.
   3.5 / 4.11.4 (web RestaurantClient ItemRow + mobile [id].tsx
   ItemRow asserting `photo_url` renders into an `<img>` / `<Image>`
   when set, doesn't render when null).
+- **Auto-merge is completing on red (June 2026).** The dependabot wave
+  #227–#272 merged with both CI workflows failing — required status
+  checks don't appear to be enforced on `master` branch protection
+  since the whiteboard-works org move (the old repo's settings didn't
+  travel). Master was broken for ~3 weeks unnoticed (restored by #274
+  + #275). Human action: re-add the required checks listed in
+  `.github/README.md` §5 under Settings → Branches.
+- **Dependabot bumps Expo-managed native deps past SDK support.** It
+  walked expo 52→56 and reanimated to 4.4 (unsupported by the SDK,
+  missing the worklets peer), and split jest from jest-expo. Consider
+  `ignore` rules in `.github/dependabot.yml` for `expo*`,
+  `react-native*`, `jest-expo`, and `jest` so SDK upgrades happen
+  deliberately via `npx expo install --fix`.
 - **Auto-merge race lost a follow-on commit on PR #150**. After the
   initial push, a second commit (the prior version of this Discovered
   note) was added before CI finished — auto-merge had already enabled

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,29 @@ without spelunking GitHub.
 
 ---
 
+2026-06-11 23:05 — tick #128 (interactive session). **Master CI was
+red; restored green.** Tick #127's docs PR (#273) failed both CI
+workflows — the failures predated it. The June dependabot wave
+(#227-#272, ~45 PRs) auto-merged with required checks apparently not
+enforced on the new org, accumulating four JS breaks and two API
+breaks. Fixes shipped as two PRs:
+- #274 (ci-js): posthog-react-native 4.45 JsonType cast in the mobile
+  adapter; reanimated pinned back to Expo 56's bundled 4.3.1 + missing
+  react-native-worklets@0.8.3 peer added; jest-expo → ~56.0.4 with
+  jest/@types/jest pinned to 29 (jest-expo is built on jest-29
+  internals; jest 30's runtime crashed its environment);
+  react-test-renderer 19.2.6 added to match react exactly; `as Route`
+  casts for Next typedRoutes on login/signup. Verified: typecheck
+  10/10, lint 6/6, test 8/8 (mobile 82/82), codegen:check clean.
+- #275 (ci-api): image_processing 2.0 dropped mini_magick from the
+  dependency tree but Ingestion::DishPhotoCropper requires it —
+  declared explicitly (~> 5.3). Also fixed 3 ingestion_runs specs that
+  were red since #223: the SSRF guard resolves DNS, WebMock doesn't —
+  stubbed Resolv for the spec host. Verified: rspec 387/0.
+Process flags for the human (also in roadmap Discovered): re-enable
+required checks on master branch protection; stop dependabot from
+bumping Expo-managed native deps past the SDK's bundled versions.
+
 2026-06-11 22:13 — tick #127 (interactive session, not the cron loop).
 **Docs sync after ~5 weeks of drift.** Since tick #126, master advanced
 through #218-#225 without status/roadmap updates:


### PR DESCRIPTION
## Why

Master's `ci-api` is red — every run fails loading `rails_helper`. Companion to #274 (which restores `ci-js`); together they take master back to green.

## What

- **Explicit `mini_magick (~> 5.3)`** — image_processing 2.0 (bumped in #257) dropped mini_magick as a hard dependency, but `Ingestion::DishPhotoCropper` does `require "mini_magick"` directly, so the whole suite died with `LoadError`. A gem the code requires belongs in the Gemfile regardless of what pulls it transitively.
- **DNS stub in `ingestion_runs_spec.rb`** — three specs have been red since #223's SSRF hardening: `UrlFetcher` now resolves DNS before fetching, and WebMock only intercepts HTTP, so the `.example` spec host hit `dns_failed` before any stub applied. Stubbed `Resolv.getaddresses` for the spec host to a public address — the same pattern `url_fetcher_spec.rb` already uses.
- **Docs**: tick #128 status entry + two roadmap **Discovered** flags for the owner (see Notes).

## Test plan

- [x] `bundle exec rspec` — **387 examples, 0 failures** (was: suite unable to load)
- [x] `bundle exec rspec spec/requests/api/v1/ingestion_runs_spec.rb` — 13/13
- [x] `mini_magick` present in `Gemfile.lock` again

## Notes

Two process problems need a human, flagged in `docs/roadmap.md` Discovered:

1. **Auto-merge is completing on red.** ~45 dependabot PRs (#227–#272) merged with failing CI — required status checks don't appear to be enforced on `master` branch protection since the whiteboard-works org move. Re-add the checks listed in `.github/README.md` §5 under Settings → Branches.
2. **Dependabot walks Expo-managed deps past SDK support** (expo 52→56, reanimated 4.4, jest 30 vs jest-expo). Consider `ignore` rules in `.github/dependabot.yml` so Expo SDK upgrades happen deliberately via `npx expo install --fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)