### PR TITLE
chore(ci): run CI checks on every PR so they can be required

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -4,19 +4,38 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    paths:
-      - "apps/api/**"
-      - ".github/workflows/ci-api.yml"
 
 concurrency:
   group: ci-api-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Cheap change detection so `rspec` always reports a status on every
+  # PR (required checks can't be satisfied by a workflow that never
+  # runs), while still skipping the heavy work on irrelevant changes.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ github.event_name != 'pull_request' || steps.filter.outputs.relevant == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - "apps/api/**"
+              - ".github/workflows/ci-api.yml"
+
   rspec:
     name: rspec · brakeman · rubocop
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     services:
       postgres:
         image: postgres:16
@@ -71,7 +90,6 @@ jobs:
 
       - name: Brakeman
         run: bundle exec brakeman --no-pager --quiet --format plain
-        continue-on-error: true
 
       - name: Rubocop
         run: bundle exec rubocop --parallel

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -4,28 +4,47 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    paths:
-      - "apps/web/**"
-      - "apps/mobile/**"
-      - "packages/**"
-      - "docs/openapi.json"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "turbo.json"
-      - "tsconfig.base.json"
-      - ".prettierrc"
-      - ".github/workflows/ci-js.yml"
 
 concurrency:
   group: ci-js-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Cheap change detection so `check` always reports a status on every
+  # PR (required checks can't be satisfied by a workflow that never
+  # runs), while still skipping the heavy work on irrelevant changes.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ github.event_name != 'pull_request' || steps.filter.outputs.relevant == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - "apps/web/**"
+              - "apps/mobile/**"
+              - "packages/**"
+              - "docs/openapi.json"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+              - "turbo.json"
+              - "tsconfig.base.json"
+              - ".prettierrc"
+              - ".github/workflows/ci-js.yml"
+
   check:
     name: typecheck · lint · test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -57,4 +76,14 @@ jobs:
         # match what's committed. Catches the case where someone
         # edited a Rails endpoint, regenerated openapi.json, but
         # forgot to re-run `build:codegen`.
+        id: codegen
         run: pnpm --filter @biteworthy/api-types codegen:check
+
+      - name: How to fix codegen drift
+        if: failure() && steps.codegen.outcome == 'failure'
+        run: |
+          echo "generated.ts is out of date with docs/openapi.json."
+          echo "To fix, run:"
+          echo "  cd apps/api && bin/openapi-export"
+          echo "  pnpm --filter @biteworthy/api-types build:codegen"
+          echo "then commit the result."


### PR DESCRIPTION
## Why

Both CI workflows used `paths:` filters on their `pull_request` triggers, so a docs-only PR never reported `CI · JS / check` or `CI · API / rspec`. That makes those contexts unusable as required status checks on master — required + never-reported means the PR can never merge. It also means PRs could merge with no CI signal at all: in the June incident, ~45 PRs auto-merged on red because nothing actually gated them. This PR restructures the workflows using the documented GitHub pattern so every PR gets a check result, unblocking branch protection.

## What

- `ci-js.yml` / `ci-api.yml`: removed the `paths:` list from the `pull_request` trigger (the `push: branches: [master, main]` trigger is unchanged).
- Added a cheap `changes` job to each workflow using `dorny/paths-filter@v3` with exactly the same path globs that were previously in the trigger, with `permissions: pull-requests: read`. On `push` events the filter step is skipped and `relevant` is unconditionally true.
- The heavy jobs keep their exact ids and names (`check` → `CI · JS / check`, `rspec` → `CI · API / rspec`) and now have `needs: changes` + `if: needs.changes.outputs.relevant == 'true'`. GitHub treats a job skipped via job-level `if` as satisfying a required check.
- `ci-js.yml`: the api-types codegen drift step now has `id: codegen`, and a follow-up step (runs only when it fails) prints exact fix instructions: `cd apps/api && bin/openapi-export`, then `pnpm --filter @biteworthy/api-types build:codegen`, then commit the result.
- `ci-api.yml`: removed `continue-on-error: true` from the Brakeman step. Rubocop remains informational (pre-existing style offenses).

## Test plan

- [x] Ran Brakeman locally from `apps/api/` — exits 0, 0 security warnings, so making it blocking is safe.
- [x] Both workflow files validated as parseable YAML.
- [x] Verified job ids/names are unchanged so the check contexts stay `CI · JS / check` and `CI · API / rspec`.
- [x] This PR itself touches `.github/workflows/ci-js.yml` and `.github/workflows/ci-api.yml`, which are in both filter lists — both heavy jobs should run here, exercising the PR path of the `changes` job.

## Notes

- Branch protection (making `CI · JS / check` and `CI · API / rspec` required on master) will be applied as a follow-up once this merges.
- Brakeman decision: it is currently clean, so it is now blocking. Rubocop stays `continue-on-error: true` because of its many pre-existing offenses.
- `.github/README.md` and `docs/` are intentionally untouched — a follow-up PR owns those updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)