### PR TITLE
docs: record automation rollout — TODO statuses, CI standards, tick #129

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,12 +4,15 @@ Repository automation. Each file's purpose:
 
 | File | Purpose |
 |---|---|
-| `workflows/ci-js.yml`     | Typecheck, lint, test + api-types codegen drift check for `apps/web`, `apps/mobile`, `packages/*`. Path-filtered. |
-| `workflows/ci-api.yml`    | RSpec + Brakeman + Rubocop for `apps/api`. Path-filtered. Postgres 16 service. |
-| `workflows/codeql.yml`    | Weekly CodeQL scans for JS/TS and Ruby. |
+| `workflows/ci-js.yml`     | Typecheck, lint, test + api-types codegen drift check for `apps/web`, `apps/mobile`, `packages/*`. Runs on every PR; a `changes` job skips the heavy work when no JS paths changed (skipped still satisfies required checks). |
+| `workflows/ci-api.yml`    | RSpec + Brakeman (blocking) + Rubocop (informational) for `apps/api`. Same every-PR + internal-skip structure. Postgres 16 service. |
+| `workflows/ci-nightly.yml`| Nightly (09:00 UTC) full run of both suites against master regardless of paths; opens/updates a `ci-nightly`-labeled issue on failure. The backstop — auto-merged PRs don't trigger master-push CI (GITHUB_TOKEN events are suppressed). |
+| `workflows/migration-guard.yml` | Fails any PR that edits/deletes a previously-shipped file under `apps/api/db/migrate/`. |
+| `workflows/expo-align.yml`| Monthly `npx expo install --fix` + react-test-renderer sync; opens an alignment PR when drift exists. Owns Expo-managed versions (dependabot ignores them). |
+| `workflows/codeql.yml`    | CodeQL scans for JS/TS and Ruby on every PR + weekly. |
 | `workflows/pr-title.yml`  | Conventional-commit format check on every PR title. |
 | `workflows/labeler.yml`   | Auto-applies `area:*` labels by changed paths. Config in `labeler.yml`. |
-| `workflows/auto-merge.yml`| Enables squash auto-merge for PRs with `claude-cd` + `auto-merge-ok`, or any PR authored by `dependabot[bot]`. |
+| `workflows/auto-merge.yml`| Enables squash auto-merge on every PR; branch protection's required checks decide when the merge actually happens. |
 | `labeler.yml`             | Path → label mapping. |
 | `dependabot.yml`          | Weekly grouped dep PRs (npm + bundler) + monthly actions bumps. |
 | `CODEOWNERS`              | Review routing. |
@@ -19,20 +22,26 @@ Repository automation. Each file's purpose:
 
 1. **PR titles** are conventional-commit-formatted; the squash-merge
    commit message inherits them. The `pr-title` workflow enforces this.
-2. **Path filters** mean a docs-only PR doesn't run RSpec, and an
-   API-only PR doesn't run JS checks. Faster, cheaper, less noise.
+2. **Path filtering happens inside the workflows** (a `changes` job +
+   job-level `if`), not at the trigger — so every PR reports every
+   required check, while docs-only PRs still skip the heavy work.
+   Don't move the filters back to the trigger: a required check that
+   never reports blocks the PR forever.
 3. **Concurrency groups** cancel in-progress runs when a new commit
    lands. The newest commit's CI is the only one that matters.
 4. **Pinned major versions** (e.g. `@v6`) on every action — no
    floating `@latest`, no SHA-pinning churn.
-5. **Required checks** for merge to master: `CI · JS / check`,
-   `CI · API / rspec`, `CodeQL / javascript-typescript`,
-   `CodeQL / ruby`. Configure in repo Settings → Branches.
+5. **Required checks** for merge to master (enforced since
+   2026-06-11): `typecheck · lint · test`, `rspec · brakeman ·
+   rubocop`, `javascript-typescript`, `ruby`. Note these are check-run
+   (job) names, not `workflow / job-id` strings. Managed in repo
+   Settings → Branches (or `gh api .../branches/master/protection`).
 6. **Auto-merge** is opt-in per PR via labels (`auto-merge-ok` +
    `claude-cd`) and is automatic for `dependabot[bot]` PRs. Branch
    protection still gates everything — failing CI blocks the merge.
-7. **`continue-on-error: true`** on Brakeman + Rubocop until the
-   codebase grows to where they're meaningful. Re-tighten in Phase 1.
+7. **Brakeman is blocking** (clean as of 2026-06-11); **Rubocop stays
+   `continue-on-error: true`** — it carries many pre-existing style
+   offenses. Tighten it only with a dedicated cleanup PR.
 
 ## Required labels (create once in repo settings)
 

--- a/docs/automations-todo.md
+++ b/docs/automations-todo.md
@@ -9,38 +9,47 @@ Status legend: `[ ]` queued · `[~]` in progress · `[x]` done · `[B]` blocked 
 
 ## P0 — merge safety net
 
-1. [~] **CI workflows report on every PR** so required checks can be
-   enforced. Today both workflows are path-filtered at the trigger, so
-   a docs-only PR never reports `CI · JS / check` — making it a
-   required check would block those PRs forever. Move the path filter
-   inside the workflow (change-detection job + job-level `if`; GitHub
-   treats skipped required jobs as satisfied). Also: make Brakeman
-   blocking if it's currently clean, and add a failure hint to the
-   codegen drift check.
-2. [~] **Enforce required status checks on `master` branch protection**
-   (`CI · JS / check`, `CI · API / rspec` — exact contexts verified at
-   apply time). Apply via `gh api` after item 1 merges; if the token
-   lacks admin, falls back to a human task (Settings → Branches).
-3. [~] **Nightly full-suite CI on master** (`schedule:` cron) running
-   both the JS and API suites regardless of paths, opening/updating a
-   pinned issue on failure. Closes the "docs merge never runs rspec,
-   master rots invisibly" gap.
-4. [~] **Migration guard** — CI check that fails any PR which modifies
-   or deletes a previously-shipped file under `apps/api/db/migrate/`
-   (new migrations are fine). Makes the playbook rule mechanical.
+1. [x] **CI workflows report on every PR** so required checks can be
+   enforced — done in #280. Path filters moved from the `pull_request`
+   trigger into a `changes` job (`dorny/paths-filter`, bumped to v4 by
+   #282) gating the heavy job; skipped jobs satisfy required checks.
+   Brakeman was clean → now blocking; Rubocop stays informational.
+   Codegen drift check now prints exact fix commands on failure.
+2. [x] **Enforce required status checks on `master` branch protection**
+   — applied 2026-06-11 via `gh api` (the token had admin). Required
+   contexts: `typecheck · lint · test`, `rspec · brakeman · rubocop`,
+   `javascript-typescript`, `ruby` (check-run names, not the
+   "workflow / job-id" form). `strict` is off; admins not enforced.
+   Verified working: red dependabot PRs are now blocked from merging.
+3. [x] **Nightly full-suite CI on master** — done in #278
+   (`.github/workflows/ci-nightly.yml`, 09:00 UTC + workflow_dispatch;
+   on failure opens/updates an issue labeled `ci-nightly` mentioning
+   @shadoath). Extra reason it matters, discovered during rollout:
+   master-push CI runs are SUPPRESSED for auto-merged PRs (the merge
+   is attributed to GITHUB_TOKEN, whose events don't trigger
+   workflows) — the nightly is currently the only thing that runs CI
+   against master itself.
+4. [x] **Migration guard** — done in #281
+   (`.github/workflows/migration-guard.yml`): fails any PR that
+   modifies/deletes/renames an existing file under
+   `apps/api/db/migrate/`; additions pass.
 
 ## P1 — dependency hygiene
 
-5. [~] **Dependabot ignore rules for Expo-managed packages**
-   (`expo*`, `react-native*`, `jest-expo`, `jest`, `@types/jest`,
-   `react-test-renderer`) — these are coupled to the Expo SDK and must
-   move together, not one-at-a-time. Note: `react`/`react-dom` are
-   deliberately NOT ignored (web needs them); accepted residual risk,
-   the nightly run + required checks now catch a bad bump.
-6. [~] **Monthly Expo SDK alignment workflow** — scheduled job that
-   runs `npx expo install --fix`, reinstalls, runs the suite, and opens
-   a PR with the aligned versions. The deliberate replacement for
-   dependabot's per-package Expo bumps.
+5. [x] **Dependabot ignore rules for Expo-managed packages** — done in
+   #279 (12 ignore patterns; the `expo` group removed). Note:
+   `react`/`react-dom` are deliberately NOT ignored (web needs them);
+   accepted residual risk — required checks + the renderer-sync step in
+   the align workflow now catch a bad bump. Painfully validated: #276
+   (an expo-group bump) merged minutes BEFORE the ignores landed,
+   re-broke mobile, and was cleaned up by #292.
+6. [x] **Monthly Expo SDK alignment workflow** — done in #283
+   (`.github/workflows/expo-align.yml`), patched in #292 after its
+   first dispatched run correctly caught — but couldn't fix — the
+   react-test-renderer/react version mismatch (the workflow now syncs
+   the renderer pin after `expo install --fix`). Known limitation:
+   the PRs it opens via GITHUB_TOKEN don't trigger CI; close/reopen
+   them to get checks, which are now required to merge.
 
 ## P2 — deploy + ops (blocked on launch provisioning)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,19 +208,17 @@ phase or "Next up" queue.
   3.5 / 4.11.4 (web RestaurantClient ItemRow + mobile [id].tsx
   ItemRow asserting `photo_url` renders into an `<img>` / `<Image>`
   when set, doesn't render when null).
-- **Auto-merge is completing on red (June 2026).** The dependabot wave
-  #227–#272 merged with both CI workflows failing — required status
-  checks don't appear to be enforced on `master` branch protection
-  since the whiteboard-works org move (the old repo's settings didn't
-  travel). Master was broken for ~3 weeks unnoticed (restored by #274
-  + #275). Human action: re-add the required checks listed in
-  `.github/README.md` §5 under Settings → Branches.
-- **Dependabot bumps Expo-managed native deps past SDK support.** It
-  walked expo 52→56 and reanimated to 4.4 (unsupported by the SDK,
-  missing the worklets peer), and split jest from jest-expo. Consider
-  `ignore` rules in `.github/dependabot.yml` for `expo*`,
-  `react-native*`, `jest-expo`, and `jest` so SDK upgrades happen
-  deliberately via `npx expo install --fix`.
+- ~~**Auto-merge is completing on red (June 2026).**~~ — **resolved
+  2026-06-11**: required status checks re-applied to master branch
+  protection via API (tick #129; contexts in `.github/README.md` §5),
+  after #280 restructured both CI workflows to report on every PR.
+  The full automation plan that came out of this incident lives in
+  `docs/automations-todo.md`.
+- ~~**Dependabot bumps Expo-managed native deps past SDK support.**~~ —
+  **resolved 2026-06-11**: ignore rules added in #279; the monthly
+  `expo-align.yml` workflow owns these versions now (#283, #292). One
+  last over-bump (#276) raced in before the ignores landed; realigned
+  in #292.
 - **Auto-merge race lost a follow-on commit on PR #150**. After the
   initial push, a second commit (the prior version of this Discovered
   note) was added before CI finished — auto-merge had already enabled

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,36 @@ without spelunking GitHub.
 
 ---
 
+2026-06-11 23:29 — tick #129 (interactive session). **Automation
+hardening shipped; branch protection enforced.** Owner asked for the
+longterm-development automations; plan written to
+`docs/automations-todo.md` (#277), then items 1-6 shipped via five
+parallel subagent PRs, all merged:
+- #280 ci-js/ci-api report on every PR (path filters moved inside via
+  a `changes` job); Brakeman now blocking; codegen drift check prints
+  fix commands on failure.
+- #278 nightly full-suite run against master + failure issue
+  (`ci-nightly` label, mentions @shadoath).
+- #281 migration guard (fails PRs editing shipped migrations).
+- #279 dependabot ignores for Expo-managed packages (+ expo group
+  removed).
+- #283 monthly `expo-align.yml` (expo install --fix → verify → PR).
+Then: **required status checks applied to master branch protection
+via API** (typecheck · lint · test / rspec · brakeman · rubocop /
+javascript-typescript / ruby; strict off, admins not enforced) —
+verified blocking red dependabot PRs immediately.
+War story in between: expo-group bump #276 auto-merged minutes before
+#279's ignores landed and re-broke mobile (react-native 0.86 drops
+the jest preset jest-expo needs). First dispatched expo-align run
+caught the react-test-renderer mismatch in its test gate exactly as
+designed but couldn't fix it; #292 realigned the deps to SDK 56 and
+taught the workflow to sync react-test-renderer after --fix.
+Discovered en route: auto-merged PRs never trigger master-push CI
+(merge attributed to GITHUB_TOKEN, events suppressed) — the nightly
+run is the only thing exercising master directly.
+Remaining TODO items are launch-blocked (P2) or human-decision (P3);
+see docs/automations-todo.md.
+
 2026-06-11 23:05 — tick #128 (interactive session). **Master CI was
 red; restored green.** Tick #127's docs PR (#273) failed both CI
 workflows — the failures predated it. The June dependabot wave


### PR DESCRIPTION
## Why

Bookkeeping for the automation rollout (docs/automations-todo.md items 1–6, PRs #277–#283, #292) and the branch-protection enforcement applied today.

## What

- `docs/automations-todo.md` — items 1–6 marked done with PR numbers + lessons learned.
- `.github/README.md` — workflows table gains `ci-nightly` / `migration-guard` / `expo-align`; standards rewritten for in-workflow path filtering, the enforced required-check contexts, blocking Brakeman, and the actual auto-merge policy.
- `docs/roadmap.md` — both June-incident Discovered flags resolved.
- `docs/status.md` — tick #129.

## Test plan

- [x] Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)