### PR TITLE
feat(api): community self-verify with suggested-confidence promotion

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
@@ -3,21 +3,26 @@ module Api
     # PATCH /api/v1/ingestion_runs/:run_id/items/:id
     #
     # Phase 2.7 — the mobile swipe-verify UI hits this endpoint when
-    # an admin accepts / edits / rejects an item. Accept also fires
+    # an item is accepted / edited / rejected. Accept also fires
     # IngestionItem#promote! (materializes the real Item) and runs
     # IngestionRun#maybe_publish! (the 80%-accepted threshold from
     # Phase 2.5).
+    #
+    # Phase 6.3 — access widened from admin-only to creator-or-admin:
+    # a community scanner verifies their OWN run. promote! receives
+    # the deciding user so community verification lands
+    # `confidence: suggested` (see the trust model in IngestionItem).
     class IngestionItemsController < BaseController
-      before_action :ensure_admin!
+      before_action :ensure_run_access!
 
       def index
-        run = IngestionRun.find(params[:ingestion_run_id])
+        run = authorized_run
         items = run.ingestion_items.order(:created_at)
         render json: { items: items.map { |it| serialize_item(it) } }
       end
 
       def update
-        run  = IngestionRun.find(params[:ingestion_run_id])
+        run  = authorized_run
         item = run.ingestion_items.find(params[:id])
 
         decision = params[:decision].to_s
@@ -42,7 +47,7 @@ module Api
           # promotion step.
           if decision == "accepted"
             item.save! if item.changed?
-            item.promote!
+            item.promote!(decided_by: current_user)
           else
             item.update!(decision: "edited", decided_at: Time.current)
           end
@@ -57,8 +62,16 @@ module Api
 
       private
 
-      def ensure_admin!
+      # The run's creator or an admin. Memoized so index/update don't
+      # re-fetch what the before_action already loaded.
+      def authorized_run
+        @authorized_run ||= IngestionRun.find(params[:ingestion_run_id])
+      end
+
+      def ensure_run_access!
         return if current_user&.is_admin?
+        return if authorized_run.user_id.present? && authorized_run.user_id == current_user&.id
+
         render json: { error: "forbidden" }, status: :forbidden
       end
 

--- a/apps/api/app/models/ingestion_item.rb
+++ b/apps/api/app/models/ingestion_item.rb
@@ -13,18 +13,27 @@ class IngestionItem < ApplicationRecord
   # Materialize a staged ingestion item into a real Item +
   # ItemIngredient + ItemTag join rows. Called from the swipe-verify
   # UI (Phase 2.5) once a human has accepted (or edited then accepted)
-  # the AI's suggestion. The new associations are saved with
-  # `confidence: confirmed, source: human` because at this point a
-  # human has explicitly signed off.
+  # the AI's suggestion.
+  #
+  # Phase 6.3 trust model: WHO verified decides the confidence level.
+  # Admin (or legacy no-arg call sites — Avo is admin-gated) →
+  # `confirmed`; a community scanner verifying their own run →
+  # `suggested`. Either way `source: human` — a human signed off, the
+  # question is whether strict-mode users should trust them yet.
+  # Strict mode only shows fully-confirmed items, so community menus
+  # are live for relaxed/balanced users and invisible to strict users
+  # until an admin confirms (Phase 6.4's confirm-all action).
   #
   # Idempotent: re-calling on an already-promoted IngestionItem
   # returns the existing Item without creating duplicates.
   #
   # Returns the materialized Item; raises if the run has no
   # restaurant attached (which means we don't know where to put it).
-  def promote!
+  def promote!(decided_by: nil)
     return item if item.present?
     raise "IngestionRun ##{ingestion_run_id} has no restaurant" if ingestion_run.restaurant_id.blank?
+
+    confidence = decided_by.nil? || decided_by.is_admin? ? "confirmed" : "suggested"
 
     transaction do
       created = Item.create!(
@@ -32,7 +41,7 @@ class IngestionItem < ApplicationRecord
         name:        name,
         description: description.presence,
         status:      "published",
-        confidence:  "confirmed"
+        confidence:  confidence
       )
 
       Array(ingredients_payload).each do |row|
@@ -43,7 +52,7 @@ class IngestionItem < ApplicationRecord
 
         ItemIngredient.create!(
           item: created, ingredient: ingredient,
-          confidence: "confirmed", source: "human"
+          confidence: confidence, source: "human"
         )
       end
 
@@ -55,7 +64,7 @@ class IngestionItem < ApplicationRecord
 
         ItemTag.create!(
           item: created, tag: tag,
-          confidence: "confirmed", source: "human"
+          confidence: confidence, source: "human"
         )
       end
 

--- a/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
@@ -31,9 +31,75 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
       expect(body["items"].first["name"]).to eq("Carne Asada Taco")
     end
 
-    it "rejects non-admins with 403" do
+    it "rejects non-admins who aren't the run's creator with 403" do
       get "/api/v1/ingestion_runs/#{run.id}/items", headers: auth_for(non_admin)
       expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "community self-verify (Phase 6.3)" do
+    let(:scanner) { create(:user, password: "password123", is_admin: false) }
+    let(:community_run) do
+      create(:ingestion_run, :staged, restaurant: restaurant, user: scanner)
+    end
+    let!(:community_item) do
+      create(:ingestion_item,
+             ingestion_run: community_run, name: "Pad Thai",
+             ingredients_payload: [{ "slug" => "meat-beef", "confidence" => 0.95 }],
+             tags_payload:        [{ "slug" => "cuisine-mexican", "confidence" => 0.92 }])
+    end
+
+    def accept_as(user)
+      patch "/api/v1/ingestion_runs/#{community_run.id}/items/#{community_item.id}",
+            params: { decision: "accepted" }.to_json,
+            headers: auth_for(user)
+    end
+
+    it "lets the run's creator list its items" do
+      get "/api/v1/ingestion_runs/#{community_run.id}/items", headers: auth_for(scanner)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["items"].first["name"]).to eq("Pad Thai")
+    end
+
+    it "403s a different non-admin even on an owned run" do
+      stranger = create(:user, password: "password123", is_admin: false)
+      get "/api/v1/ingestion_runs/#{community_run.id}/items", headers: auth_for(stranger)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "creator acceptance promotes with confidence: suggested on the Item AND the joins" do
+      accept_as(scanner)
+
+      expect(response).to have_http_status(:ok)
+      promoted = Item.find(response.parsed_body["item_id"])
+      expect(promoted.confidence).to eq("suggested")
+      expect(promoted.item_ingredients.pluck(:confidence, :source)).to all(eq(%w[suggested human]))
+      expect(promoted.item_tags.pluck(:confidence, :source)).to        all(eq(%w[suggested human]))
+    end
+
+    it "admin acceptance of the same run promotes with confidence: confirmed" do
+      accept_as(admin)
+
+      promoted = Item.find(response.parsed_body["item_id"])
+      expect(promoted.confidence).to eq("confirmed")
+      expect(promoted.item_ingredients.pluck(:confidence)).to all(eq("confirmed"))
+      expect(promoted.item_tags.pluck(:confidence)).to        all(eq("confirmed"))
+    end
+
+    it "end-to-end: a community-promoted item is hidden from strict mode, visible to balanced" do
+      accept_as(scanner)
+      promoted_id = response.parsed_body["item_id"]
+
+      get "/api/v1/restaurants/#{restaurant.id}/items", params: { strictness: "strict" }
+      strict_row = response.parsed_body["items"].find { |i| i["id"] == promoted_id }
+      expect(strict_row["status"]).to eq("hidden")
+      expect(strict_row["reasons"].map { |r| r["kind"] }).to include("unconfirmed_strict")
+
+      get "/api/v1/restaurants/#{restaurant.id}/items", params: { strictness: "balanced" }
+      balanced_row = response.parsed_body["items"].find { |i| i["id"] == promoted_id }
+      expect(balanced_row["status"]).to eq("visible")
     end
   end
 
@@ -110,7 +176,7 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
       expect(response.parsed_body["error"]).to eq("invalid_decision")
     end
 
-    it "rejects a non-admin caller with 403" do
+    it "rejects a non-admin who isn't the run's creator with 403" do
       patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
             params: { decision: "accepted" }.to_json,
             headers: auth_for(non_admin)

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,25 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 10:20 — tick #134. **Phase 6.3 shipped — community
+self-verify + suggested-confidence trust model.** #300 (6.2) merged
+with zero codex findings. This PR:
+- IngestionItems endpoints widened from admin-only to
+  creator-or-admin (`ensure_run_access!`); ownerless runs stay
+  admin-only; strangers 403.
+- `IngestionItem#promote!(decided_by:)` — admin or legacy no-arg
+  call sites (Avo is admin-gated) promote `confirmed`; a community
+  scanner verifying their own run promotes `suggested` on the Item
+  AND every ItemIngredient/ItemTag join (source stays `human`).
+- End-to-end spec proves the safety contract: a community-promoted
+  item is hidden under `?strictness=strict` with reason
+  `unconfirmed_strict` and visible under balanced — strict-mode
+  users never see unconfirmed community data.
+rspec 428/428 (+5); brakeman 0. maybe_publish! unchanged (80%
+threshold now reachable by community runs — that's the feature).
+Next: Phase 6.4 moderation visibility (Avo scope + confirm-all +
+dashboard counters).
+
 2026-06-12 03:45 — tick #133 (part 2). **Phase 6.2 shipped —
 community restaurant creation + dedup.** #299 (6.1.2) merged.
 - New migration: `restaurants.created_by_user_id` (nullable FK).


### PR DESCRIPTION
## Why

Phase 6.3 (`docs/plans/phase-6.md`) — the heart of the trust model. Community scanners must be able to verify their own runs (the swipe-verify endpoints were admin-only), but their verification must not grant the same trust level as an admin's: strict-mode users only ever see `confirmed` associations.

## What

- **`IngestionItemsController`**: `ensure_admin!` → `ensure_run_access!` (run creator OR admin; ownerless runs remain admin-only via a nil-guard; strangers 403). The accept path passes `decided_by: current_user` into promote.
- **`IngestionItem#promote!(decided_by: nil)`**: admin deciders — and legacy no-arg call sites like the admin-gated Avo accept action — keep `confidence: "confirmed"`. Non-admin deciders write `confidence: "suggested"` on the materialized Item **and** every `ItemIngredient`/`ItemTag` row. `source` stays `"human"` either way — a human signed off; the question is whether strict-mode users should trust them yet. Trust-model rationale documented on the method.
- `maybe_publish!` intentionally unchanged: community runs can now cross the 80% threshold and publish — live for relaxed/balanced users, invisible to strict users until Phase 6.4's admin confirm-all.

## Test plan

- [x] `bundle exec rspec` — 428 examples, 0 failures (+5)
- [x] The headline spec is **end-to-end**: creator accepts → `GET /restaurants/:id/items?strictness=strict` hides the item with reason `unconfirmed_strict`; `balanced` shows it. This encodes WHY the confidence split exists, not just what promote! writes.
- [x] Admin-vs-creator promotion asserted down to the join rows
- [x] `bundle exec brakeman` — 0 warnings

## Notes

The filter-engine TS side needs no change: it already treats any non-`confirmed` item as hidden under strict mode — the server and client filters stay in lockstep because the *data* carries the trust level, not the code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)