### PR TITLE
fix(api): pre-check quotas before url fetch; accrue usage on schema failures

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
@@ -25,6 +25,11 @@ module Api
 
         return unless validate_files!(files)
 
+        # Cheap unlocked pre-check so an over-quota caller can't make
+        # us do an outbound URL fetch (codex P2 on #298). Advisory only
+        # — the authoritative check re-runs under the lock below.
+        return unless enforce_community_limits!
+
         # URL fetch happens BEFORE the per-user lock — an upstream
         # server's slowness must not extend how long we hold a DB
         # transaction + advisory lock.

--- a/apps/api/app/jobs/extract_menu_job.rb
+++ b/apps/api/app/jobs/extract_menu_job.rb
@@ -46,6 +46,9 @@ class ExtractMenuJob < ApplicationJob
       run.fail!("anthropic_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
       return
     rescue AnthropicClient::ValidationError => e
+      # The 200 was billed even though its body failed our schema —
+      # accrue it so the cost ceiling can't leak via failed runs.
+      run.record_api_usage!(client.last_usage, model: client.model)
       run.fail!("schema_validation_failed: #{e.errors.first(3).join('; ')}")
       return
     end

--- a/apps/api/app/jobs/resolve_ingredients_job.rb
+++ b/apps/api/app/jobs/resolve_ingredients_job.rb
@@ -37,6 +37,8 @@ class ResolveIngredientsJob < ApplicationJob
       run.fail!("resolve_ingredients_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
       return
     rescue AnthropicClient::ValidationError => e
+      # Billed 200 with a non-conforming body — still accrue its cost.
+      run.record_api_usage!(client.last_usage, model: client.model)
       run.fail!("resolve_ingredients_validation_failed: #{e.errors.first(3).join('; ')}")
       return
     end

--- a/apps/api/app/jobs/resolve_tags_job.rb
+++ b/apps/api/app/jobs/resolve_tags_job.rb
@@ -35,6 +35,8 @@ class ResolveTagsJob < ApplicationJob
       run.fail!("resolve_tags_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
       return
     rescue AnthropicClient::ValidationError => e
+      # Billed 200 with a non-conforming body — still accrue its cost.
+      run.record_api_usage!(client.last_usage, model: client.model)
       run.fail!("resolve_tags_validation_failed: #{e.errors.first(3).join('; ')}")
       return
     end

--- a/apps/api/spec/jobs/extract_menu_job_spec.rb
+++ b/apps/api/spec/jobs/extract_menu_job_spec.rb
@@ -122,6 +122,17 @@ RSpec.describe ExtractMenuJob, type: :job do
       expect(run.failure_message).to start_with("schema_validation_failed:")
       expect(run.failure_message).to include("sections must be an array")
     end
+
+    it "still accrues the billed usage (Phase 6.1.2 — a 200 that fails our schema cost money)" do
+      usage = { "input_tokens" => 100_000, "output_tokens" => 2_000 }
+      allow_any_instance_of(AnthropicClient).to receive(:last_usage).and_return(usage)
+
+      described_class.perform_now(run.id)
+
+      run.reload
+      expect(run.failed?).to be true
+      expect(run.api_cost_cents).to be > 0
+    end
   end
 
   describe "live-cassette integration smoke test" do

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -254,6 +254,17 @@ RSpec.describe "Ingestion runs API", type: :request do
         3.times { create_run_as(admin) }
         expect(response).to have_http_status(:created)
       end
+
+      it "rejects over-quota callers BEFORE doing any outbound URL fetch (Phase 6.1.2)" do
+        2.times { create(:ingestion_run, user: non_admin, restaurant: restaurant) }
+        expect(UrlFetcher).not_to receive(:fetch)
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id, source_url: "https://example.com/menu" },
+             headers: auth_for(non_admin)
+
+        expect(response).to have_http_status(:too_many_requests)
+      end
     end
 
     describe "global daily cost ceiling" do

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,15 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 03:05 — tick #133 (part 1). **Phase 6.1.2 — two codex P2s
+from #298 fixed forward.** (1) Over-quota callers could still force
+an outbound URL fetch: a cheap unlocked limits pre-check now runs
+before UrlFetcher; the authoritative check still re-runs under the
+advisory lock. (2) Billed 200s that failed schema validation never
+accrued usage: all three jobs now record_api_usage! in the
+ValidationError rescue before fail!. rspec 410/410 (+2). Part 2 of
+this tick: Phase 6.2.
+
 2026-06-12 02:35 — tick #132. **Phase 6.1.1 — community ingestion
 hardened per codex review of #297.** All three codex findings were
 real and are fixed forward:


### PR DESCRIPTION
## Why

Codex flagged two P2s on #298 (both verified real): over-quota callers could still force an outbound URL fetch, and billed 200s that fail schema validation were never accrued against the cost ceiling.

## What

- `IngestionRunsController#create`: cheap unlocked `enforce_community_limits!` pre-check before `UrlFetcher.fetch`; the authoritative check still re-runs inside the advisory lock (the pre-check is advisory, the locked check is the race-safe one)
- All three pipeline jobs record `client.last_usage` in their `ValidationError` rescue before `fail!` — a 200 whose body fails our JSON schema still cost real money

## Test plan

- [x] `bundle exec rspec` — 410 examples, 0 failures (+2: over-quota URL post never touches UrlFetcher and 429s; failed-validation run still accrues `api_cost_cents`)

## Notes

ApiError rescues intentionally do NOT record usage — on a non-2xx the client raises before `last_usage` is set, so there's nothing billed to accrue there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)