### PR TITLE
chore(ci): block edits to previously-shipped migrations

### DIFF
--- a/.github/workflows/migration-guard.yml
+++ b/.github/workflows/migration-guard.yml
@@ -1,0 +1,41 @@
+name: Migration guard
+
+# Enforces the repo rule "never edit a previously-shipped migration — add a
+# new one" (CLAUDE.md + docs/delivery-playbook.md). Fails any PR that
+# modifies, deletes, or renames a file under apps/api/db/migrate/ that
+# already exists on the base branch. Newly added migrations are fine.
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/db/migrate/**"
+
+concurrency:
+  group: migration-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: no edits to shipped migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for modified/deleted/renamed shipped migrations
+        run: |
+          git fetch origin "${{ github.base_ref }}"
+          # M = modified, D = deleted, R = renamed. Added (A) files are
+          # intentionally excluded — new migrations are the whole point.
+          offending="$(git diff --name-status --diff-filter=MDR "origin/${{ github.base_ref }}...HEAD" -- apps/api/db/migrate/)"
+          if [ -n "$offending" ]; then
+            echo "::error::This PR modifies, deletes, or renames previously-shipped migrations:"
+            echo "$offending"
+            echo ""
+            echo "Shipped migrations are immutable. Add a new migration instead of"
+            echo "editing a shipped one (see docs/delivery-playbook.md)."
+            exit 1
+          fi
+          echo "Only additions under apps/api/db/migrate/ — OK."


### PR DESCRIPTION
## Why

The repo rule (CLAUDE.md + docs/delivery-playbook.md) is "never edit a previously-shipped migration — add a new one," but nothing enforced it mechanically. A PR could silently rewrite a shipped migration and pass CI.

## What

New workflow `.github/workflows/migration-guard.yml`:

- Triggers on `pull_request` only when `apps/api/db/migrate/**` is touched (not intended as a required check — it is only meaningful when migrations change).
- Single `guard` job: full-depth checkout, fetches the base ref, then runs `git diff --name-status --diff-filter=MDR origin/<base>...HEAD -- apps/api/db/migrate/`.
- If any modified (M), deleted (D), or renamed (R) migration is found, it lists the offending files and fails with: add a new migration instead of editing a shipped one (see docs/delivery-playbook.md).
- Added (A) files are excluded by the filter, so new migrations pass with "only additions — OK."

Dependency-free: plain bash in a single run step, actions/checkout@v6, concurrency group matching the other workflows.

## Test plan

- Validated the YAML parses (Ruby YAML.safe_load).
- Local verification of the diff logic on a throwaway branch:
  - Appended a comment to `apps/api/db/migrate/20260101000001_enable_extensions.rb`, committed, and ran the exact diff command against `origin/master` — it correctly listed `M apps/api/db/migrate/20260101000001_enable_extensions.rb`.
  - Committed a dummy new migration file and confirmed it shows up only under `--diff-filter=A`; the `MDR` filter excludes additions by construction, so the guard ignores it.
  - Scratch branch deleted; nothing from the test was committed here.
- This PR itself does not touch `apps/api/db/migrate/`, so the new workflow will not run on it — first real exercise will be the next migration-touching PR.

## Notes

- Uses `origin/<base>...HEAD` (three-dot merge-base diff), so changes already on master that aren't in the PR don't produce false positives.
- Renames are treated as violations (R is in the filter): renaming a shipped migration changes its identity just like deleting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)