### PR TITLE
fix(api): close three moderation gaps codex found on #302

### DIFF
--- a/apps/api/app/avo/filters/community_runs.rb
+++ b/apps/api/app/avo/filters/community_runs.rb
@@ -1,0 +1,16 @@
+# Phase 6.4.1 — run-level moderation lens: ingestion runs created by
+# non-admin users, so an admin can audit what the community scanned
+# (the restaurant-level filter shows the OUTCOME; this shows the
+# submissions, including failed/staged ones that never published).
+class Avo::Filters::CommunityRuns < Avo::Filters::BooleanFilter
+  self.name = "Community runs"
+
+  def apply(_request, query, value)
+    return query unless value[:community]
+    query.joins(:user).where(users: { is_admin: false })
+  end
+
+  def options
+    { community: "Created by a non-admin user" }
+  end
+end

--- a/apps/api/app/avo/resources/ingestion_run.rb
+++ b/apps/api/app/avo/resources/ingestion_run.rb
@@ -45,4 +45,9 @@ class Avo::Resources::IngestionRun < Avo::BaseResource
   def actions
     action Avo::Actions::IngestionRuns::ReExtract
   end
+
+  # Phase 6.4.1 — run-level community moderation lens.
+  def filters
+    filter Avo::Filters::CommunityRuns
+  end
 end

--- a/apps/api/app/models/restaurant.rb
+++ b/apps/api/app/models/restaurant.rb
@@ -18,9 +18,20 @@ class Restaurant < ApplicationRecord
   validates :status, inclusion: { in: STATUSES }
 
   scope :published, -> { where(status: "published") }
-  # Phase 6.4 — the moderation lens: live restaurants that exist
-  # because a community member created + scanned them.
-  scope :community_published, -> { published.where.not(created_by_user_id: nil) }
+  # Phase 6.4 — the moderation lens. Two ways a restaurant enters it:
+  # a community member created it (created_by_user_id present), OR a
+  # community member re-scanned an existing/seeded restaurant, which
+  # leaves `suggested` items behind (6.4.1 — codex caught that
+  # rescans escaped the creator-only version of this scope).
+  scope :community_published, -> {
+    published.where(
+      "restaurants.created_by_user_id IS NOT NULL OR EXISTS (
+         SELECT 1 FROM items
+         WHERE items.restaurant_id = restaurants.id
+           AND items.confidence = 'suggested'
+       )"
+    )
+  }
 
   # Phase 6.4 — graduate a community-verified menu to strict-mode
   # visibility: flip every `suggested` association a HUMAN vouched for
@@ -42,7 +53,15 @@ class Restaurant < ApplicationRecord
                              .where(items: { restaurant_id: id },
                                     confidence: "suggested", source: "human")
                              .update_all(confidence: "confirmed")
-      items_n       = items.where(confidence: "suggested").update_all(confidence: "confirmed")
+
+      # Only items whose EVERY association is now confirmed graduate —
+      # an item still carrying an ai-suggested join must stay
+      # `suggested`, or strict mode would show it while an untrusted
+      # association remains (6.4.1 — codex).
+      items_n = items.where(confidence: "suggested")
+                     .where.not(id: ItemIngredient.where(confidence: "suggested").select(:item_id))
+                     .where.not(id: ItemTag.where(confidence: "suggested").select(:item_id))
+                     .update_all(confidence: "confirmed")
 
       { items: items_n, ingredients: ingredients_n, tags: tags_n }
     end

--- a/apps/api/spec/models/restaurant_community_spec.rb
+++ b/apps/api/spec/models/restaurant_community_spec.rb
@@ -5,13 +5,23 @@ RSpec.describe Restaurant, type: :model do
   let(:scanner) { create(:user, password: "password123", is_admin: false) }
 
   describe ".community_published" do
-    it "includes live community-created restaurants only" do
+    it "includes live community-created restaurants" do
       community_live  = create(:restaurant, :published, created_by_user: scanner)
       community_draft = create(:restaurant, status: "draft", created_by_user: scanner)
-      admin_seeded    = create(:restaurant, :published) # no creator
+      admin_seeded    = create(:restaurant, :published) # no creator, no suggested items
 
       expect(described_class.community_published).to contain_exactly(community_live)
       expect(described_class.community_published).not_to include(community_draft, admin_seeded)
+    end
+
+    it "includes seeded restaurants that received a community RE-scan (suggested items, no creator)" do
+      rescanned = create(:restaurant, :published) # admin-seeded
+      create(:item, :published, restaurant: rescanned) # factory default confidence: suggested
+
+      pristine = create(:restaurant, :published)
+      create(:item, :published, :confirmed, restaurant: pristine)
+
+      expect(described_class.community_published).to contain_exactly(rescanned)
     end
   end
 
@@ -35,14 +45,18 @@ RSpec.describe Restaurant, type: :model do
       expect(ItemTag.where(item: community_item).pluck(:confidence)).to        all(eq("confirmed"))
     end
 
-    it "leaves ai-sourced suggestions alone — the admin endorses the human, not the model" do
+    it "leaves ai-sourced suggestions alone AND keeps their item unconfirmed" do
       onion = create(:ingredient, slug: "vegetable-onion")
       ai_row = ItemIngredient.create!(item: community_item, ingredient: onion,
                                       confidence: "suggested", source: "ai")
 
-      restaurant.confirm_community_associations!
+      counts = restaurant.confirm_community_associations!
 
       expect(ai_row.reload.confidence).to eq("suggested")
+      # The item must NOT graduate while an untrusted association
+      # remains — strict mode keys off item.confidence (6.4.1).
+      expect(community_item.reload.confidence).to eq("suggested")
+      expect(counts[:items]).to eq(0)
     end
 
     it "does not touch other restaurants" do

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,16 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 11:10 — tick #136. **Phase 6.4.1 — three codex P2s from
+#302 fixed forward.** (1) community_published scope now also catches
+seeded restaurants that received a community RE-scan (EXISTS on
+suggested items, not just created_by). (2) confirm-all no longer
+graduates an item whose ai-suggested joins remain — item.confidence
+only flips when EVERY association is confirmed (strict mode keys
+off item.confidence). (3) New Avo CommunityRuns filter on the
+ingestion-runs resource (runs by non-admin users). rspec 436/436
+(+1 net). Next: Phase 6.5 web community scan entrypoint.
+
 2026-06-12 10:55 — tick #135. **Phase 6.4 shipped — moderation
 visibility.** #301 (6.3) merged, zero codex findings. Loop cadence
 shortened to 15 min by owner. This PR:


### PR DESCRIPTION
## Why

Codex raised three P2s on #302 — all verified real.

## What

1. **Rescans escaped the moderation scope.** A community re-scan of an admin-seeded restaurant leaves `suggested` items but no `created_by_user_id`. `Restaurant.community_published` now ORs an `EXISTS` on suggested items, so both entry paths (community-created AND community-rescanned) surface in the Avo filter.
2. **Mixed AI items could leak into strict mode.** confirm-all flipped `item.confidence` unconditionally while deliberately leaving `source: ai` joins suggested — but strict mode keys off `item.confidence`, so such items became strict-visible with an untrusted association attached. Items now graduate only when **every** association is confirmed.
3. **No run-level lens.** New `Avo::Filters::CommunityRuns` on the ingestion-runs resource (runs by non-admin users), so admins can audit submissions including failed/staged runs that never published.

## Test plan

- [x] `bundle exec rspec` — 436 examples, 0 failures (rescan-scope membership; ai-mixed item stays suggested with counts asserting 0 graduations)
- [x] `bundle exec brakeman` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)