### PR TITLE
docs: phase 6-8 subplans (anyone-can-scan, mobile scan loop, taste ranking)

### DIFF
--- a/docs/plans/phase-6.md
+++ b/docs/plans/phase-6.md
@@ -1,0 +1,173 @@
+# Phase 6 — Anyone-can-scan ingestion (subplan)
+
+Phase 6 turns the admin-only ingestion pipeline (Phase 2) into the
+community feature the product vision demands: **any signed-in user can
+walk into a restaurant that isn't in the system, scan its menu, verify
+the extraction, and publish it** — without an admin in the loop, and
+without compromising the strict-mode safety guarantees.
+
+The pipeline itself doesn't change. What changes is who may invoke it,
+what trust level their output lands at, and the guardrails (quotas,
+cost ceilings, duplicate detection, moderation visibility) that make
+opening it safe.
+
+**Demo at the end:** a brand-new non-admin account creates "Maria's
+Tacos" with an address, uploads a menu photo, swipe-verifies the
+staged items, and the restaurant goes live with every item visible to
+relaxed/balanced users — while strict-mode users see nothing until an
+admin confirms the associations. A second user scanning the same menu
+gets a "did you mean Maria's Tacos?" dedup prompt instead of creating
+a duplicate.
+
+## Trust model (read before any task)
+
+The existing columns do the heavy lifting — no new trust machinery:
+
+- `ItemIngredient`/`ItemTag` rows carry `confidence` + `source`.
+- Admin-verified promotions stay `confidence: confirmed, source: human`.
+- **Community-verified promotions land `confidence: suggested,
+  source: human`.** Strict-mode users only see fully-confirmed items,
+  so community data is live for relaxed/balanced users and invisible
+  to strict users until an admin (or restaurant owner, Phase 4.9)
+  confirms it. This is the honest-disclosure contract extended to
+  community data — do not weaken it.
+
+## Stop conditions specific to Phase 6
+
+- Quota/cost limits must be env-tunable with safe defaults; if a task
+  finds itself hard-coding a dollar amount, stop and parameterize.
+- If opening an endpoint requires loosening an auth check whose other
+  callers you don't understand, stop and map the callers first
+  (CLAUDE.md Rule 6).
+
+## Tasks (one PR each)
+
+### 6.1 — Non-admin ingestion runs + quotas + cost ceiling
+
+**Branch**: `claude/phase-6.1-community-ingestion-access`
+
+- Drop `ensure_admin!` from `POST /api/v1/ingestion_runs`; any
+  authenticated user may create a run. `GET` show already permits
+  owner-or-admin; keep that.
+- Per-user quota: max `INGESTION_RUNS_PER_USER_PER_DAY` (default 5)
+  non-admin runs per rolling 24h. 429 with a clear error payload when
+  exceeded. Admins bypass.
+- Global cost ceiling: if the sum of `api_cost_cents` across runs
+  created in the current UTC day exceeds
+  `INGESTION_DAILY_COST_CEILING_CENTS` (default 2000 = $20), non-admin
+  run creation returns 503 with a "try again tomorrow" error. Admins
+  bypass.
+- Update the rswag spec for the endpoint; re-run `bin/openapi-export`
+  + api-types codegen in the same PR (CI checks drift).
+
+Specs: quota boundary (5th ok, 6th 429), admin bypass, cost ceiling
+trip + reset, anonymous still 401.
+
+### 6.2 — Community restaurant creation + duplicate detection
+
+**Branch**: `claude/phase-6.2-community-restaurant-create`
+
+- New `POST /api/v1/restaurants` (authenticated): `name`, `city_slug`,
+  optional address fields. Creates a `draft` restaurant recording the
+  creating user (`created_by_user_id` — new nullable FK column, new
+  migration).
+- **Dedup guard** (pg_trgm is already enabled): before create, check
+  `similarity(restaurants.name, $name) > 0.55` among restaurants in
+  the same city. On match, respond 409 with the candidate list
+  (id, slug, name, address) so clients can offer "did you mean…?".
+  `force: true` param overrides after the client has shown the prompt.
+- `POST /api/v1/ingestion_runs` accepts the resulting restaurant_id
+  from a draft restaurant the caller created (it must already — verify
+  + spec the ownership check: non-admins may only target draft
+  restaurants they created OR published restaurants, for re-scans).
+- rswag + openapi-export + codegen in the same PR.
+
+Specs: create happy path, dedup 409 with candidates, force override,
+cross-city same-name no-collision, non-owner targeting another user's
+draft restaurant 403.
+
+### 6.3 — Self-verify + community-trust promotion
+
+**Branch**: `claude/phase-6.3-community-self-verify`
+
+- Allow a run's creator (not just admins) to `GET` + `PATCH` its
+  ingestion items (accept/reject/edit). Other non-admin users: 403.
+- `IngestionItem#promote!` learns who is promoting: admin deciders
+  keep `confidence: confirmed`; non-admin deciders write
+  `confidence: suggested, source: human` on the created
+  `ItemIngredient`/`ItemTag` rows (see Trust model above). The Item's
+  own `confidence` column follows the same rule.
+- `maybe_publish!` (80% threshold) works unchanged for community runs:
+  restaurant + items go `published` — visible to relaxed/balanced,
+  invisible to strict until confirmed.
+- rswag + openapi-export + codegen.
+
+Specs: creator can decide own run / stranger 403; promotion writes
+suggested for non-admin and confirmed for admin; strict-mode filter
+hides a community-published item end-to-end (request spec against
+`GET /restaurants/:id/items?strictness=strict`).
+
+### 6.4 — Community-publish moderation visibility
+
+**Branch**: `claude/phase-6.4-community-moderation-queue`
+
+Admins need to *see* what the community publishes without gating it.
+
+- Avo: scope/filter on restaurants + ingestion runs surfacing
+  "community-published in the last 30 days" (created_by_user_id
+  present, published via a non-admin run).
+- Admin one-click "confirm all" action on a community-published
+  restaurant: flips its items' `suggested` associations to
+  `confirmed` (audit trail: source stays `human`). This is how a
+  community menu graduates to strict-mode visibility.
+- Counters on `/admin/dashboard`: community runs today, cost spent
+  today vs ceiling.
+
+Specs: confirm-all action flips associations + item confidence;
+dashboard counters compute correctly.
+
+### 6.5 — Web: community scan entrypoint
+
+**Branch**: `claude/phase-6.5-web-community-scan`
+
+- `/ingest` opens to any logged-in user (remove the admin gating in
+  the page/proxy); logged-out users get a login redirect with
+  `?next=/ingest`.
+- New-restaurant step: name + city + address form, calling
+  `POST /api/v1/restaurants`; render the 409 dedup candidates as
+  "did you mean?" cards (pick one → reuse, or "create anyway").
+- After upload: poll run status (existing pattern), then a simple
+  web verify page (list items, accept/reject/edit inline — the web
+  twin of mobile's swipe-verify, table layout is fine).
+- Quota/cost errors (429/503) render human messages.
+
+Specs (vitest/RTL): form validation, dedup-candidate rendering, verify
+list accept/reject wiring, error states.
+
+### 6.6 — Mobile: community scan entrypoint
+
+**Branch**: `claude/phase-6.6-mobile-community-scan`
+
+- Mirror 6.5 in the Expo app: `/ingest` available to any logged-in
+  user; new-restaurant form screen ahead of capture; dedup prompt;
+  swipe-verify (already built, Phase 2.7) reachable by the run
+  creator; quota/cost error states.
+
+Specs (jest/RTL): same coverage as 6.5 at the screen level.
+
+## Cross-cutting
+
+- Analytics: fire existing funnel events where they apply; add new
+  optional-field payloads only (renaming events is forbidden —
+  packages/analytics contract).
+- Every API change: rswag spec + `bin/openapi-export` + codegen in the
+  same PR.
+
+## Out of scope for Phase 6
+
+- Reputation/karma levels (explicitly out of v1 scope).
+- Re-scan merge/update of an existing published menu (Phase 7.3 covers
+  the UX entry; deep menu-diff merging is its own future phase —
+  re-scans create a new run whose promoted items replace by exact
+  name match only).
+- Taste ranking (Phase 8).

--- a/docs/plans/phase-7.md
+++ b/docs/plans/phase-7.md
@@ -1,0 +1,85 @@
+# Phase 7 — Close the real-world mobile scan loop (subplan)
+
+Phase 7 makes the phone the primary instrument of the product vision:
+stand in a restaurant, open the app, scan the menu, and minutes later
+read a simplified menu filtered to *you*. Phase 6 opened the pipeline
+to everyone; Phase 7 removes the remaining friction on the device.
+
+**Demo at the end:** cold-start the app at a restaurant. Home screen
+shows nearby/searchable restaurants and a big "Scan a menu" button.
+The restaurant isn't listed → tap Scan → name it → photograph two
+menu pages with the real camera → watch extraction progress → swipe-
+verify → land on the filtered menu and pick dinner.
+
+## Stop conditions specific to Phase 7
+
+- Camera work needs a physical device to truly verify; CI can only
+  cover the component contract with the camera module mocked. Note
+  any "verified in simulator only" honestly in the PR body.
+- If expo-camera's API in the installed SDK differs from what the
+  skeleton assumed, fix the skeleton — don't pin an older camera lib.
+
+## Tasks (one PR each)
+
+### 7.1 — Wire the real camera capture
+
+**Branch**: `claude/phase-7.1-camera-capture`
+
+The Phase 2.6 screen (`apps/mobile/app/ingest/index.tsx`) has the
+multi-page capture flow but the camera ref is a TODO.
+
+- Wire `expo-camera` (`CameraView` + `useCameraPermissions`): request
+  permission with a friendly rationale state, capture stills via the
+  ref, append to the existing multi-page thumbnail strip, retake per
+  page.
+- Permission-denied state links to system settings.
+- Keep the existing upload path (`lib/api/ingestion-runs.ts`)
+  untouched.
+
+Specs (jest, camera module mocked): permission flow states, capture
+appends a page, retake replaces, upload invoked with all pages.
+
+### 7.2 — Real mobile home screen
+
+**Branch**: `claude/phase-7.2-mobile-home`
+
+Replace the placeholder `apps/mobile/app/index.tsx`:
+
+- Restaurant search (name, against `GET /api/v1/restaurants` —
+  add a `?q=` ilike/trigram param to the endpoint if it lacks one;
+  rswag + openapi-export + codegen if the API changes).
+- "Near me" section when location permission granted (sort by
+  distance using address lat/lng already in the schema; graceful
+  fallback to the city list without permission).
+- Primary CTA: "Scan a menu" → `/ingest`.
+- Profile entry point (onboarding if no profile yet, else summary).
+
+Specs: search debounce + result rendering, no-permission fallback,
+CTA navigation.
+
+### 7.3 — Stitch the scan-to-menu flow
+
+**Branch**: `claude/phase-7.3-scan-flow-stitch`
+
+The end-to-end ribbon tying 6.6 + 7.1 + 7.2 together:
+
+- From home search: "Can't find it? Scan it" empty-state action →
+  new-restaurant form (Phase 6.6) → camera (7.1) → run progress
+  screen (poll status with the existing pattern; show stage names
+  extracting/resolving/staged) → swipe-verify → on publish,
+  deep-link to `/restaurants/[id]` showing the user's own filtered
+  view of the menu they just scanned.
+- Re-scan entry: on an existing restaurant's menu screen, an
+  overflow action "Menu changed? Re-scan" creating a new run against
+  that restaurant (Phase 6.2's ownership rules apply).
+- Fire the funnel events that already exist for these surfaces.
+
+Specs: navigation-flow test with mocked API (happy path reaches the
+restaurant screen), progress screen state mapping, re-scan entry
+creates a run against the right restaurant id.
+
+## Out of scope for Phase 7
+
+- iPad/tablet layouts.
+- Offline capture queueing.
+- Menu-diff merging on re-scan (see Phase 6 out-of-scope note).

--- a/docs/plans/phase-8.md
+++ b/docs/plans/phase-8.md
@@ -1,0 +1,138 @@
+# Phase 8 — "Most likely to enjoy" taste ranking (subplan)
+
+Phase 8 is the product's differentiator. Phases 1–7 answer "what CAN
+I eat here?" (hard dietary safety). Phase 8 answers **"what WILL I
+love here?"** — a taste lens that ranks the safe items and leads with
+a Top Picks view, so a 60-item menu reads like an 8-item menu.
+
+Design principle: **safety filters, taste ranks.** Avoid lists keep
+hiding items (hard, existing behavior, untouched). Taste signals are
+*soft* — they reorder and highlight, never hide. The two must stay
+separate concepts in schema, API, and UI copy.
+
+**Demo at the end:** two users with the same allergy profile open the
+same restaurant. Both see the same safe items, but each sees a
+different Top Picks row — one's love of spicy Thai curries vs the
+other's burger habit — with a one-line "because you like…" explainer
+per pick.
+
+## Scoring model (v1 — deliberately simple)
+
+```
+score(item) =
+    2.0 * |item.tag_ids ∩ liked_tag_ids|
+  + 1.0 * |item.ingredient_ids ∩ liked_ingredient_ids|
+  - 2.0 * |item.tag_ids ∩ disliked_tag_ids|
+  - 1.0 * |item.ingredient_ids ∩ disliked_ingredient_ids|
+  + 0.5 * normalized_popularity            (popularity / max_at_restaurant)
+  + 0.5 * (avg_visible_rating - 3) / 2     (0 when unreviewed)
+```
+
+Weights are constants in ONE place per implementation (SQL + TS) with
+a shared fixture test asserting both produce identical scores for the
+same inputs. No ML, no embeddings, no per-user weight learning in v1
+— the schema leaves room (signals are arrays, weights are code).
+
+Top Picks = the N (default 5) highest-scoring *visible* items with
+score > 0. Fewer than 3 positive-score items → no Top Picks row
+(don't fake enthusiasm).
+
+## Stop conditions specific to Phase 8
+
+- The SQL ranking and the filter-engine TS ranking MUST land in the
+  same PR as each other whenever either changes (repo rule), with the
+  shared-fixture parity test.
+- If ranking pressure tempts you to *hide* low-scoring items: stop.
+  Taste never hides. Re-read the design principle.
+
+## Tasks (one PR each)
+
+### 8.1 — Taste signal schema + profile API
+
+**Branch**: `claude/phase-8.1-taste-schema`
+
+- Migration: `liked_ingredient_ids uuid[]`, `liked_tag_ids uuid[]`,
+  `disliked_ingredient_ids uuid[]`, `disliked_tag_ids uuid[]` on
+  `user_profiles` (default `{}`), GIN not needed (read-side only).
+- `GET/PATCH /api/v1/profile` reads/writes the four arrays with the
+  same validation pattern as the avoid arrays (UUIDs must exist).
+- A value may not appear in both liked and disliked (validation).
+- Avoid-vs-taste interaction: an id present in an avoid list is
+  ignored by scoring (filter wins; no error).
+- rswag + `bin/openapi-export` + api-types codegen in the same PR.
+
+Specs: round-trip, both-lists validation error, avoid-overlap
+ignored, unknown UUID rejected.
+
+### 8.2 — Scoring engine (SQL + filter-engine, one PR)
+
+**Branch**: `claude/phase-8.2-taste-scoring`
+
+- `GET /api/v1/restaurants/:id/items` computes `taste_score` per the
+  model above (SQL: cardinality of array intersections; ratings via
+  the visible-reviews aggregate) and returns it per item, plus
+  `taste_reasons` (which liked tags/ingredients matched, for the
+  "because you like…" line). Sort: visible items by
+  `taste_score DESC, popularity DESC, name ASC` when the caller has
+  any taste signal; unchanged legacy sort otherwise.
+- `packages/filter-engine`: `scoreItem(item, profile)` +
+  `topPicks(items, profile, n=5)` mirroring the SQL exactly.
+- Shared fixture: one JSON file of items+profiles checked into the
+  filter-engine package; vitest asserts TS scores; an RSpec test
+  loads the same JSON and asserts SQL scores match to 4 decimal
+  places.
+- rswag + openapi-export + codegen (response shape changed).
+
+Specs: parity fixture, zero-signal no-op, dislike outweighs
+popularity, unreviewed items get no rating term.
+
+### 8.3 — Top Picks UI (web)
+
+**Branch**: `claude/phase-8.3-web-top-picks`
+
+- `/restaurants/[slug]`: when ≥3 positive-score items, render a
+  "Top picks for you" row above the sections — card per pick with
+  photo (Phase 4.11), name, price, and the one-line taste reason.
+  Full menu below, unchanged except subtle score-ordered sections.
+- Anonymous / no-taste-signal users see today's layout untouched.
+- "Why these?" affordance explaining picks come from their likes.
+
+Specs (vitest/RTL): row renders at ≥3 picks, absent below, reason
+line text, anonymous unchanged.
+
+### 8.4 — Top Picks UI (mobile)
+
+**Branch**: `claude/phase-8.4-mobile-top-picks`
+
+- Mirror 8.3 in `apps/mobile/app/restaurants/[id].tsx`: horizontal
+  Top Picks cards above the section list; same thresholds and
+  anonymous behavior.
+
+Specs (jest/RTL): same coverage at screen level.
+
+### 8.5 — Taste onboarding step (web + mobile)
+
+**Branch**: `claude/phase-8.5-taste-onboarding`
+
+- New onboarding step between strictness and review: "What do you
+  love?" — tap-to-like cuisine/flavor tag chips (from the tag
+  families) + optional ingredient search; long-press/secondary action
+  marks dislike. Skippable — taste is optional, safety is not.
+- Existing users: an "Improve my picks" entry on the profile screen
+  reaches the same step standalone.
+- PATCHes the Phase 8.1 fields.
+
+Specs: chip toggle cycle (neutral → liked → disliked → neutral),
+skip leaves arrays empty, PATCH payload shape.
+
+## Cross-cutting
+
+- Analytics: add optional properties (e.g. `top_picks_shown`,
+  `taste_signal_count`) to existing events only — no event renames.
+- Copy must never imply a low-scored item is unsafe — taste ≠ safety.
+
+## Out of scope for Phase 8
+
+- Learning weights from behavior (taps, reviews, overrides) — future.
+- Collaborative filtering / "people like you" — future.
+- Per-restaurant cuisine inference beyond existing tags.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,12 +11,33 @@ The loop takes these in order, top-down. `[BLOCKED]` prefix means
 "skip; needs a human to clear." See `docs/delivery-playbook.md` for
 the merge / review / status rules.
 
+**Phases 6–8** ⭐ The product-vision arc (owner-approved 2026-06-12):
+**6** anyone-can-scan ingestion (`docs/plans/phase-6.md`) → **7** close
+the real-world mobile scan loop (`docs/plans/phase-7.md`) → **8**
+"most likely to enjoy" taste ranking (`docs/plans/phase-8.md`).
+Queue below runs top-down; the launch wiring items stay `[BLOCKED]`
+at the bottom until credentials drop.
+
 **Phase 5** ⭐ Launch (Durango). Subplan: `docs/plans/phase-5.md`. **Loop work complete** — every code-only Phase-5 PR is on master. The full state-of-the-world checklist for the human is at `docs/launch-readiness.md`.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
-2. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
+1. **Phase 6.1 — non-admin ingestion runs + quotas + cost ceiling** (`docs/plans/phase-6.md`)
+2. **Phase 6.2 — community restaurant creation + pg_trgm duplicate detection**
+3. **Phase 6.3 — self-verify + community-trust promotion (suggested, not confirmed)**
+4. **Phase 6.4 — community-publish moderation visibility (Avo + dashboard)**
+5. **Phase 6.5 — web community scan entrypoint (open /ingest + new-restaurant + web verify)**
+6. **Phase 6.6 — mobile community scan entrypoint**
+7. **Phase 7.1 — wire the real camera capture (expo-camera)** (`docs/plans/phase-7.md`)
+8. **Phase 7.2 — real mobile home screen (search + near-me + scan CTA)**
+9. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
+10. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
+11. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)**
+12. **Phase 8.3 — Top Picks UI (web)**
+13. **Phase 8.4 — Top Picks UI (mobile)**
+14. **Phase 8.5 — taste onboarding step (web + mobile)**
+15. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
+16. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
 ### Done
 
@@ -190,6 +211,42 @@ Subplan: `docs/plans/phase-5.md`.
 - Public launch posts + outreach to Durango press
 
 **Demo:** real users on a Friday night using it to pick where to eat.
+
+## Phase 6 — Anyone-can-scan ingestion
+
+Subplan: `docs/plans/phase-6.md`. Opens the Phase-2 pipeline to every
+signed-in user with quotas, a cost ceiling, pg_trgm duplicate
+detection, and a trust model where community verification lands
+`confidence: suggested` (strict-mode users stay protected until an
+admin confirms).
+
+**Demo:** a non-admin account creates a new restaurant, scans its
+menu, swipe-verifies, and it goes live — invisible to strict-mode
+users until confirmed. A second scanner gets a "did you mean…?"
+dedup prompt.
+
+## Phase 7 — Close the real-world mobile scan loop
+
+Subplan: `docs/plans/phase-7.md`. Wires the real expo-camera capture
+(the Phase 2.6 TODO), replaces the placeholder mobile home screen
+with search + near-me + a scan CTA, and stitches search-miss →
+create → capture → progress → verify → filtered menu into one flow.
+
+**Demo:** cold-start the app at a restaurant that isn't listed and
+get from "Scan a menu" to reading your own filtered menu without
+leaving the flow.
+
+## Phase 8 — "Most likely to enjoy" taste ranking
+
+Subplan: `docs/plans/phase-8.md`. Safety filters, taste ranks: new
+liked/disliked signal arrays on profiles, a deterministic scoring
+model implemented twice (SQL + filter-engine) with a parity fixture,
+a Top Picks row on web + mobile, and an optional taste onboarding
+step.
+
+**Demo:** two users with identical allergies open the same menu and
+see the same safe items but different Top Picks, each with a
+"because you like…" explainer.
 
 ## Discovered (loop-added followups)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,24 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 00:05 — tick #130 (interactive session, loop restarted).
+**Owner approved the product-vision arc; Phases 6–8 planned and
+queued.** Owner restated the BIG goal (anyone scans any menu → full
+import incl. ingredients/prices/photos → personalized "most likely
+to enjoy" view) and greenlit an overnight 30-min loop to ship it.
+Gap analysis: pipeline/extraction/filtering largely built; gaps are
+(A) ingestion is admin-only, (B) no taste ranking — only avoid-list
+hiding, (C) mobile camera ref TODO + placeholder home screen, (D)
+nothing deployed (human-gated). This PR commits the plan:
+`docs/plans/phase-6.md` (anyone-can-scan: quotas, cost ceiling,
+community restaurant create + pg_trgm dedup, self-verify with
+suggested-confidence trust model, moderation visibility, web+mobile
+entrypoints), `docs/plans/phase-7.md` (camera wiring, real home
+screen, end-to-end scan flow), `docs/plans/phase-8.md` (taste
+signals schema, SQL+TS scoring parity, Top Picks UI, taste
+onboarding) + roadmap Next-up queue (14 unblocked items, launch
+wiring stays [BLOCKED] at bottom). Next: Phase 6.1.
+
 2026-06-11 23:29 — tick #129 (interactive session). **Automation
 hardening shipped; branch protection enforced.** Owner asked for the
 longterm-development automations; plan written to


### PR DESCRIPTION
## Why

Owner restated the BIG product goal tonight (anyone scans any menu → full import incl. ingredients/prices/photos → personalized "most likely to enjoy" simplified view) and approved the gap-analysis plan. This PR commits that plan in the format the delivery loop consumes. Roadmap item: Phases 6–8 arc.

## What

- `docs/plans/phase-6.md` — anyone-can-scan ingestion: non-admin runs + quotas + cost ceiling, community restaurant creation + pg_trgm dedup, self-verify with a suggested-confidence trust model (strict-mode users stay protected), moderation visibility, web + mobile entrypoints.
- `docs/plans/phase-7.md` — close the mobile scan loop: wire the real expo-camera capture (Phase 2.6 TODO), real home screen (search + near-me + scan CTA), stitched scan-to-menu flow.
- `docs/plans/phase-8.md` — taste ranking: liked/disliked signal arrays, deterministic scoring in SQL + filter-engine with a shared parity fixture, Top Picks UI on both surfaces, optional taste onboarding step. Principle: safety filters, taste ranks.
- `docs/roadmap.md` — Next-up queue replaced with the 14 unblocked tasks (6.1 → 8.5); launch-wiring items stay [BLOCKED] at the bottom; phase sections added.
- `docs/status.md` — tick #130 logged.

## Test plan

- [x] Docs-only change — no code paths affected
- [x] Queue ordering matches the owner-approved A → C → B sequencing (6 → 7 → 8)
- [x] [BLOCKED] launch items preserved verbatim at queue bottom

## Notes

The 30-min delivery loop is live again as of tonight (interactive session). First implementation PR (Phase 6.1) follows immediately after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)