### PR TITLE
fix(api): harden community ingestion — cost accrual, quota race, upload caps

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -53,6 +53,12 @@ ANTHROPIC_API_KEY=
 INGESTION_RUNS_PER_USER_PER_DAY=5
 INGESTION_DAILY_COST_CEILING_CENTS=2000
 
+# Phase 6.1.1 — per-run multipart upload caps (apply to everyone,
+# admins included; the extraction job base64-encodes every input byte
+# into the vision prompt). Bytes default matches UrlFetcher's 10 MB.
+INGESTION_MAX_INPUT_FILES=10
+INGESTION_MAX_INPUT_FILE_BYTES=10485760
+
 # --- Mailer ------------------------------------------------------------------
 # Used by Devise for password-reset emails. The mailer itself isn't
 # wired in until Phase 4; this is documented now so .env stays canonical.

--- a/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
@@ -13,8 +13,6 @@ module Api
     # global daily API-spend ceiling; admins bypass both. Community
     # trust handling (suggested-confidence promotion) is Phase 6.3.
     class IngestionRunsController < BaseController
-      before_action :enforce_community_limits!, only: [:create]
-
       def create
         restaurant = Restaurant.find(params.require(:restaurant_id))
         files      = Array(params[:inputs]).reject(&:blank?)
@@ -25,10 +23,34 @@ module Api
           return
         end
 
+        return unless validate_files!(files)
+
+        # URL fetch happens BEFORE the per-user lock — an upstream
+        # server's slowness must not extend how long we hold a DB
+        # transaction + advisory lock.
+        fetched = nil
         if source_url
-          create_from_url(restaurant, source_url)
-        else
-          create_from_files(restaurant, files)
+          begin
+            fetched = UrlFetcher.fetch(source_url)
+          rescue UrlFetcher::FetchError => e
+            render json: { error: "url_fetch_failed", reason: e.reason, status: e.status },
+                   status: :unprocessable_entity
+            return
+          end
+        end
+
+        # The quota check and the INSERT must be atomic per user, or
+        # parallel requests just under the quota all pass the read and
+        # all insert (codex P2 on #297). pg_advisory_xact_lock keyed on
+        # the user id serializes them; admins skip the lock entirely.
+        with_per_user_serialization do
+          next unless enforce_community_limits!
+
+          if fetched
+            create_from_fetched(restaurant, source_url, fetched)
+          else
+            create_from_files(restaurant, files)
+          end
         end
       end
 
@@ -56,8 +78,7 @@ module Api
         render json: serialize_run(run), status: :created
       end
 
-      def create_from_url(restaurant, source_url)
-        result = UrlFetcher.fetch(source_url)
+      def create_from_fetched(restaurant, source_url, result)
         run = IngestionRun.create!(
           user:       current_user,
           restaurant: restaurant,
@@ -72,26 +93,74 @@ module Api
         run.transition_to!(:extracting)
 
         render json: serialize_run(run), status: :created
-      rescue UrlFetcher::FetchError => e
-        render json: { error: "url_fetch_failed", reason: e.reason, status: e.status },
-               status: :unprocessable_entity
       end
 
       PER_USER_DAILY_RUNS_DEFAULT      = 5
       DAILY_COST_CEILING_CENTS_DEFAULT = 2_000 # $20/day across all non-admin spend
+      MAX_INPUT_FILES_DEFAULT          = 10
+      MAX_INPUT_FILE_BYTES_DEFAULT     = 10 * 1024 * 1024 # match UrlFetcher's 10 MB cap
 
+      ALLOWED_INPUT_CONTENT_TYPES = %w[
+        image/jpeg image/png image/heic image/heif image/webp application/pdf
+      ].freeze
+
+      # Direct multipart uploads need the same bounds the URL path has
+      # had since Phase 2.8 (codex P2 on #297). Applies to admins too —
+      # the extraction job base64-encodes every byte into the prompt,
+      # so oversized inputs hurt regardless of who sent them.
+      def validate_files!(files)
+        return true if files.empty?
+
+        if files.size > max_input_files
+          render json: { error: "too_many_files", limit: max_input_files },
+                 status: :unprocessable_entity
+          return false
+        end
+
+        if files.any? { |f| f.size.to_i > max_input_file_bytes }
+          render json: { error: "file_too_large", limit_bytes: max_input_file_bytes },
+                 status: :unprocessable_entity
+          return false
+        end
+
+        if files.any? { |f| ALLOWED_INPUT_CONTENT_TYPES.exclude?(f.content_type.to_s) }
+          render json: { error: "unsupported_file_type", allowed: ALLOWED_INPUT_CONTENT_TYPES },
+                 status: :unprocessable_entity
+          return false
+        end
+
+        true
+      end
+
+      def with_per_user_serialization(&block)
+        return yield if current_user&.is_admin?
+
+        ActiveRecord::Base.transaction do
+          ActiveRecord::Base.connection.execute(
+            ActiveRecord::Base.sanitize_sql_array(
+              ["SELECT pg_advisory_xact_lock(hashtext(?))", current_user.id]
+            )
+          )
+          block.call
+        end
+      end
+
+      # Returns true when within limits; renders + returns false otherwise.
       def enforce_community_limits!
-        return if current_user&.is_admin?
+        return true if current_user&.is_admin?
 
         if runs_in_last_24h >= per_user_daily_limit
           render json: { error: "quota_exceeded", limit: per_user_daily_limit },
                  status: :too_many_requests
-          return
+          return false
         end
 
         if todays_spend_cents >= daily_cost_ceiling_cents
           render json: { error: "cost_ceiling_reached" }, status: :service_unavailable
+          return false
         end
+
+        true
       end
 
       def runs_in_last_24h
@@ -111,6 +180,14 @@ module Api
 
       def daily_cost_ceiling_cents
         Integer(ENV.fetch("INGESTION_DAILY_COST_CEILING_CENTS", DAILY_COST_CEILING_CENTS_DEFAULT))
+      end
+
+      def max_input_files
+        Integer(ENV.fetch("INGESTION_MAX_INPUT_FILES", MAX_INPUT_FILES_DEFAULT))
+      end
+
+      def max_input_file_bytes
+        Integer(ENV.fetch("INGESTION_MAX_INPUT_FILE_BYTES", MAX_INPUT_FILE_BYTES_DEFAULT))
       end
 
       def detect_input_kind(file)

--- a/apps/api/app/jobs/extract_menu_job.rb
+++ b/apps/api/app/jobs/extract_menu_job.rb
@@ -52,6 +52,7 @@ class ExtractMenuJob < ApplicationJob
 
     elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
 
+    run.record_api_usage!(client.last_usage, model: client.model)
     run.update!(
       staging:    result,
       latency_ms: elapsed_ms

--- a/apps/api/app/jobs/resolve_ingredients_job.rb
+++ b/apps/api/app/jobs/resolve_ingredients_job.rb
@@ -43,6 +43,7 @@ class ResolveIngredientsJob < ApplicationJob
 
     elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
 
+    run.record_api_usage!(client.last_usage, model: client.model)
     run.update!(
       staging:    apply_resolution(run.staging, result, key: :ingredients),
       latency_ms: elapsed_ms

--- a/apps/api/app/jobs/resolve_tags_job.rb
+++ b/apps/api/app/jobs/resolve_tags_job.rb
@@ -41,6 +41,7 @@ class ResolveTagsJob < ApplicationJob
 
     elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
 
+    run.record_api_usage!(client.last_usage, model: client.model)
     new_staging = ResolveIngredientsJob.new.apply_resolution(run.staging, result, key: :tags)
 
     run.transaction do

--- a/apps/api/app/models/ingestion_run.rb
+++ b/apps/api/app/models/ingestion_run.rb
@@ -101,6 +101,25 @@ class IngestionRun < ApplicationRecord
     true
   end
 
+  # Phase 6.1.1 — accrue one Anthropic call's usage onto the run.
+  # Called by each pipeline job after a successful API call. Safe
+  # no-op when usage is nil (job specs stub messages_create without
+  # usage; VCR replays carry it). Jobs run sequentially per run, so
+  # read-modify-write here doesn't race.
+  def record_api_usage!(usage, model: nil)
+    return self if usage.blank?
+
+    pricing_model = model || self.model || AnthropicClient::DEFAULT_MODEL
+    update!(
+      model:                 pricing_model,
+      api_cost_cents:        api_cost_cents + Ingestion::UsageCost.cents(usage, model: pricing_model),
+      cached_input_tokens:   cached_input_tokens + usage["cache_read_input_tokens"].to_i,
+      uncached_input_tokens: uncached_input_tokens + usage["input_tokens"].to_i +
+                             usage["cache_creation_input_tokens"].to_i
+    )
+    self
+  end
+
   private
 
   def record_state_entry!(new_status)

--- a/apps/api/app/services/anthropic_client.rb
+++ b/apps/api/app/services/anthropic_client.rb
@@ -83,6 +83,13 @@ class AnthropicClient
 
   attr_reader :api_key, :model, :base_url
 
+  # The `usage` object from the most recent successful messages_create
+  # call ({"input_tokens" =>, "output_tokens" =>,
+  # "cache_read_input_tokens" =>, "cache_creation_input_tokens" =>}).
+  # Phase 6.1.1 — jobs read this after each call to accrue real cost
+  # onto IngestionRun.api_cost_cents. Nil until a call succeeds.
+  attr_reader :last_usage
+
   def initialize(api_key: nil, model: nil, base_url: nil, conn: nil)
     @api_key  = api_key  || ENV["ANTHROPIC_API_KEY"] || ""
     @model    = model    || DEFAULT_MODEL
@@ -113,6 +120,7 @@ class AnthropicClient
     end
 
     parsed = response.body.is_a?(Hash) ? response.body : JSON.parse(response.body)
+    @last_usage = parsed["usage"]
     return parsed if response_schema.nil?
 
     text = ResponseParser.first_text(parsed)

--- a/apps/api/app/services/ingestion/usage_cost.rb
+++ b/apps/api/app/services/ingestion/usage_cost.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Phase 6.1.1 — turns an Anthropic `usage` object into cents so
+# IngestionRun.api_cost_cents reflects real spend (the Phase 6.1 daily
+# cost ceiling and the Phase 2.9 dashboard both read that column).
+#
+# Pricing is cents per million tokens, from the published rate card
+# (claude-sonnet-4-6: $3/MTok input, $15/MTok output; prompt-cache
+# reads bill at 0.1x input, 5-minute-TTL cache writes at 1.25x input).
+# Unknown models fall back to the default model's pricing — wrong-ish
+# beats zero for a spend guardrail.
+#
+# Per-call costs round UP to the next cent. Sub-cent resolve calls
+# would otherwise round to zero and the ceiling would leak; for a
+# guardrail, overstating by <1 cent per call is the safe direction.
+module Ingestion
+  class UsageCost
+    CENTS_PER_MTOK = {
+      "claude-sonnet-4-6" => {
+        input:       300,
+        output:      1_500,
+        cache_read:  30,
+        cache_write: 375
+      }
+    }.freeze
+
+    def self.cents(usage, model: AnthropicClient::DEFAULT_MODEL)
+      return 0 if usage.blank?
+
+      rates = CENTS_PER_MTOK.fetch(model, CENTS_PER_MTOK.fetch(AnthropicClient::DEFAULT_MODEL))
+      raw = (usage["input_tokens"].to_i          * rates[:input]) +
+            (usage["output_tokens"].to_i         * rates[:output]) +
+            (usage["cache_read_input_tokens"].to_i     * rates[:cache_read]) +
+            (usage["cache_creation_input_tokens"].to_i * rates[:cache_write])
+      (raw / 1_000_000.0).ceil
+    end
+  end
+end

--- a/apps/api/spec/jobs/extract_menu_job_spec.rb
+++ b/apps/api/spec/jobs/extract_menu_job_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe ExtractMenuJob, type: :job do
       run.reload
       expect(run.status).to eq("staged")
     end
+
+    it "accrues real cost + tokens from the call's usage (Phase 6.1.1)" do
+      usage = { "input_tokens" => 100_000, "output_tokens" => 2_000,
+                "cache_read_input_tokens" => 0, "cache_creation_input_tokens" => 0 }
+      allow_any_instance_of(AnthropicClient).to receive(:last_usage).and_return(usage)
+
+      described_class.perform_now(run.id)
+
+      run.reload
+      expect(run.api_cost_cents).to be > 0
+      expect(run.uncached_input_tokens).to eq(100_000)
+      expect(run.model).to eq(AnthropicClient::DEFAULT_MODEL)
+    end
   end
 
   describe "no inputs attached" do

--- a/apps/api/spec/models/ingestion_run_spec.rb
+++ b/apps/api/spec/models/ingestion_run_spec.rb
@@ -102,4 +102,33 @@ RSpec.describe IngestionRun, type: :model do
       expect(run.failed?).to     be false
     end
   end
+
+  describe "#record_api_usage! (Phase 6.1.1)" do
+    let(:run) { create(:ingestion_run) }
+
+    let(:usage) do
+      { "input_tokens" => 100_000, "output_tokens" => 2_000,
+        "cache_read_input_tokens" => 50_000, "cache_creation_input_tokens" => 10_000 }
+    end
+
+    it "accrues cost + token counts and stamps the model" do
+      run.record_api_usage!(usage, model: "claude-sonnet-4-6")
+
+      run.reload
+      expect(run.api_cost_cents).to eq(Ingestion::UsageCost.cents(usage, model: "claude-sonnet-4-6"))
+      expect(run.cached_input_tokens).to   eq(50_000)
+      expect(run.uncached_input_tokens).to eq(110_000) # input + cache writes
+      expect(run.model).to eq("claude-sonnet-4-6")
+    end
+
+    it "accumulates across calls — three pipeline stages add up, not overwrite" do
+      2.times { run.record_api_usage!(usage, model: "claude-sonnet-4-6") }
+
+      expect(run.reload.cached_input_tokens).to eq(100_000)
+    end
+
+    it "no-ops on nil usage (stubbed clients, failed calls)" do
+      expect { run.record_api_usage!(nil) }.not_to change { run.reload.api_cost_cents }
+    end
+  end
 end

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -158,10 +158,62 @@ RSpec.describe "Ingestion runs API", type: :request do
     around do |example|
       old_quota   = ENV["INGESTION_RUNS_PER_USER_PER_DAY"]
       old_ceiling = ENV["INGESTION_DAILY_COST_CEILING_CENTS"]
+      old_files   = ENV["INGESTION_MAX_INPUT_FILES"]
+      old_bytes   = ENV["INGESTION_MAX_INPUT_FILE_BYTES"]
       example.run
     ensure
       ENV["INGESTION_RUNS_PER_USER_PER_DAY"]    = old_quota
       ENV["INGESTION_DAILY_COST_CEILING_CENTS"] = old_ceiling
+      ENV["INGESTION_MAX_INPUT_FILES"]          = old_files
+      ENV["INGESTION_MAX_INPUT_FILE_BYTES"]     = old_bytes
+    end
+
+    describe "upload caps (Phase 6.1.1)" do
+      it "422s when more files than the cap are attached" do
+        ENV["INGESTION_MAX_INPUT_FILES"] = "2"
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id,
+                       inputs: [fake_image("1.jpg"), fake_image("2.jpg"), fake_image("3.jpg")] },
+             headers: auth_for(non_admin)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to include("error" => "too_many_files", "limit" => 2)
+      end
+
+      it "422s when a file exceeds the byte cap" do
+        ENV["INGESTION_MAX_INPUT_FILE_BYTES"] = "2"
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id, inputs: [fake_image] },
+             headers: auth_for(non_admin)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error"]).to eq("file_too_large")
+      end
+
+      it "422s on content types the pipeline can't extract from" do
+        txt = Rack::Test::UploadedFile.new(StringIO.new("just text"), "text/plain",
+                                           original_filename: "menu.txt")
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id, inputs: [txt] },
+             headers: auth_for(non_admin)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error"]).to eq("unsupported_file_type")
+      end
+
+      it "applies the caps to admins too" do
+        ENV["INGESTION_MAX_INPUT_FILES"] = "1"
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id,
+                       inputs: [fake_image("1.jpg"), fake_image("2.jpg")] },
+             headers: auth_for(admin)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
 
     def create_run_as(user)

--- a/apps/api/spec/services/anthropic_client_spec.rb
+++ b/apps/api/spec/services/anthropic_client_spec.rb
@@ -113,6 +113,24 @@ RSpec.describe AnthropicClient do
       expect(result["content"].first["text"]).to include("Tacos")
     end
 
+    it "exposes the response usage via #last_usage (Phase 6.1.1 cost accrual)" do
+      stub_request(:post, "#{base_url}/v1/messages")
+        .to_return(status: 200, body: happy_response_body,
+                   headers: { "Content-Type" => "application/json" })
+
+      expect(client.last_usage).to be_nil
+
+      client.messages_create(
+        system:   [{ type: "text", text: "x" }],
+        messages: [{ role: "user", content: "hello" }]
+      )
+
+      expect(client.last_usage).to eq(
+        "input_tokens" => 10, "output_tokens" => 5,
+        "cache_creation_input_tokens" => 0, "cache_read_input_tokens" => 0
+      )
+    end
+
     context "with response_schema" do
       let(:menu_schema) do
         {

--- a/apps/api/spec/services/ingestion/usage_cost_spec.rb
+++ b/apps/api/spec/services/ingestion/usage_cost_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Ingestion::UsageCost do
+  describe ".cents" do
+    it "prices a vision-extraction-shaped call (big uncached input)" do
+      # 100k input tokens at $3/MTok = 30 cents; 2k output at $15/MTok = 3 cents
+      usage = { "input_tokens" => 100_000, "output_tokens" => 2_000,
+                "cache_read_input_tokens" => 0, "cache_creation_input_tokens" => 0 }
+
+      expect(described_class.cents(usage, model: "claude-sonnet-4-6")).to eq(33)
+    end
+
+    it "prices cache reads at a tenth of input and cache writes at 1.25x" do
+      # 1M cache-read = 30 cents; 1M cache-write = 375 cents
+      usage = { "input_tokens" => 0, "output_tokens" => 0,
+                "cache_read_input_tokens" => 1_000_000,
+                "cache_creation_input_tokens" => 1_000_000 }
+
+      expect(described_class.cents(usage, model: "claude-sonnet-4-6")).to eq(405)
+    end
+
+    it "rounds sub-cent calls UP so the daily ceiling can't leak via many cheap calls" do
+      usage = { "input_tokens" => 100, "output_tokens" => 100 }
+
+      expect(described_class.cents(usage, model: "claude-sonnet-4-6")).to eq(1)
+    end
+
+    it "returns 0 for nil/blank usage (stubbed-client specs, failed calls)" do
+      expect(described_class.cents(nil)).to eq(0)
+      expect(described_class.cents({})).to eq(0)
+    end
+
+    it "falls back to default-model pricing for unknown models" do
+      usage = { "input_tokens" => 1_000_000 }
+
+      expect(described_class.cents(usage, model: "some-future-model")).to eq(300)
+    end
+  end
+end

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,29 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 02:35 — tick #132. **Phase 6.1.1 — community ingestion
+hardened per codex review of #297.** All three codex findings were
+real and are fixed forward:
+- **P1 (cost ceiling read a column nothing wrote):** confirmed —
+  no job ever wrote `api_cost_cents`. AnthropicClient now exposes
+  `last_usage`; new `Ingestion::UsageCost` prices it (sonnet-4-6
+  rate card, cache-read 0.1x / cache-write 1.25x, ceil per call so
+  sub-cent calls can't leak the ceiling); all three pipeline jobs
+  call the new `IngestionRun#record_api_usage!` (cost + cached/
+  uncached token columns + model stamp). The Phase 2.9 dashboard
+  starts showing real numbers too.
+- **P2 (quota TOCTOU race):** quota check + INSERT now serialized
+  per user via `pg_advisory_xact_lock(hashtext(user_id))`; admins
+  skip the lock. URL fetch happens BEFORE the lock so a slow
+  upstream can't hold a DB transaction open.
+- **P2 (unbounded multipart uploads):** per-run caps — max files
+  (`INGESTION_MAX_INPUT_FILES`, 10), per-file bytes
+  (`INGESTION_MAX_INPUT_FILE_BYTES`, 10 MB = UrlFetcher's cap),
+  content-type allowlist (jpeg/png/heic/heif/webp/pdf). Applies to
+  admins too.
+rspec 408/408 (+14); brakeman 0. Next: Phase 6.2 community
+restaurant creation + pg_trgm dedup.
+
 2026-06-12 02:00 — tick #131. **Phase 6.1 shipped — anyone can create
 ingestion runs.** Plan PR #296 merged. This PR drops `ensure_admin!`
 from POST /api/v1/ingestion_runs and adds the community guardrails:


### PR DESCRIPTION
## Why

Codex review of #297 flagged three real issues with opening ingestion to all users. All three verified and fixed forward (Phase 6.1.1, part of the `docs/plans/phase-6.md` arc).

## What

**P1 — the cost ceiling read a column nothing wrote.** Verified: no pipeline job ever wrote `api_cost_cents` (the Phase 2.9 dashboard has been showing zeros too).
- `AnthropicClient` exposes `last_usage` (the `usage` object from the most recent call)
- New `Ingestion::UsageCost` prices usage from the sonnet-4-6 rate card ($3/MTok in, $15/MTok out, cache-read 0.1×, 5-min cache-write 1.25×); per-call cost **ceils** so many sub-cent calls can't slide under the ceiling
- New `IngestionRun#record_api_usage!` accrues cost + `cached_input_tokens` + `uncached_input_tokens` + stamps `model`; called by all three jobs after each successful call; graceful no-op when usage is nil (stubbed-client specs)

**P2 — quota TOCTOU race.** Quota check + INSERT now run inside one transaction holding `pg_advisory_xact_lock(hashtext(user_id))` — parallel just-under-quota requests serialize. Admins skip the lock. The URL fetch was deliberately moved **before** the lock so a slow upstream can't hold a DB transaction + lock open.

**P2 — unbounded multipart uploads.** Per-run caps, applied to admins too: `INGESTION_MAX_INPUT_FILES` (10), `INGESTION_MAX_INPUT_FILE_BYTES` (10 MB, matching UrlFetcher), content-type allowlist (jpeg/png/heic/heif/webp/pdf). Documented in `.env.example`.

## Test plan

- [x] `bundle exec rspec` — 408 examples, 0 failures (+14 new: UsageCost math incl. ceil + unknown-model fallback, record_api_usage! accrual/accumulation/no-op, client last_usage, upload-cap 422s incl. admin)
- [x] `bundle exec brakeman` — 0 warnings (advisory-lock SQL goes through sanitize_sql_array)

## Notes

- Pricing constants live in ONE place (`Ingestion::UsageCost::CENTS_PER_MTOK`); unknown models fall back to default-model pricing — wrong-ish beats zero for a guardrail.
- The race fix is structural (lock) rather than spec-asserted — request specs with real thread races are flaky by construction; existing quota specs cover behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)