### PR TITLE
feat(api): community restaurant creation with pg_trgm duplicate detection

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
@@ -18,6 +18,15 @@ module Api
         files      = Array(params[:inputs]).reject(&:blank?)
         source_url = params[:source_url].to_s.presence
 
+        # Phase 6.2 ownership rule: non-admins may scan drafts they
+        # created (the new-restaurant flow) or published restaurants
+        # (re-scans). Another user's draft is off limits — drafts are
+        # invisible work-in-progress until their creator publishes.
+        unless can_target_restaurant?(restaurant)
+          render json: { error: "forbidden_restaurant" }, status: :forbidden
+          return
+        end
+
         if files.empty? && source_url.nil?
           render json: { error: "no_inputs" }, status: :unprocessable_entity
           return
@@ -135,6 +144,13 @@ module Api
         end
 
         true
+      end
+
+      def can_target_restaurant?(restaurant)
+        return true if current_user&.is_admin?
+        return true if restaurant.status == "published"
+
+        restaurant.status == "draft" && restaurant.created_by_user_id == current_user.id
       end
 
       def with_per_user_serialization(&block)

--- a/apps/api/app/controllers/api/v1/restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/restaurants_controller.rb
@@ -9,15 +9,106 @@ module Api
     #
     # Public (unauthenticated) — anonymous browsing is part of the
     # Phase 3 demo.
+    #
+    # POST /api/v1/restaurants (Phase 6.2) — the community "scan a new
+    # restaurant" entrypoint. Authenticated. Creates a `draft`
+    # restaurant recording the creator; a pg_trgm similarity guard
+    # answers "did you mean…?" with 409 + candidates before creating a
+    # near-duplicate in the same city. `force: true` (sent after the
+    # client has shown the candidates) skips the guard.
     class RestaurantsController < BaseController
       skip_before_action :authenticate_user!, only: [:show]
+
+      # Calibrated against pg_trgm similarity() on realistic pairs:
+      # true duplicates ("Maria's Tacos"/"Marias Taco" 0.53,
+      # "Home Slice Pizza"/"Home Slice" 0.65, "Oscar's Cafe"/
+      # "Oscars Café" 0.50) sit above 0.45; genuinely different
+      # restaurants ("Durango Diner"/"Durango Bagel" 0.42,
+      # "Thai Kitchen"/"Himalayan Kitchen" 0.35) sit below. This is a
+      # "did you mean?" prompt with a force override, not a hard block,
+      # so the cost of a borderline match is one extra tap.
+      DUPLICATE_SIMILARITY_THRESHOLD = 0.45
+      MAX_DUPLICATE_CANDIDATES       = 5
 
       def show
         restaurant = Restaurant.published.includes(:city).find_by_id_or_slug!(params[:id])
         render json: serialize(restaurant)
       end
 
+      def create
+        name = params.require(:name).to_s.strip
+        if name.blank?
+          render json: { error: "name_required" }, status: :unprocessable_entity
+          return
+        end
+
+        city = City.find_by(slug: params.require(:city_slug).to_s)
+        if city.nil?
+          render json: { error: "unknown_city" }, status: :not_found
+          return
+        end
+
+        unless params[:force].to_s == "true"
+          candidates = duplicate_candidates(name, city)
+          if candidates.any?
+            render json: { error: "possible_duplicate", candidates: candidates },
+                   status: :conflict
+            return
+          end
+        end
+
+        restaurant = Restaurant.create!(
+          name:               name,
+          slug:               unique_slug_for(name),
+          city:               city,
+          status:             "draft",
+          created_by_user_id: current_user.id
+        )
+        attach_address!(restaurant, city)
+
+        render json: serialize(restaurant), status: :created
+      end
+
       private
+
+      def duplicate_candidates(name, city)
+        Restaurant
+          .where(city: city)
+          .where("similarity(restaurants.name, ?) > ?", name, DUPLICATE_SIMILARITY_THRESHOLD)
+          .order(Arel.sql(ActiveRecord::Base.sanitize_sql_array(
+            ["similarity(restaurants.name, ?) DESC", name]
+          )))
+          .limit(MAX_DUPLICATE_CANDIDATES)
+          .includes(:addresses)
+          .map do |r|
+            { id: r.id, slug: r.slug, name: r.name, status: r.status,
+              street: r.addresses.first&.street }
+          end
+      end
+
+      # parameterize + numeric suffix on collision ("ninis", "ninis-2").
+      def unique_slug_for(name)
+        base = name.parameterize
+        base = "restaurant" if base.blank?
+        return base unless Restaurant.exists?(slug: base)
+
+        n = 2
+        n += 1 while Restaurant.exists?(slug: "#{base}-#{n}")
+        "#{base}-#{n}"
+      end
+
+      def attach_address!(restaurant, city)
+        street = params[:street].to_s.strip.presence
+        postal = params[:postal_code].to_s.strip.presence
+        return if street.nil? && postal.nil?
+
+        restaurant.addresses.create!(
+          street:      street,
+          postal_code: postal,
+          city:        city.name,
+          region:      city.region
+        )
+      end
 
       def serialize(r)
         {

--- a/apps/api/app/models/restaurant.rb
+++ b/apps/api/app/models/restaurant.rb
@@ -3,6 +3,9 @@ class Restaurant < ApplicationRecord
 
   belongs_to :city
   belongs_to :claimed_by_user, class_name: "User", optional: true
+  # Phase 6.2 — community-created restaurants record their creator;
+  # admin/seed-created rows leave this nil.
+  belongs_to :created_by_user, class_name: "User", optional: true
 
   has_many :addresses,     dependent: :destroy
   has_many :hours,         dependent: :destroy

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -63,7 +63,9 @@ Rails.application.routes.draw do
       get "/cities/:city_slug/restaurants",
           to: "city_restaurants#index",
           as: :city_restaurants_ranking
-      resources :restaurants, only: [:index, :show] do
+      # Phase 6.2 — :create is the community "scan a new restaurant"
+      # entrypoint (authenticated; pg_trgm dedup guard inside).
+      resources :restaurants, only: [:index, :show, :create] do
         resources :items, only: [:index, :show]
         # Phase 4.9 — restaurant claim flow.
         post   "claim",        to: "restaurant_claims#create"

--- a/apps/api/db/migrate/20260612031000_add_created_by_user_to_restaurants.rb
+++ b/apps/api/db/migrate/20260612031000_add_created_by_user_to_restaurants.rb
@@ -1,0 +1,14 @@
+class AddCreatedByUserToRestaurants < ActiveRecord::Migration[8.1]
+  # Phase 6.2 — community restaurant creation. Records which user
+  # created a restaurant through POST /api/v1/restaurants so the
+  # ingestion ownership rule ("non-admins may only scan drafts they
+  # created, or published restaurants") and the Phase 6.4 moderation
+  # scope ("community-published recently") have something to key on.
+  # Nullable: admin/seed-created restaurants have no creator.
+  def change
+    add_reference :restaurants, :created_by_user,
+                  type: :uuid, null: true,
+                  foreign_key: { to_table: :users },
+                  index: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_164500) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_031000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -281,6 +281,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_164500) do
     t.datetime "claimed_at"
     t.uuid "claimed_by_user_id"
     t.datetime "created_at", null: false
+    t.uuid "created_by_user_id"
     t.string "name", null: false
     t.string "phone"
     t.string "slug", null: false
@@ -290,6 +291,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_164500) do
     t.index ["city_id", "status"], name: "index_restaurants_on_city_id_and_status"
     t.index ["city_id"], name: "index_restaurants_on_city_id"
     t.index ["claimed_by_user_id"], name: "index_restaurants_on_claimed_by_user_id"
+    t.index ["created_by_user_id"], name: "index_restaurants_on_created_by_user_id"
     t.index ["slug"], name: "index_restaurants_on_slug", unique: true
   end
 
@@ -436,6 +438,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_164500) do
   add_foreign_key "restaurant_visits", "users"
   add_foreign_key "restaurants", "cities"
   add_foreign_key "restaurants", "users", column: "claimed_by_user_id"
+  add_foreign_key "restaurants", "users", column: "created_by_user_id"
   add_foreign_key "reviews", "items"
   add_foreign_key "reviews", "users"
   add_foreign_key "suggestions", "users"

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -152,6 +152,45 @@ RSpec.describe "Ingestion runs API", type: :request do
     end
   end
 
+  describe "restaurant targeting (Phase 6.2)" do
+    before { allow(ExtractMenuJob).to receive(:perform_later) }
+
+    it "lets a non-admin scan a draft restaurant they created" do
+      own_draft = create(:restaurant, status: "draft", created_by_user: non_admin)
+
+      post "/api/v1/ingestion_runs",
+           params: { restaurant_id: own_draft.id, inputs: [fake_image] },
+           headers: auth_for(non_admin)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it "403s a non-admin scanning another user's draft" do
+      stranger_draft = create(:restaurant, status: "draft",
+                                           created_by_user: create(:user, password: "password123"))
+
+      expect {
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: stranger_draft.id, inputs: [fake_image] },
+             headers: auth_for(non_admin)
+      }.not_to change(IngestionRun, :count)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body["error"]).to eq("forbidden_restaurant")
+    end
+
+    it "lets an admin scan any draft" do
+      stranger_draft = create(:restaurant, status: "draft",
+                                           created_by_user: create(:user, password: "password123"))
+
+      post "/api/v1/ingestion_runs",
+           params: { restaurant_id: stranger_draft.id, inputs: [fake_image] },
+           headers: auth_for(admin)
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+
   describe "community limits (Phase 6.1)" do
     before { allow(ExtractMenuJob).to receive(:perform_later) }
 

--- a/apps/api/spec/requests/api/v1/restaurant_creation_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurant_creation_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+# Phase 6.2 — community restaurant creation + pg_trgm dedup guard.
+RSpec.describe "Restaurant creation API", type: :request do
+  let(:city) { create(:city, slug: "durango") }
+  let(:user) { create(:user, password: "password123", is_admin: false) }
+
+  def auth_for(u)
+    token, _ = Warden::JWTAuth::UserEncoder.new.call(u, :user, nil)
+    { "Authorization" => "Bearer #{token}" }
+  end
+
+  def create_restaurant(as: user, **params)
+    post "/api/v1/restaurants", params: params, headers: auth_for(as)
+  end
+
+  describe "POST /api/v1/restaurants" do
+    it "creates a draft restaurant recording the creator" do
+      expect {
+        create_restaurant(name: "Maria's Tacos", city_slug: city.slug)
+      }.to change(Restaurant, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body["name"]).to   eq("Maria's Tacos")
+      expect(body["status"]).to eq("draft")
+      expect(body["slug"]).to   eq("maria-s-tacos")
+      expect(body["city"]["slug"]).to eq("durango")
+      expect(Restaurant.find(body["id"]).created_by_user_id).to eq(user.id)
+    end
+
+    it "suffixes the slug on collision" do
+      create(:restaurant, name: "Maria's Tacos", slug: "maria-s-tacos", city: city)
+
+      create_restaurant(name: "Maria's Tacos", city_slug: city.slug, force: true)
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body["slug"]).to eq("maria-s-tacos-2")
+    end
+
+    it "attaches an address when street is given" do
+      create_restaurant(name: "Maria's Tacos", city_slug: city.slug,
+                        street: "742 Main Ave", postal_code: "81301")
+
+      restaurant = Restaurant.find(response.parsed_body["id"])
+      expect(restaurant.addresses.first).to have_attributes(
+        street: "742 Main Ave", postal_code: "81301", city: "Durango", region: "CO"
+      )
+    end
+
+    it "401s unauthenticated callers" do
+      post "/api/v1/restaurants", params: { name: "X", city_slug: city.slug }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "404s on an unknown city slug" do
+      create_restaurant(name: "Maria's Tacos", city_slug: "atlantis")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body["error"]).to eq("unknown_city")
+    end
+
+    it "422s on a blank name" do
+      create_restaurant(name: "   ", city_slug: city.slug)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "duplicate detection" do
+    let!(:existing) do
+      create(:restaurant, :published, name: "Maria's Tacos", slug: "maria-s-tacos", city: city)
+    end
+
+    it "409s with candidates when a similar name exists in the same city" do
+      expect {
+        create_restaurant(name: "Marias Taco", city_slug: city.slug)
+      }.not_to change(Restaurant, :count)
+
+      expect(response).to have_http_status(:conflict)
+      body = response.parsed_body
+      expect(body["error"]).to eq("possible_duplicate")
+      expect(body["candidates"].first).to include(
+        "id" => existing.id, "name" => "Maria's Tacos", "status" => "published"
+      )
+    end
+
+    it "force: true creates anyway after the client showed the prompt" do
+      expect {
+        create_restaurant(name: "Marias Taco", city_slug: city.slug, force: true)
+      }.to change(Restaurant, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it "the same name in a DIFFERENT city is not a duplicate" do
+      other_city = create(:city, slug: "telluride")
+
+      create_restaurant(name: "Maria's Tacos", city_slug: other_city.slug)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it "an unrelated name in the same city is not a duplicate" do
+      create_restaurant(name: "Golden Dragon Noodle House", city_slug: city.slug)
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -254,6 +254,13 @@ The loop appends here when work surfaces a new task that doesn't
 belong in the current phase. Humans triage these into the appropriate
 phase or "Next up" queue.
 
+- **Ingestion + restaurant endpoints lack rswag specs** (noted while
+  shipping 6.1/6.2). `POST /ingestion_runs`, `PATCH .../items/:id`,
+  `POST /restaurants` aren't in `docs/openapi.json`, so api-types
+  stays hand-written for them. One PR could rswag the lot + re-run
+  codegen. Pre-existing gap (only auth/profile/items were ever
+  rswag'd) — surfaced now because Phase 6 keeps touching these
+  endpoints.
 - ~~Wire `jest-expo` preset + `@testing-library/react-native` for the
   mobile app, AND wire `@testing-library/react` + jsdom for the web
   app~~ — **promoted to Next-up #1 (web side) in tick #94 after three

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,25 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 03:45 — tick #133 (part 2). **Phase 6.2 shipped —
+community restaurant creation + dedup.** #299 (6.1.2) merged.
+- New migration: `restaurants.created_by_user_id` (nullable FK).
+- `POST /api/v1/restaurants` (authenticated): name + city_slug +
+  optional street/postal → draft restaurant recording creator;
+  unique slug via parameterize + numeric suffix.
+- Dedup guard: pg_trgm `similarity(name, ?) > 0.45` within the same
+  city → 409 `possible_duplicate` + up to 5 candidates (id/slug/
+  name/status/street); `force: true` overrides. Threshold calibrated
+  against live pg_trgm scores: true variants 0.50–0.65, different
+  restaurants ≤0.42 ("Durango Diner"/"Durango Bagel").
+- Ingestion ownership rule: non-admins may only scan drafts they
+  created or published restaurants; foreign drafts 403.
+rspec 423/423 (+13); brakeman 0. Deviation from subplan, surfaced
+honestly: no rswag spec for the new endpoint — NONE of the
+restaurant/ingestion endpoints were ever rswag'd, so openapi/codegen
+doesn't change; added a Discovered entry to rswag the lot in one PR.
+Next: Phase 6.3 self-verify + community-trust promotion.
+
 2026-06-12 03:05 — tick #133 (part 1). **Phase 6.1.2 — two codex P2s
 from #298 fixed forward.** (1) Over-quota callers could still force
 an outbound URL fetch: a cheap unlocked limits pre-check now runs


### PR DESCRIPTION
## Why

Phase 6.2 (`docs/plans/phase-6.md`) — a user standing in a restaurant that isn't in the system needs to create it before scanning. Without dedup, two users scanning the same place create two restaurants.

## What

- **Migration** (new file, no shipped-migration edits): `restaurants.created_by_user_id` — nullable uuid FK to users, indexed. Nullable because admin/seed-created rows have no creator.
- **`POST /api/v1/restaurants`** (authenticated): `name` + `city_slug` + optional `street`/`postal_code` → `draft` restaurant recording the creator. Slug = `parameterize` + numeric suffix on collision. Address row created when street/postal present (city/region denormalized from the City).
- **Dedup guard**: `similarity(restaurants.name, ?) > 0.45` within the same city → 409 `{error: "possible_duplicate", candidates: [...]}` (≤5, ordered by similarity, with street for disambiguation). `force: true` skips the guard after the client has shown the candidates. **Threshold calibrated against live pg_trgm scores**, documented in the code: true variants ("Maria's Tacos"/"Marias Taco" 0.53, "Home Slice Pizza"/"Home Slice" 0.65) clear it; genuinely different restaurants ("Durango Diner"/"Durango Bagel" 0.42, "Thai Kitchen"/"Himalayan Kitchen" 0.35) don't.
- **Ingestion ownership rule** (`IngestionRunsController`): non-admins may only target drafts they created or published restaurants (re-scans); another user's draft → 403 `forbidden_restaurant`.
- `Restaurant belongs_to :created_by_user` (optional).

## Test plan

- [x] `bundle exec rspec` — 423 examples, 0 failures (+13: creation happy path/auth/blank-name/unknown-city, slug suffixing, address attach, dedup 409 + candidates, force override, cross-city + unrelated-name non-collisions, ingestion own-draft 201 / foreign-draft 403 / admin bypass)
- [x] `bundle exec brakeman` — 0 warnings (similarity SQL is parameterized; ORDER BY goes through sanitize_sql_array)

## Notes

- **Deviation from subplan, surfaced per Rule 1**: no rswag spec for the new endpoint. None of the restaurant/ingestion endpoints were ever rswag'd (openapi.json only covers auth/profile/items), so there is no codegen delta. Added a Discovered entry to roadmap to rswag the whole group in one PR rather than starting a partial convention here.
- Drafts are not readable via `GET /restaurants/:id` (it's scoped to published) — the scan flow holds the id from the create response. A "my drafts" read endpoint can ride along with Phase 6.5/6.6 if the clients need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)