### PR TITLE
chore(ci): stop dependabot bumping Expo-managed packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,25 @@ updates:
       prefix: chore
       prefix-development: chore
       include: scope
+    # Expo-SDK-coupled packages (and jest, which jest-expo is built on) must
+    # move together via `npx expo install --fix`, not one at a time — piecemeal
+    # bumps walked mobile from SDK 52 to 56 and broke CI for ~3 weeks in
+    # June 2026. The monthly expo-align workflow owns their upgrades; see
+    # docs/automations-todo.md item 5. react/react-dom are deliberately NOT
+    # ignored (web needs their updates) — accepted residual risk for mobile.
+    ignore:
+      - dependency-name: "expo"
+      - dependency-name: "expo-*"
+      - dependency-name: "@expo/*"
+      - dependency-name: "react-native"
+      - dependency-name: "react-native-*"
+      - dependency-name: "@react-native/*"
+      - dependency-name: "@react-native-community/*"
+      - dependency-name: "metro*"
+      - dependency-name: "jest-expo"
+      - dependency-name: "jest"
+      - dependency-name: "@types/jest"
+      - dependency-name: "react-test-renderer"
     groups:
       types:
         patterns: ["@types/*"]
@@ -24,8 +43,6 @@ updates:
         patterns: ["eslint*", "@eslint/*", "typescript-eslint*"]
       next:
         patterns: ["next", "@next/*", "eslint-config-next"]
-      expo:
-        patterns: ["expo*", "@expo/*", "react-native*", "metro*"]
       tanstack:
         patterns: ["@tanstack/*"]
 


### PR DESCRIPTION
## Why

In June 2026, dependabot's weekly expo group walked the mobile app from Expo SDK 52 to 56 one package at a time (#201, #230, #241, #259). Along the way it pushed react-native-reanimated past the version supported by the installed SDK and bumped jest to 30 while jest-expo is built on jest 29 internals — breaking mobile CI for about 3 weeks (fixed in #274/#275). These packages' versions are coupled to the Expo SDK and must move together via `npx expo install --fix`, not one package at a time.

## What

- Add an `ignore:` list to the npm dependabot config covering Expo-SDK-coupled packages: `expo`, `expo-*`, `@expo/*`, `react-native`, `react-native-*`, `@react-native/*`, `@react-native-community/*`, `metro*`, plus the jest-expo-coupled test stack (`jest-expo`, `jest`, `@types/jest`, `react-test-renderer`). No `versions:` key, so all updates are ignored.
- Remove the `expo` group from `groups:` — every pattern it matched (`expo*`, `@expo/*`, `react-native*`, `metro*`) is now ignored, so the group was dead weight.
- Comment in the file points at the monthly expo-align workflow and docs/automations-todo.md item 5.

## Test plan

- YAML validated with Ruby's `YAML.safe_load_file` (parses; npm update block contains the 12 ignore entries and no expo group).
- Dependabot config can't be fully exercised until its next scheduled run (Mondays 09:00 America/Denver) — watch that no Expo/RN/jest PRs appear.

## Notes

- `react`/`react-dom` are deliberately NOT ignored: Expo pins them per SDK, but web needs their updates. Accepted residual risk — a react bump that outruns the mobile SDK should be caught by mobile CI.
- The monthly expo-align workflow that deliberately runs `npx expo install --fix` is landing in a parallel PR; this PR only stops the piecemeal bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)