### PR TITLE
feat(api): open ingestion runs to all users with quota + cost ceiling

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -46,6 +46,13 @@ ADMIN_PASSWORD=admin
 # so it doesn't need the key. Production must set it.
 ANTHROPIC_API_KEY=
 
+# Phase 6.1 — community ingestion guardrails. Non-admin run creation is
+# bounded by a per-user rolling-24h quota and a global daily spend
+# ceiling (sum of ingestion_runs.api_cost_cents created today, UTC).
+# Admins bypass both. Defaults shown.
+INGESTION_RUNS_PER_USER_PER_DAY=5
+INGESTION_DAILY_COST_CEILING_CENTS=2000
+
 # --- Mailer ------------------------------------------------------------------
 # Used by Devise for password-reset emails. The mailer itself isn't
 # wired in until Phase 4; this is documented now so .env stays canonical.

--- a/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
@@ -4,12 +4,16 @@ module Api
     #   { restaurant_id: <uuid>, inputs[]: <files> }
     # GET  /api/v1/ingestion_runs/:id
     #
-    # Phase 2.6 — the mobile camera capture flow uploads here. Auth-gated
-    # to admins (Phase 4 introduces a contributor role). The endpoint
-    # creates the run, attaches the images, and kicks off the
+    # Phase 2.6 — the mobile camera capture flow uploads here. The
+    # endpoint creates the run, attaches the images, and kicks off the
     # ExtractMenuJob via the state machine.
+    #
+    # Phase 6.1 — open to any authenticated user (was admin-only).
+    # Non-admins are bounded by a per-user rolling-24h run quota and a
+    # global daily API-spend ceiling; admins bypass both. Community
+    # trust handling (suggested-confidence promotion) is Phase 6.3.
     class IngestionRunsController < BaseController
-      before_action :ensure_admin!, only: [:create]
+      before_action :enforce_community_limits!, only: [:create]
 
       def create
         restaurant = Restaurant.find(params.require(:restaurant_id))
@@ -73,9 +77,40 @@ module Api
                status: :unprocessable_entity
       end
 
-      def ensure_admin!
+      PER_USER_DAILY_RUNS_DEFAULT      = 5
+      DAILY_COST_CEILING_CENTS_DEFAULT = 2_000 # $20/day across all non-admin spend
+
+      def enforce_community_limits!
         return if current_user&.is_admin?
-        render json: { error: "forbidden" }, status: :forbidden
+
+        if runs_in_last_24h >= per_user_daily_limit
+          render json: { error: "quota_exceeded", limit: per_user_daily_limit },
+                 status: :too_many_requests
+          return
+        end
+
+        if todays_spend_cents >= daily_cost_ceiling_cents
+          render json: { error: "cost_ceiling_reached" }, status: :service_unavailable
+        end
+      end
+
+      def runs_in_last_24h
+        IngestionRun.where(user_id: current_user.id)
+                    .where(created_at: 24.hours.ago..)
+                    .count
+      end
+
+      def todays_spend_cents
+        IngestionRun.where(created_at: Time.current.utc.beginning_of_day..)
+                    .sum(:api_cost_cents)
+      end
+
+      def per_user_daily_limit
+        Integer(ENV.fetch("INGESTION_RUNS_PER_USER_PER_DAY", PER_USER_DAILY_RUNS_DEFAULT))
+      end
+
+      def daily_cost_ceiling_cents
+        Integer(ENV.fetch("INGESTION_DAILY_COST_CEILING_CENTS", DAILY_COST_CEILING_CENTS_DEFAULT))
       end
 
       def detect_input_kind(file)

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -42,13 +42,17 @@ RSpec.describe "Ingestion runs API", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it "rejects a non-admin caller with 403" do
-      post "/api/v1/ingestion_runs",
-           params: { restaurant_id: restaurant.id, inputs: [fake_image] },
-           headers: auth_for(non_admin)
+    it "creates a run for a non-admin caller (Phase 6.1 — anyone can scan)" do
+      allow(ExtractMenuJob).to receive(:perform_later)
 
-      expect(response).to have_http_status(:forbidden)
-      expect(response.parsed_body["error"]).to eq("forbidden")
+      expect {
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id, inputs: [fake_image] },
+             headers: auth_for(non_admin)
+      }.to change(IngestionRun, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(IngestionRun.last.user_id).to eq(non_admin.id)
     end
 
     it "422s when no inputs are attached" do
@@ -144,6 +148,86 @@ RSpec.describe "Ingestion runs API", type: :request do
         expect(body["error"]).to  eq("url_fetch_failed")
         expect(body["reason"]).to eq("non_2xx")
         expect(body["status"]).to eq(503)
+      end
+    end
+  end
+
+  describe "community limits (Phase 6.1)" do
+    before { allow(ExtractMenuJob).to receive(:perform_later) }
+
+    around do |example|
+      old_quota   = ENV["INGESTION_RUNS_PER_USER_PER_DAY"]
+      old_ceiling = ENV["INGESTION_DAILY_COST_CEILING_CENTS"]
+      example.run
+    ensure
+      ENV["INGESTION_RUNS_PER_USER_PER_DAY"]    = old_quota
+      ENV["INGESTION_DAILY_COST_CEILING_CENTS"] = old_ceiling
+    end
+
+    def create_run_as(user)
+      post "/api/v1/ingestion_runs",
+           params: { restaurant_id: restaurant.id, inputs: [fake_image] },
+           headers: auth_for(user)
+    end
+
+    describe "per-user daily quota" do
+      before { ENV["INGESTION_RUNS_PER_USER_PER_DAY"] = "2" }
+
+      it "allows runs up to the quota, then 429s with the limit in the payload" do
+        2.times { create_run_as(non_admin) }
+        expect(response).to have_http_status(:created)
+
+        expect { create_run_as(non_admin) }.not_to change(IngestionRun, :count)
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.parsed_body).to include("error" => "quota_exceeded", "limit" => 2)
+      end
+
+      it "is a rolling 24h window — runs older than 24h don't count" do
+        create(:ingestion_run, user: non_admin, restaurant: restaurant, created_at: 25.hours.ago)
+        create(:ingestion_run, user: non_admin, restaurant: restaurant, created_at: 1.hour.ago)
+
+        create_run_as(non_admin)
+        expect(response).to have_http_status(:created)
+      end
+
+      it "is per-user — another user's runs don't count against mine" do
+        other = create(:user, password: "password123", is_admin: false)
+        2.times { create(:ingestion_run, user: other, restaurant: restaurant) }
+
+        create_run_as(non_admin)
+        expect(response).to have_http_status(:created)
+      end
+
+      it "admins bypass the quota" do
+        3.times { create_run_as(admin) }
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    describe "global daily cost ceiling" do
+      before { ENV["INGESTION_DAILY_COST_CEILING_CENTS"] = "1000" }
+
+      it "503s non-admin creation once today's spend reaches the ceiling" do
+        create(:ingestion_run, user: admin, restaurant: restaurant, api_cost_cents: 1_000)
+
+        expect { create_run_as(non_admin) }.not_to change(IngestionRun, :count)
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.parsed_body["error"]).to eq("cost_ceiling_reached")
+      end
+
+      it "ignores spend from previous days" do
+        create(:ingestion_run, user: admin, restaurant: restaurant,
+                               api_cost_cents: 5_000, created_at: 2.days.ago)
+
+        create_run_as(non_admin)
+        expect(response).to have_http_status(:created)
+      end
+
+      it "admins bypass the ceiling" do
+        create(:ingestion_run, user: admin, restaurant: restaurant, api_cost_cents: 9_999)
+
+        create_run_as(admin)
+        expect(response).to have_http_status(:created)
       end
     end
   end

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,21 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 02:00 — tick #131. **Phase 6.1 shipped — anyone can create
+ingestion runs.** Plan PR #296 merged. This PR drops `ensure_admin!`
+from POST /api/v1/ingestion_runs and adds the community guardrails:
+per-user rolling-24h quota (`INGESTION_RUNS_PER_USER_PER_DAY`,
+default 5 → 429 `quota_exceeded`) + global daily spend ceiling over
+`api_cost_cents` (`INGESTION_DAILY_COST_CEILING_CENTS`, default
+$20 → 503 `cost_ceiling_reached`); admins bypass both. Both vars
+documented in `apps/api/.env.example`. The non-admin-403 spec became
+a non-admin-201 spec; 7 new limit specs (quota boundary, rolling
+window, per-user isolation, prior-day spend ignored, admin bypasses).
+rspec 394/394; brakeman 0 warnings. Note: ingestion_runs has no
+rswag spec (pre-existing gap — openapi.json never covered it), so no
+codegen delta. Next: Phase 6.2 community restaurant creation +
+pg_trgm dedup.
+
 2026-06-12 00:05 — tick #130 (interactive session, loop restarted).
 **Owner approved the product-vision arc; Phases 6–8 planned and
 queued.** Owner restated the BIG goal (anyone scans any menu → full


### PR DESCRIPTION
## Why

Phase 6.1 (`docs/plans/phase-6.md`) — first step of the anyone-can-scan arc the owner approved tonight. The product goal requires any signed-in user to scan a menu; today `POST /api/v1/ingestion_runs` is admin-only.

## What

- `IngestionRunsController`: `ensure_admin!` on `:create` replaced with `enforce_community_limits!` —
  - per-user rolling-24h quota: `INGESTION_RUNS_PER_USER_PER_DAY` (default 5) → 429 `{error: "quota_exceeded", limit: N}`
  - global daily spend ceiling: sum of `api_cost_cents` on runs created today (UTC) vs `INGESTION_DAILY_COST_CEILING_CENTS` (default 2000 = $20) → 503 `{error: "cost_ceiling_reached"}`
  - admins bypass both; `GET :show` owner-or-admin rule unchanged
- Both env vars documented in `apps/api/.env.example`
- Specs: the non-admin-403 expectation flipped to non-admin-201; new `community limits` block covers quota boundary (2nd ok / 3rd 429), rolling-24h window, per-user isolation, admin quota bypass, ceiling trip, prior-day spend ignored, admin ceiling bypass
- `docs/status.md` tick #131

## Test plan

- [x] `bundle exec rspec` — 394 examples, 0 failures (full suite)
- [x] `bundle exec brakeman` — 0 warnings
- [x] Rubocop advisory (no project .rubocop.yml; CI runs it continue-on-error)

## Notes

- `ingestion_runs` has **no rswag spec** (pre-existing — openapi.json never covered this endpoint), so there is no codegen delta in this PR. Worth a Discovered entry when the queue next gets triaged: the mobile/web ingestion clients still rely on hand-written types.
- Community *verification* trust handling (suggested-vs-confirmed promotion) is deliberately NOT in this PR — that's Phase 6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)