### PR TITLE
feat(api): community-publish moderation visibility for admins

### DIFF
--- a/apps/api/app/avo/actions/restaurants/confirm_community.rb
+++ b/apps/api/app/avo/actions/restaurants/confirm_community.rb
@@ -1,0 +1,33 @@
+# Phase 6.4 — one-click graduation of a community-published
+# restaurant to strict-mode visibility. Flips every human-vouched
+# `suggested` association (and the items' own confidence) to
+# `confirmed`. AI-sourced rows are left alone — see
+# Restaurant#confirm_community_associations!.
+class Avo::Actions::Restaurants::ConfirmCommunity < Avo::BaseAction
+  self.name = "Confirm community menu → strict-mode visible"
+  self.message = "Flip all human-verified `suggested` associations on the selected restaurant(s) to `confirmed`? Strict-mode users will start seeing these items."
+  self.confirm_button_label = "Confirm all"
+
+  def handle(query:, **)
+    totals = self.class.confirm_all(query)
+
+    succeed "Confirmed #{totals[:items]} item(s), " \
+            "#{totals[:ingredients]} ingredient link(s), " \
+            "#{totals[:tags]} tag link(s) across #{totals[:restaurants]} restaurant(s)."
+  end
+
+  # Pure logic; reusable by specs (mirrors IngestionItems::Accept).
+  def self.confirm_all(restaurants)
+    totals = { restaurants: 0, items: 0, ingredients: 0, tags: 0 }
+
+    restaurants.each do |restaurant|
+      counts = restaurant.confirm_community_associations!
+      totals[:restaurants] += 1
+      totals[:items]       += counts[:items]
+      totals[:ingredients] += counts[:ingredients]
+      totals[:tags]        += counts[:tags]
+    end
+
+    totals
+  end
+end

--- a/apps/api/app/avo/filters/community_published.rb
+++ b/apps/api/app/avo/filters/community_published.rb
@@ -1,0 +1,16 @@
+# Phase 6.4 — the admin's moderation lens over community-created
+# restaurants. Doesn't gate anything (community publishes go live per
+# the Phase 6.3 trust model); this is how an admin SEES what the
+# community shipped so the confirm-all action can graduate it.
+class Avo::Filters::CommunityPublished < Avo::Filters::BooleanFilter
+  self.name = "Community published"
+
+  def apply(_request, query, value)
+    return query unless value[:community]
+    query.community_published
+  end
+
+  def options
+    { community: "Created by a community member and live" }
+  end
+end

--- a/apps/api/app/avo/resources/restaurant.rb
+++ b/apps/api/app/avo/resources/restaurant.rb
@@ -16,12 +16,24 @@ class Avo::Resources::Restaurant < Avo::BaseResource
     field :status, as: :text
     field :claimed_by_user_id, as: :text
     field :claimed_at, as: :date_time
+    field :created_by_user_id, as: :text
     field :city, as: :belongs_to
     field :claimed_by_user, as: :belongs_to
+    field :created_by_user, as: :belongs_to
     field :addresses, as: :has_many
     field :hours, as: :has_many
     field :menus, as: :has_many
     field :menu_sections, as: :has_many, through: :menus
     field :items, as: :has_many
+  end
+
+  # Phase 6.4 — moderation lens + graduation action for
+  # community-published restaurants.
+  def filters
+    filter Avo::Filters::CommunityPublished
+  end
+
+  def actions
+    action Avo::Actions::Restaurants::ConfirmCommunity
   end
 end

--- a/apps/api/app/controllers/admin/dashboard_controller.rb
+++ b/apps/api/app/controllers/admin/dashboard_controller.rb
@@ -18,6 +18,22 @@ module Admin
     def index
       @metrics       = Ingestion::CostMetrics.by_period
       @target_target = Ingestion::CostMetrics::TARGET_CENTS_PER_ITEM
+
+      # Phase 6.4 — community-ingestion counters. Same UTC-day window
+      # the Phase 6.1 cost ceiling enforces, so "spend today" here is
+      # exactly the number the 503 guard compares against.
+      # (Parens required: an endless range at end-of-line parses the
+      # NEXT line as its end — bit me once already.)
+      today_utc             = (Time.current.utc.beginning_of_day..)
+      @community_runs_today = IngestionRun.joins(:user)
+                                          .where(users: { is_admin: false })
+                                          .where(created_at: today_utc)
+                                          .count
+      @spend_today_cents    = IngestionRun.where(created_at: today_utc).sum(:api_cost_cents)
+      @ceiling_cents        = Integer(ENV.fetch(
+        "INGESTION_DAILY_COST_CEILING_CENTS",
+        Api::V1::IngestionRunsController::DAILY_COST_CEILING_CENTS_DEFAULT
+      ))
     end
 
     private

--- a/apps/api/app/models/restaurant.rb
+++ b/apps/api/app/models/restaurant.rb
@@ -18,6 +18,35 @@ class Restaurant < ApplicationRecord
   validates :status, inclusion: { in: STATUSES }
 
   scope :published, -> { where(status: "published") }
+  # Phase 6.4 — the moderation lens: live restaurants that exist
+  # because a community member created + scanned them.
+  scope :community_published, -> { published.where.not(created_by_user_id: nil) }
+
+  # Phase 6.4 — graduate a community-verified menu to strict-mode
+  # visibility: flip every `suggested` association a HUMAN vouched for
+  # to `confirmed`, plus the items' own confidence. Deliberately does
+  # NOT touch `source: ai` rows — the admin is endorsing the human
+  # verifier's judgment, not the model's unreviewed guesses.
+  #
+  # update_all is safe here: the join callbacks only sync the
+  # denormalized id arrays, and no ids change.
+  #
+  # Returns counts for the admin-facing confirmation message.
+  def confirm_community_associations!
+    transaction do
+      ingredients_n = ItemIngredient.joins(:item)
+                                    .where(items: { restaurant_id: id },
+                                           confidence: "suggested", source: "human")
+                                    .update_all(confidence: "confirmed")
+      tags_n        = ItemTag.joins(:item)
+                             .where(items: { restaurant_id: id },
+                                    confidence: "suggested", source: "human")
+                             .update_all(confidence: "confirmed")
+      items_n       = items.where(confidence: "suggested").update_all(confidence: "confirmed")
+
+      { items: items_n, ingredients: ingredients_n, tags: tags_n }
+    end
+  end
 
   # SEO-friendly URLs (`/restaurants/ninis-1`) need lookup-by-slug;
   # mobile/api consumers still pass UUIDs. Single endpoint accepts

--- a/apps/api/app/views/admin/dashboard/index.html.erb
+++ b/apps/api/app/views/admin/dashboard/index.html.erb
@@ -35,6 +35,31 @@
       50-item menu = <strong><%= @target_target %>¢ per item</strong>.
     </p>
 
+    <div class="grid" style="margin-bottom: 24px;">
+      <div class="card" data-period="community-today">
+        <h2>Community ingestion (today, UTC)</h2>
+
+        <div class="stat">
+          <span class="label">Community runs</span>
+          <span class="value"><%= @community_runs_today %></span>
+        </div>
+        <% ceiling_ratio = @ceiling_cents.zero? ? 0 : @spend_today_cents.to_f / @ceiling_cents %>
+        <div class="stat">
+          <span class="label">Spend vs daily ceiling</span>
+          <span class="value <%= ceiling_ratio >= 0.8 ? "warn" : "ok" %>">
+            $<%= sprintf("%.2f", @spend_today_cents.to_f / 100) %> /
+            $<%= sprintf("%.2f", @ceiling_cents.to_f / 100) %>
+          </span>
+        </div>
+
+        <p class="target-line">
+          Same UTC-day window the Phase 6.1 cost ceiling enforces — when
+          spend hits the ceiling, non-admin run creation 503s until the
+          UTC day rolls over.
+        </p>
+      </div>
+    </div>
+
     <div class="grid">
       <% @metrics.each do |period_key, b| %>
         <div class="card" data-period="<%= period_key %>">

--- a/apps/api/spec/avo/actions/restaurants/confirm_community_spec.rb
+++ b/apps/api/spec/avo/actions/restaurants/confirm_community_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Avo::Actions::Restaurants::ConfirmCommunity do
+  let(:scanner) { create(:user, password: "password123", is_admin: false) }
+
+  it "confirms across multiple selected restaurants and reports totals" do
+    r1 = create(:restaurant, :published, created_by_user: scanner)
+    r2 = create(:restaurant, :published, created_by_user: scanner)
+    create(:item, :published, restaurant: r1, ingredients: [create(:ingredient, slug: "dairy-cheese")])
+    create(:item, :published, restaurant: r2, tag_list: [create(:tag, slug: "cuisine-thai")])
+
+    totals = described_class.confirm_all(Restaurant.where(id: [r1.id, r2.id]))
+
+    expect(totals).to eq(restaurants: 2, items: 2, ingredients: 1, tags: 1)
+    expect(Item.where(restaurant: [r1, r2]).pluck(:confidence)).to all(eq("confirmed"))
+  end
+end

--- a/apps/api/spec/models/restaurant_community_spec.rb
+++ b/apps/api/spec/models/restaurant_community_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+# Phase 6.4 — moderation lens + strict-mode graduation.
+RSpec.describe Restaurant, type: :model do
+  let(:scanner) { create(:user, password: "password123", is_admin: false) }
+
+  describe ".community_published" do
+    it "includes live community-created restaurants only" do
+      community_live  = create(:restaurant, :published, created_by_user: scanner)
+      community_draft = create(:restaurant, status: "draft", created_by_user: scanner)
+      admin_seeded    = create(:restaurant, :published) # no creator
+
+      expect(described_class.community_published).to contain_exactly(community_live)
+      expect(described_class.community_published).not_to include(community_draft, admin_seeded)
+    end
+  end
+
+  describe "#confirm_community_associations!" do
+    let(:restaurant) { create(:restaurant, :published, created_by_user: scanner) }
+    let(:cheese)     { create(:ingredient, slug: "dairy-cheese") }
+    let(:mexican)    { create(:tag, slug: "cuisine-mexican") }
+
+    let!(:community_item) do
+      # factory writes joins with confidence = item.confidence ("suggested")
+      create(:item, :published, restaurant: restaurant,
+                                ingredients: [cheese], tag_list: [mexican])
+    end
+
+    it "flips human-vouched suggested associations AND item confidence to confirmed" do
+      counts = restaurant.confirm_community_associations!
+
+      expect(counts).to eq(items: 1, ingredients: 1, tags: 1)
+      expect(community_item.reload.confidence).to eq("confirmed")
+      expect(ItemIngredient.where(item: community_item).pluck(:confidence)).to all(eq("confirmed"))
+      expect(ItemTag.where(item: community_item).pluck(:confidence)).to        all(eq("confirmed"))
+    end
+
+    it "leaves ai-sourced suggestions alone — the admin endorses the human, not the model" do
+      onion = create(:ingredient, slug: "vegetable-onion")
+      ai_row = ItemIngredient.create!(item: community_item, ingredient: onion,
+                                      confidence: "suggested", source: "ai")
+
+      restaurant.confirm_community_associations!
+
+      expect(ai_row.reload.confidence).to eq("suggested")
+    end
+
+    it "does not touch other restaurants" do
+      other_item = create(:item, :published, ingredients: [create(:ingredient, slug: "grain-wheat")])
+
+      restaurant.confirm_community_associations!
+
+      expect(other_item.reload.confidence).to eq("suggested")
+      expect(ItemIngredient.where(item: other_item).pluck(:confidence)).to all(eq("suggested"))
+    end
+
+    it "keeps the denormalized id arrays intact (update_all skips callbacks by design)" do
+      before_ids = community_item.reload.ingredient_ids
+
+      restaurant.confirm_community_associations!
+
+      expect(community_item.reload.ingredient_ids).to eq(before_ids)
+    end
+  end
+end

--- a/apps/api/spec/requests/admin/dashboard_spec.rb
+++ b/apps/api/spec/requests/admin/dashboard_spec.rb
@@ -48,4 +48,21 @@ RSpec.describe "Admin::Dashboard", type: :request do
     expect(response.body).to include("Last 30 days")
     expect(response.body).to include("Cache hit rate")
   end
+
+  describe "community counters (Phase 6.4)" do
+    it "counts community runs separately from admin runs and shows spend vs ceiling" do
+      scanner = create(:user, password: "password123", is_admin: false)
+      admin_u = create(:user, password: "password123", is_admin: true)
+      create(:ingestion_run, restaurant: restaurant, user: scanner, api_cost_cents: 30)
+      create(:ingestion_run, restaurant: restaurant, user: admin_u, api_cost_cents: 70)
+
+      get "/admin/dashboard", headers: basic_auth
+
+      expect(response.body).to include("Community ingestion (today, UTC)")
+      community_card = response.body[/data-period="community-today".*?<\/div>\s*<\/div>/m]
+      expect(community_card).to include(">1<")          # 1 community run (admin's excluded)
+      expect(response.body).to include("$1.00 /")        # 30 + 70 cents total spend
+      expect(response.body).to include("$20.00")         # default ceiling
+    end
+  end
 end

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,26 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 10:55 — tick #135. **Phase 6.4 shipped — moderation
+visibility.** #301 (6.3) merged, zero codex findings. Loop cadence
+shortened to 15 min by owner. This PR:
+- `Restaurant.community_published` scope + Avo boolean filter on the
+  restaurants resource (+ created_by_user fields).
+- `Restaurant#confirm_community_associations!` + Avo bulk action
+  "Confirm community menu → strict-mode visible": flips
+  suggested/human joins + item confidence to confirmed via
+  update_all (id arrays untouched — only ids sync via callbacks).
+  Deliberately skips source:ai rows — admin endorses the human
+  verifier, not the model. Returns counts for the admin message.
+- /admin/dashboard: "Community ingestion (today, UTC)" card —
+  community run count (non-admin users) + spend vs ceiling using
+  EXACTLY the same UTC-day window the 6.1 ceiling enforces; warns
+  at ≥80%.
+War story: endless-range-at-end-of-line Ruby parse trap — `x = t..`
+consumed the next line as the range end → PG DatetimeFieldOverflow.
+Parenthesized + commented. rspec 435/435 (+7); brakeman 0.
+Next: Phase 6.5 web community scan entrypoint.
+
 2026-06-12 10:20 — tick #134. **Phase 6.3 shipped — community
 self-verify + suggested-confidence trust model.** #300 (6.2) merged
 with zero codex findings. This PR:


### PR DESCRIPTION
## Why

Phase 6.4 (`docs/plans/phase-6.md`) — community publishes go live without admin gating (by design, Phase 6.3), so admins need to *see* what shipped and a one-click way to graduate trusted menus to strict-mode visibility.

## What

- **`Restaurant.community_published`** scope (live + has a creator) + **Avo boolean filter** on the restaurants resource; `created_by_user` fields added to the resource.
- **`Restaurant#confirm_community_associations!`** + Avo bulk action *"Confirm community menu → strict-mode visible"*: flips every `suggested`/`source: human` ItemIngredient/ItemTag plus the items' own confidence to `confirmed`, returning per-kind counts for the admin message. Two deliberate choices documented in code:
  - `source: ai` rows are NOT flipped — the admin endorses the human verifier's judgment, not the model's unreviewed guesses.
  - `update_all` is safe: join callbacks only sync the denormalized id arrays and no ids change (spec asserts arrays stay intact).
- **`/admin/dashboard`**: new "Community ingestion (today, UTC)" card — community run count (runs by non-admin users) + spend vs the daily ceiling, computed over **exactly the same UTC-day window** the Phase 6.1 503-guard enforces, warn-styled at ≥80%.

## Test plan

- [x] `bundle exec rspec` — 435 examples, 0 failures (+7: scope membership, confirm flips item+joins, ai-rows untouched, other restaurants untouched, id arrays intact, multi-restaurant action totals, dashboard counters)
- [x] `bundle exec brakeman` — 0 warnings

## Notes

War story for the next reader: `x = Time.current.utc.beginning_of_day..` at end-of-line parses the **next line** as the range end (endless-range continuation), which sent `0` to Postgres as a timestamp → `PG::DatetimeFieldOverflow`. Now parenthesized with a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)