### PR TITLE
feat(web): community scan entrypoint — restaurant picker, dedup cards, verify page

### DIFF
--- a/apps/web/src/app/api/ingestion_runs/[id]/items/[itemId]/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/items/[itemId]/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Phase 6.5 — `PATCH /api/ingestion_runs/:id/items/:itemId` proxies
+ * accept / reject / edit decisions from the web verify page.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string; itemId: string }> },
+) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+  const { id, itemId } = await context.params;
+  const body = await request.text();
+  const upstream = await fetch(
+    `${API_BASE}/api/v1/ingestion_runs/${encodeURIComponent(id)}/items/${encodeURIComponent(itemId)}`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body,
+    },
+  );
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/ingestion_runs/[id]/items/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/items/route.ts
@@ -1,0 +1,31 @@
+/**
+ * Phase 6.5 — `GET /api/ingestion_runs/:id/items` proxies the staged
+ * item list for the web verify page (creator-or-admin per Phase 6.3).
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+  const { id } = await context.params;
+  const upstream = await fetch(
+    `${API_BASE}/api/v1/ingestion_runs/${encodeURIComponent(id)}/items`,
+    {
+      headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+      cache: 'no-store',
+    },
+  );
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/ingestion_runs/[id]/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/route.ts
@@ -1,0 +1,28 @@
+/**
+ * Phase 6.5 — `GET /api/ingestion_runs/:id` proxies run-status
+ * polling for the web verify flow.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+  const { id } = await params;
+  const upstream = await fetch(`${API_BASE}/api/v1/ingestion_runs/${encodeURIComponent(id)}`, {
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+    cache: 'no-store',
+  });
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/restaurants/route.ts
+++ b/apps/web/src/app/api/restaurants/route.ts
@@ -1,0 +1,32 @@
+/**
+ * Phase 6.5 — `POST /api/restaurants` proxies community restaurant
+ * creation (Phase 6.2's endpoint) with the JWT from the HttpOnly
+ * cookie. 409 possible_duplicate responses pass through verbatim so
+ * the /ingest page can render the "did you mean…?" cards.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../lib/server-auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+
+export async function POST(request: NextRequest) {
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+  const body = await request.text();
+  const upstream = await fetch(`${API_BASE}/api/v1/restaurants`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body,
+  });
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/ingest/_NewRestaurantPicker.tsx
+++ b/apps/web/src/app/ingest/_NewRestaurantPicker.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import {
+  createRestaurant,
+  friendlyIngestionError,
+  type CreatedRestaurant,
+  type DuplicateCandidate,
+} from '../../lib/ingestion';
+
+/**
+ * Phase 6.5 — the "which restaurant?" step of the community scan
+ * flow. Create a new draft restaurant (with the Phase 6.2 dedup
+ * guard rendered as "did you mean…?" cards) or pick one of the
+ * suggested existing restaurants.
+ *
+ * Launch market is Durango; the city slug is a free input rather
+ * than a select because there is no cities index endpoint yet (the
+ * route is a Phase-0 stub — see routes.rb).
+ */
+export function NewRestaurantPicker({
+  onPicked,
+}: {
+  onPicked: (restaurant: { id: string; name: string }) => void;
+}) {
+  const [name, setName] = useState('');
+  const [citySlug, setCitySlug] = useState('durango');
+  const [street, setStreet] = useState('');
+  const [postalCode, setPostalCode] = useState('');
+  const [candidates, setCandidates] = useState<DuplicateCandidate[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (force: boolean) => {
+    setError(null);
+    if (!name.trim()) {
+      setError('Restaurant name is required.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      const result = await createRestaurant({
+        name: name.trim(),
+        citySlug: citySlug.trim(),
+        street: street.trim() || undefined,
+        postalCode: postalCode.trim() || undefined,
+        force,
+      });
+      if (result.kind === 'duplicates') {
+        setCandidates(result.candidates);
+        return;
+      }
+      setCandidates(null);
+      onPicked(pickedShape(result.restaurant));
+    } catch (e) {
+      setError(friendlyIngestionError(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <form
+        onSubmit={(e: FormEvent) => {
+          e.preventDefault();
+          void submit(false);
+        }}
+        className="space-y-3"
+      >
+        <label className="block">
+          <span className="text-sm font-medium text-zinc-700">Restaurant name</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Maria's Tacos"
+            className="mt-1 w-full rounded border border-zinc-300 px-3 py-2"
+          />
+        </label>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <label className="block">
+            <span className="text-sm font-medium text-zinc-700">City slug</span>
+            <input
+              type="text"
+              value={citySlug}
+              onChange={(e) => setCitySlug(e.target.value)}
+              className="mt-1 w-full rounded border border-zinc-300 px-3 py-2"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-zinc-700">Street (optional)</span>
+            <input
+              type="text"
+              value={street}
+              onChange={(e) => setStreet(e.target.value)}
+              placeholder="742 Main Ave"
+              className="mt-1 w-full rounded border border-zinc-300 px-3 py-2"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-zinc-700">ZIP (optional)</span>
+            <input
+              type="text"
+              value={postalCode}
+              onChange={(e) => setPostalCode(e.target.value)}
+              placeholder="81301"
+              className="mt-1 w-full rounded border border-zinc-300 px-3 py-2"
+            />
+          </label>
+        </div>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded bg-orange-600 px-4 py-2 font-semibold text-white disabled:opacity-50"
+        >
+          {submitting ? 'Checking…' : 'Create restaurant'}
+        </button>
+      </form>
+
+      {error && (
+        <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-900" role="alert">
+          {error}
+        </div>
+      )}
+
+      {candidates && candidates.length > 0 && (
+        <div className="space-y-2 rounded-xl border border-amber-300 bg-amber-50 p-4" role="region" aria-label="possible duplicates">
+          <p className="font-semibold text-amber-900">Did you mean one of these?</p>
+          <ul className="space-y-2">
+            {candidates.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center justify-between rounded border border-amber-200 bg-white p-3"
+              >
+                <div>
+                  <p className="font-medium">{c.name}</p>
+                  <p className="text-sm text-zinc-600">
+                    {c.street ?? 'No address on file'} · {c.status}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onPicked({ id: c.id, name: c.name })}
+                  className="rounded border border-orange-600 px-3 py-1 text-sm font-semibold text-orange-700"
+                >
+                  Use this one
+                </button>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => void submit(true)}
+            className="text-sm font-semibold text-amber-900 underline"
+          >
+            None of these — create “{name}” anyway
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function pickedShape(r: CreatedRestaurant): { id: string; name: string } {
+  return { id: r.id, name: r.name };
+}

--- a/apps/web/src/app/ingest/__tests__/NewRestaurantPicker.test.tsx
+++ b/apps/web/src/app/ingest/__tests__/NewRestaurantPicker.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NewRestaurantPicker } from '../_NewRestaurantPicker';
+import * as ingestion from '../../../lib/ingestion';
+
+vi.mock('../../../lib/ingestion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/ingestion')>();
+  return { ...actual, createRestaurant: vi.fn() };
+});
+
+const createRestaurantMock = vi.mocked(ingestion.createRestaurant);
+
+// NOTE: no beforeEach mock-clearing — see VerifyItemRow.test.tsx for
+// the vitest-4 unhandled-rejection quirk this avoids. Tests use
+// per-test impls + call-count deltas instead.
+describe('NewRestaurantPicker', () => {
+
+  it('calls onPicked with the created restaurant', async () => {
+    createRestaurantMock.mockResolvedValue({
+      kind: 'created',
+      restaurant: { id: 'r-1', slug: 'marias', name: "Maria's Tacos", status: 'draft' },
+    });
+    const onPicked = vi.fn();
+    render(<NewRestaurantPicker onPicked={onPicked} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Maria's Tacos"), {
+      target: { value: "Maria's Tacos" },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create restaurant' }));
+
+    await waitFor(() =>
+      expect(onPicked).toHaveBeenCalledWith({ id: 'r-1', name: "Maria's Tacos" }),
+    );
+  });
+
+  it('renders "did you mean" cards on duplicates; picking one calls onPicked with the existing id', async () => {
+    createRestaurantMock.mockResolvedValue({
+      kind: 'duplicates',
+      candidates: [
+        { id: 'r-9', slug: 'marias', name: "Maria's Tacos", status: 'published', street: '742 Main Ave' },
+      ],
+    });
+    const onPicked = vi.fn();
+    render(<NewRestaurantPicker onPicked={onPicked} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Maria's Tacos"), {
+      target: { value: 'Marias Taco' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create restaurant' }));
+
+    await screen.findByText('Did you mean one of these?');
+    expect(screen.getByText('742 Main Ave · published')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use this one' }));
+    expect(onPicked).toHaveBeenCalledWith({ id: 'r-9', name: "Maria's Tacos" });
+  });
+
+  it('"create anyway" re-submits with force', async () => {
+    createRestaurantMock
+      .mockResolvedValueOnce({
+        kind: 'duplicates',
+        candidates: [
+          { id: 'r-9', slug: 'marias', name: "Maria's Tacos", status: 'published', street: null },
+        ],
+      })
+      .mockResolvedValueOnce({
+        kind: 'created',
+        restaurant: { id: 'r-2', slug: 'marias-taco', name: 'Marias Taco', status: 'draft' },
+      });
+    const onPicked = vi.fn();
+    render(<NewRestaurantPicker onPicked={onPicked} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Maria's Tacos"), {
+      target: { value: 'Marias Taco' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create restaurant' }));
+    await screen.findByText('Did you mean one of these?');
+
+    fireEvent.click(screen.getByRole('button', { name: /create “Marias Taco” anyway/ }));
+
+    await waitFor(() => expect(onPicked).toHaveBeenCalledWith({ id: 'r-2', name: 'Marias Taco' }));
+    expect(createRestaurantMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ force: true }),
+    );
+  });
+
+  it('shows a validation error when the name is blank', async () => {
+    const callsBefore = createRestaurantMock.mock.calls.length;
+    const onPicked = vi.fn();
+    render(<NewRestaurantPicker onPicked={onPicked} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create restaurant' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Restaurant name is required.');
+    expect(createRestaurantMock.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/apps/web/src/app/ingest/page.tsx
+++ b/apps/web/src/app/ingest/page.tsx
@@ -2,40 +2,39 @@
 
 import { useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
+import type { Route } from 'next';
 import {
   ingestFromFile,
   ingestFromUrl,
+  friendlyIngestionError,
   IngestionRequestError,
-  type IngestionRunPayload,
 } from '../../lib/ingestion';
+import { NewRestaurantPicker } from './_NewRestaurantPicker';
 
 /**
- * Phase 2.8 + 4.1 — admin entrypoint for AI ingestion via web.
- *
- * Two parallel ways to start a run:
- *   1. Paste a restaurant menu URL (HTML or PDF). Server-side
- *      `UrlFetcher` downloads it and attaches the body.
- *   2. Drop a PDF file. Same backend pipeline from the multipart side.
- *
- * Phase 4.1 dropped the JWT-paste field; auth comes from the
- * `bw_session` cookie set by `/login`. A 401 from the proxy bounces
- * the user to /login?next=/ingest.
+ * Phase 2.8 + 4.1 — web entrypoint for AI ingestion.
+ * Phase 6.5 — community scan flow: any signed-in user picks or
+ * creates the restaurant (with the Phase 6.2 dedup guard), uploads a
+ * menu URL/PDF, and lands on /ingest/verify/<run> to swipe through
+ * the extraction. Quota/budget errors (Phase 6.1) render as human
+ * messages.
  */
 export default function IngestPage() {
   const router = useRouter();
 
-  const [restaurantId, setRestaurantId] = useState('');
+  const [restaurant, setRestaurant] = useState<{ id: string; name: string } | null>(null);
+  const [manualId, setManualId] = useState('');
   const [sourceUrl, setSourceUrl] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState<IngestionRunPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const restaurantId = restaurant?.id ?? manualId;
 
   const submit = async (mode: 'url' | 'file') => {
     setError(null);
-    setResult(null);
     if (!restaurantId) {
-      setError('Restaurant id is required.');
+      setError('Pick or create a restaurant first.');
       return;
     }
     if (mode === 'url' && !sourceUrl) {
@@ -53,13 +52,13 @@ export default function IngestPage() {
         mode === 'url'
           ? await ingestFromUrl({ restaurantId, sourceUrl })
           : await ingestFromFile({ restaurantId, file: file! });
-      setResult(run);
+      router.push(`/ingest/verify/${run.id}` as Route);
     } catch (e) {
       if (e instanceof IngestionRequestError && e.status === 401) {
         router.replace(`/login?next=${encodeURIComponent('/ingest')}`);
         return;
       }
-      setError((e as Error).message);
+      setError(friendlyIngestionError(e));
     } finally {
       setSubmitting(false);
     }
@@ -69,30 +68,50 @@ export default function IngestPage() {
     <main className="mx-auto max-w-3xl space-y-8 p-6">
       <header>
         <p className="text-sm font-semibold uppercase tracking-widest text-orange-600">
-          Ingest a menu
+          Scan a menu
         </p>
-        <h1 className="mt-1 text-3xl font-bold">Web upload entrypoint</h1>
+        <h1 className="mt-1 text-3xl font-bold">Add a restaurant’s menu</h1>
         <p className="mt-2 text-zinc-600">
-          Paste a restaurant menu URL OR drop a PDF. Either way, the AI extracts the
-          items and stages them for swipe-verify in <code>/admin</code>.
+          Pick the restaurant (or create it if it’s new), then give us the menu — a
+          URL or a PDF. The AI extracts the items and you verify them before they go
+          live.
         </p>
       </header>
 
       <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
-        <label className="block">
-          <span className="text-sm font-medium text-zinc-700">Restaurant UUID</span>
-          <input
-            type="text"
-            value={restaurantId}
-            onChange={(e) => setRestaurantId(e.target.value)}
-            className="mt-1 w-full rounded border border-zinc-300 px-3 py-2 font-mono text-sm"
-            placeholder="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-          />
-        </label>
+        <h2 className="text-lg font-semibold">1. Which restaurant?</h2>
+        {restaurant ? (
+          <div className="flex items-center justify-between rounded border border-green-300 bg-green-50 p-3">
+            <p className="text-green-900">
+              Scanning for <strong>{restaurant.name}</strong>
+            </p>
+            <button
+              type="button"
+              onClick={() => setRestaurant(null)}
+              className="text-sm font-semibold text-green-900 underline"
+            >
+              Change
+            </button>
+          </div>
+        ) : (
+          <>
+            <NewRestaurantPicker onPicked={setRestaurant} />
+            <details className="text-sm text-zinc-500">
+              <summary className="cursor-pointer">Already have a restaurant UUID?</summary>
+              <input
+                type="text"
+                value={manualId}
+                onChange={(e) => setManualId(e.target.value)}
+                className="mt-2 w-full rounded border border-zinc-300 px-3 py-2 font-mono text-sm"
+                placeholder="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+              />
+            </details>
+          </>
+        )}
       </section>
 
       <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
-        <h2 className="text-lg font-semibold">From a URL</h2>
+        <h2 className="text-lg font-semibold">2. From a URL</h2>
         <form
           onSubmit={(e: FormEvent) => {
             e.preventDefault();
@@ -118,7 +137,7 @@ export default function IngestPage() {
       </section>
 
       <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
-        <h2 className="text-lg font-semibold">Or drop a PDF</h2>
+        <h2 className="text-lg font-semibold">Or drop a PDF / photo</h2>
         <input
           type="file"
           accept="application/pdf,image/*"
@@ -138,17 +157,6 @@ export default function IngestPage() {
       {error && (
         <div className="rounded border border-red-300 bg-red-50 p-4 text-red-900" role="alert">
           {error}
-        </div>
-      )}
-      {result && (
-        <div className="rounded border border-green-300 bg-green-50 p-4 text-green-900" role="status">
-          <p>
-            Run <code>{result.id}</code> → <strong>{result.status}</strong> (
-            {result.input_kind})
-          </p>
-          <p className="mt-1 text-sm">
-            Find it in /admin/resources/ingestion_runs.
-          </p>
         </div>
       )}
     </main>

--- a/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  decideRunItem,
+  friendlyIngestionError,
+  type IngestionItemPayload,
+} from '../../../../lib/ingestion';
+
+/**
+ * Phase 6.5 — one staged item in the web verify list. The web twin
+ * of mobile's swipe-verify card (Phase 2.7): accept promotes (with
+ * the Phase 6.3 trust level of whoever is signed in), reject buries.
+ */
+export function VerifyItemRow({
+  runId,
+  item,
+  onDecided,
+}: {
+  runId: string;
+  item: IngestionItemPayload;
+  onDecided: (updated: IngestionItemPayload) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const decide = async (decision: 'accepted' | 'rejected') => {
+    setError(null);
+    try {
+      setBusy(true);
+      const updated = await decideRunItem({ runId, itemId: item.id, decision });
+      onDecided(updated);
+    } catch (e) {
+      setError(friendlyIngestionError(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const decided = item.decision === 'accepted' || item.decision === 'rejected';
+  const price = item.prices_payload[0]?.price_cents;
+
+  return (
+    <li className="rounded-xl border border-zinc-200 p-4" data-testid={`verify-item-${item.id}`}>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="font-semibold">
+            {item.name}
+            {price != null && (
+              <span className="ml-2 font-normal text-zinc-500">
+                ${(price / 100).toFixed(2)}
+              </span>
+            )}
+          </p>
+          {item.section_name && (
+            <p className="text-xs uppercase tracking-wide text-zinc-400">{item.section_name}</p>
+          )}
+          {item.description && <p className="mt-1 text-sm text-zinc-600">{item.description}</p>}
+          <p className="mt-2 flex flex-wrap gap-1">
+            {item.ingredients_payload.map((row) => (
+              <span
+                key={row.slug}
+                className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700"
+              >
+                {row.slug}
+              </span>
+            ))}
+            {item.tags_payload.map((row) => (
+              <span
+                key={row.slug}
+                className="rounded-full bg-orange-50 px-2 py-0.5 text-xs text-orange-700"
+              >
+                {row.slug}
+              </span>
+            ))}
+          </p>
+        </div>
+
+        <div className="flex shrink-0 flex-col items-end gap-2">
+          {decided ? (
+            <span
+              className={
+                item.decision === 'accepted'
+                  ? 'rounded bg-green-100 px-2 py-1 text-sm font-semibold text-green-800'
+                  : 'rounded bg-zinc-100 px-2 py-1 text-sm font-semibold text-zinc-600'
+              }
+            >
+              {item.decision}
+            </span>
+          ) : (
+            <>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void decide('accepted')}
+                className="rounded bg-green-600 px-3 py-1 text-sm font-semibold text-white disabled:opacity-50"
+              >
+                Accept
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void decide('rejected')}
+                className="rounded border border-zinc-300 px-3 py-1 text-sm font-semibold text-zinc-600 disabled:opacity-50"
+              >
+                Reject
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      {error && (
+        <p className="mt-2 text-sm text-red-700" role="alert">
+          {error}
+        </p>
+      )}
+    </li>
+  );
+}

--- a/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { VerifyItemRow } from '../_VerifyItemRow';
+import * as ingestion from '../../../../../lib/ingestion';
+import type { IngestionItemPayload } from '../../../../../lib/ingestion';
+
+vi.mock('../../../../../lib/ingestion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../lib/ingestion')>();
+  return { ...actual, decideRunItem: vi.fn() };
+});
+
+const decideMock = vi.mocked(ingestion.decideRunItem);
+
+const item: IngestionItemPayload = {
+  id: 'item-1',
+  ingestion_run_id: 'run-1',
+  item_id: null,
+  name: 'Pad Thai',
+  description: 'Rice noodles, peanut, lime.',
+  section_name: 'Noodles',
+  decision: 'pending',
+  decided_at: null,
+  ingredients_payload: [{ slug: 'nut-peanut', confidence: 0.97 }],
+  tags_payload: [{ slug: 'cuisine-thai', confidence: 0.99 }],
+  prices_payload: [{ size: null, price_cents: 1450 }],
+  unresolved_ingredients: [],
+  unresolved_tags: [],
+};
+
+// NOTE: no beforeEach mock-clearing here — vitest 4 flags later
+// rejected mock results as unhandled when the mock was cleared in a
+// beforeEach (empirically verified). Per-test mockImplementation
+// overrides + toHaveBeenLastCalledWith give the same isolation.
+describe('VerifyItemRow', () => {
+
+  it('renders name, price, section, and payload chips', () => {
+    render(<VerifyItemRow runId="run-1" item={item} onDecided={vi.fn()} />);
+
+    expect(screen.getByText('Pad Thai')).toBeInTheDocument();
+    expect(screen.getByText('$14.50')).toBeInTheDocument();
+    expect(screen.getByText('Noodles')).toBeInTheDocument();
+    expect(screen.getByText('nut-peanut')).toBeInTheDocument();
+    expect(screen.getByText('cuisine-thai')).toBeInTheDocument();
+  });
+
+  it('accept wires through decideRunItem and reports the updated item', async () => {
+    const updated = { ...item, decision: 'accepted' as const };
+    decideMock.mockResolvedValue(updated);
+    const onDecided = vi.fn();
+    render(<VerifyItemRow runId="run-1" item={item} onDecided={onDecided} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    await waitFor(() => expect(onDecided).toHaveBeenCalledWith(updated));
+    expect(decideMock).toHaveBeenLastCalledWith({
+      runId: 'run-1',
+      itemId: 'item-1',
+      decision: 'accepted',
+    });
+  });
+
+  it('decided items show a status badge instead of buttons', () => {
+    render(
+      <VerifyItemRow
+        runId="run-1"
+        item={{ ...item, decision: 'accepted' }}
+        onDecided={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('accepted')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Accept' })).toBeNull();
+  });
+
+  it('renders the friendly error when the decision fails', async () => {
+    decideMock.mockImplementation(() =>
+      Promise.reject(new ingestion.IngestionRequestError(503, { error: 'cost_ceiling_reached' })),
+    );
+    render(<VerifyItemRow runId="run-1" item={item} onDecided={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/budget/);
+  });
+});

--- a/apps/web/src/app/ingest/verify/[runId]/page.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { use, useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import {
+  fetchRun,
+  fetchRunItems,
+  friendlyIngestionError,
+  type IngestionItemPayload,
+  type IngestionRunPayload,
+} from '../../../../lib/ingestion';
+import { VerifyItemRow } from './_VerifyItemRow';
+
+const PIPELINE_LABELS: Record<IngestionRunPayload['status'], string> = {
+  queued: 'Waiting in line…',
+  extracting: 'Reading the menu…',
+  resolving: 'Matching ingredients…',
+  staged: 'Ready to verify',
+  published: 'Published!',
+  failed: 'Extraction failed',
+};
+
+const POLL_MS = 3_000;
+
+/**
+ * Phase 6.5 — web verify page. Polls the run while the pipeline is
+ * working, then renders the staged items for accept/reject. The 80%
+ * threshold (Phase 2.5) flips the run + restaurant to published as
+ * decisions come in; we re-poll after each decision to notice.
+ */
+export default function VerifyRunPage({ params }: { params: Promise<{ runId: string }> }) {
+  const { runId } = use(params);
+
+  const [run, setRun] = useState<IngestionRunPayload | null>(null);
+  const [items, setItems] = useState<IngestionItemPayload[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const latest = await fetchRun(runId);
+      setRun(latest);
+      if (latest.status === 'staged' || latest.status === 'published') {
+        setItems(await fetchRunItems(runId));
+      } else if (latest.status !== 'failed') {
+        pollTimer.current = setTimeout(() => void refresh(), POLL_MS);
+      }
+    } catch (e) {
+      setError(friendlyIngestionError(e));
+    }
+  }, [runId]);
+
+  useEffect(() => {
+    void refresh();
+    return () => {
+      if (pollTimer.current) clearTimeout(pollTimer.current);
+    };
+  }, [refresh]);
+
+  const onDecided = (updated: IngestionItemPayload) => {
+    setItems((prev) => prev?.map((it) => (it.id === updated.id ? updated : it)) ?? null);
+    // A decision may have crossed the 80% publish threshold.
+    void fetchRun(runId).then(setRun).catch(() => undefined);
+  };
+
+  const decidedCount = items?.filter((it) => it.decision !== 'pending').length ?? 0;
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-6">
+      <header>
+        <p className="text-sm font-semibold uppercase tracking-widest text-orange-600">
+          Verify the scan
+        </p>
+        <h1 className="mt-1 text-3xl font-bold">
+          {run ? PIPELINE_LABELS[run.status] : 'Loading…'}
+        </h1>
+        {run && run.status !== 'staged' && run.status !== 'published' && run.status !== 'failed' && (
+          <p className="mt-2 text-zinc-600" role="status">
+            This usually takes under a minute. The page refreshes itself.
+          </p>
+        )}
+        {run?.status === 'failed' && (
+          <p className="mt-2 text-red-700" role="alert">
+            {run.failure_message ?? 'Something went wrong during extraction.'}
+          </p>
+        )}
+      </header>
+
+      {run?.status === 'published' && (
+        <div className="rounded-xl border border-green-300 bg-green-50 p-4 text-green-900" role="status">
+          <p className="font-semibold">This menu is live! 🎉</p>
+          <p className="mt-1 text-sm">
+            <Link href={`/restaurants/${run.restaurant_id}`} className="underline">
+              See the restaurant page
+            </Link>{' '}
+            — items you verified show for everyone (strict-mode users see them once an
+            admin confirms).
+          </p>
+        </div>
+      )}
+
+      {items && (
+        <>
+          <p className="text-sm text-zinc-500" role="status">
+            {decidedCount} of {items.length} decided — accept at least 80% to publish.
+          </p>
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <VerifyItemRow key={item.id} runId={runId} item={item} onDecided={onDecided} />
+            ))}
+          </ul>
+        </>
+      )}
+
+      {error && (
+        <div className="rounded border border-red-300 bg-red-50 p-4 text-red-900" role="alert">
+          {error}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/lib/__tests__/ingestion.test.ts
+++ b/apps/web/src/lib/__tests__/ingestion.test.ts
@@ -116,3 +116,124 @@ describe('ingestFromFile', () => {
     ).rejects.toBeInstanceOf(IngestionRequestError);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 6.5 — community scan flow
+// ---------------------------------------------------------------------------
+
+import {
+  createRestaurant,
+  decideRunItem,
+  fetchRunItems,
+  friendlyIngestionError,
+  type IngestionItemPayload,
+} from '../ingestion';
+
+const sampleItem: IngestionItemPayload = {
+  id: 'item-1',
+  ingestion_run_id: 'rrrr-1111',
+  item_id: null,
+  name: 'Pad Thai',
+  description: 'Rice noodles, peanut, lime.',
+  section_name: 'Noodles',
+  decision: 'pending',
+  decided_at: null,
+  ingredients_payload: [{ slug: 'nut-peanut', confidence: 0.97 }],
+  tags_payload: [{ slug: 'cuisine-thai', confidence: 0.99 }],
+  prices_payload: [{ size: null, price_cents: 1450 }],
+  unresolved_ingredients: [],
+  unresolved_tags: [],
+};
+
+describe('createRestaurant', () => {
+  it('returns created on 201', async () => {
+    const fetchImpl = fakeFetch(201, { id: 'r-1', slug: 'marias', name: "Maria's", status: 'draft' });
+
+    const result = await createRestaurant({ name: "Maria's", citySlug: 'durango', fetchImpl });
+
+    expect(result).toEqual({
+      kind: 'created',
+      restaurant: { id: 'r-1', slug: 'marias', name: "Maria's", status: 'draft' },
+    });
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/restaurants');
+    expect(JSON.parse(init.body as string)).toMatchObject({ name: "Maria's", city_slug: 'durango' });
+  });
+
+  it('returns the candidate list on 409 instead of throwing', async () => {
+    const candidates = [
+      { id: 'r-9', slug: 'marias', name: "Maria's Tacos", status: 'published', street: '742 Main Ave' },
+    ];
+    const fetchImpl = fakeFetch(409, { error: 'possible_duplicate', candidates });
+
+    const result = await createRestaurant({ name: 'Marias Taco', citySlug: 'durango', fetchImpl });
+
+    expect(result).toEqual({ kind: 'duplicates', candidates });
+  });
+
+  it('sends force: "true" when overriding the dedup prompt', async () => {
+    const fetchImpl = fakeFetch(201, { id: 'r-2', slug: 'x', name: 'X', status: 'draft' });
+
+    await createRestaurant({ name: 'X', citySlug: 'durango', force: true, fetchImpl });
+
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string).force).toBe('true');
+  });
+
+  it('throws IngestionRequestError on other failures', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'unknown_city' });
+
+    await expect(
+      createRestaurant({ name: 'X', citySlug: 'atlantis', fetchImpl }),
+    ).rejects.toBeInstanceOf(IngestionRequestError);
+  });
+});
+
+describe('fetchRunItems / decideRunItem', () => {
+  it('unwraps the items array', async () => {
+    const fetchImpl = fakeFetch(200, { items: [sampleItem] });
+
+    const items = await fetchRunItems('rrrr-1111', fetchImpl);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]!.name).toBe('Pad Thai');
+  });
+
+  it('PATCHes the decision to the per-item proxy route', async () => {
+    const fetchImpl = fakeFetch(200, { ...sampleItem, decision: 'accepted' });
+
+    const updated = await decideRunItem({
+      runId: 'rrrr-1111',
+      itemId: 'item-1',
+      decision: 'accepted',
+      fetchImpl,
+    });
+
+    expect(updated.decision).toBe('accepted');
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/ingestion_runs/rrrr-1111/items/item-1');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body as string)).toEqual({ decision: 'accepted' });
+  });
+});
+
+describe('friendlyIngestionError', () => {
+  it('maps 429 quota errors with the limit', () => {
+    const err = new IngestionRequestError(429, { error: 'quota_exceeded', limit: 5 } as never);
+    expect(friendlyIngestionError(err)).toBe('Daily scan limit reached (5/day) — try again tomorrow.');
+  });
+
+  it('maps 503 ceiling errors', () => {
+    const err = new IngestionRequestError(503, { error: 'cost_ceiling_reached' });
+    expect(friendlyIngestionError(err)).toMatch(/budget.*used up/);
+  });
+
+  it('maps 403 forbidden_restaurant', () => {
+    const err = new IngestionRequestError(403, { error: 'forbidden_restaurant' });
+    expect(friendlyIngestionError(err)).toMatch(/someone else's draft/);
+  });
+
+  it('falls back to the raw message otherwise', () => {
+    expect(friendlyIngestionError(new Error('boom'))).toBe('boom');
+  });
+});

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -63,6 +63,161 @@ async function postIngestionRun(
   return (await res.json()) as IngestionRunPayload;
 }
 
+/** Phase 6.5 — community restaurant creation + the verify flow. */
+
+export interface DuplicateCandidate {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  street: string | null;
+}
+
+export interface CreatedRestaurant {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+}
+
+export type CreateRestaurantResult =
+  | { kind: 'created'; restaurant: CreatedRestaurant }
+  | { kind: 'duplicates'; candidates: DuplicateCandidate[] };
+
+export async function createRestaurant(opts: {
+  name: string;
+  citySlug: string;
+  street?: string;
+  postalCode?: string;
+  force?: boolean;
+  fetchImpl?: typeof fetch;
+}): Promise<CreateRestaurantResult> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/restaurants', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+    body: JSON.stringify({
+      name: opts.name,
+      city_slug: opts.citySlug,
+      street: opts.street,
+      postal_code: opts.postalCode,
+      force: opts.force ? 'true' : undefined,
+    }),
+  });
+
+  if (res.status === 409) {
+    const body = (await res.json()) as { candidates: DuplicateCandidate[] };
+    return { kind: 'duplicates', candidates: body.candidates ?? [] };
+  }
+  if (!res.ok) {
+    let parsed: IngestionApiError | null = null;
+    try {
+      parsed = (await res.json()) as IngestionApiError;
+    } catch {
+      // ignore
+    }
+    throw new IngestionRequestError(res.status, parsed);
+  }
+  return { kind: 'created', restaurant: (await res.json()) as CreatedRestaurant };
+}
+
+export interface IngestionItemPayload {
+  id: string;
+  ingestion_run_id: string;
+  item_id: string | null;
+  name: string | null;
+  description: string | null;
+  section_name: string | null;
+  decision: 'pending' | 'accepted' | 'rejected' | 'edited';
+  decided_at: string | null;
+  ingredients_payload: Array<{ slug: string; confidence: number }>;
+  tags_payload: Array<{ slug: string; confidence: number }>;
+  prices_payload: Array<{ size: string | null; price_cents: number }>;
+  unresolved_ingredients: string[];
+  unresolved_tags: string[];
+}
+
+async function getJson<T>(path: string, fetchImpl: typeof fetch): Promise<T> {
+  const res = await fetchImpl(path, { credentials: 'same-origin' });
+  if (!res.ok) {
+    let parsed: IngestionApiError | null = null;
+    try {
+      parsed = (await res.json()) as IngestionApiError;
+    } catch {
+      // ignore
+    }
+    throw new IngestionRequestError(res.status, parsed);
+  }
+  return (await res.json()) as T;
+}
+
+export async function fetchRun(
+  runId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<IngestionRunPayload> {
+  return getJson<IngestionRunPayload>(`/api/ingestion_runs/${encodeURIComponent(runId)}`, fetchImpl);
+}
+
+export async function fetchRunItems(
+  runId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<IngestionItemPayload[]> {
+  const body = await getJson<{ items: IngestionItemPayload[] }>(
+    `/api/ingestion_runs/${encodeURIComponent(runId)}/items`,
+    fetchImpl,
+  );
+  return body.items;
+}
+
+export async function decideRunItem(opts: {
+  runId: string;
+  itemId: string;
+  decision: 'accepted' | 'rejected';
+  fetchImpl?: typeof fetch;
+}): Promise<IngestionItemPayload> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(
+    `/api/ingestion_runs/${encodeURIComponent(opts.runId)}/items/${encodeURIComponent(opts.itemId)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ decision: opts.decision }),
+    },
+  );
+  if (!res.ok) {
+    let parsed: IngestionApiError | null = null;
+    try {
+      parsed = (await res.json()) as IngestionApiError;
+    } catch {
+      // ignore
+    }
+    throw new IngestionRequestError(res.status, parsed);
+  }
+  return (await res.json()) as IngestionItemPayload;
+}
+
+/**
+ * Human messages for the Phase 6.1 guardrails. Anything unmapped
+ * falls back to the raw error message.
+ */
+export function friendlyIngestionError(err: unknown): string {
+  if (err instanceof IngestionRequestError) {
+    if (err.status === 429) {
+      const limit = (err.body as { limit?: number } | null)?.limit;
+      return `Daily scan limit reached${limit ? ` (${limit}/day)` : ''} — try again tomorrow.`;
+    }
+    if (err.status === 503) {
+      return "Today's community scanning budget is used up — try again tomorrow.";
+    }
+    if (err.status === 403 && err.body?.error === 'forbidden_restaurant') {
+      return "That restaurant is someone else's draft — pick a published restaurant or create your own.";
+    }
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
 export async function ingestFromUrl(opts: {
   restaurantId: string;
   sourceUrl: string;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,20 +22,15 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 6.1 — non-admin ingestion runs + quotas + cost ceiling** (`docs/plans/phase-6.md`)
-2. **Phase 6.2 — community restaurant creation + pg_trgm duplicate detection**
-3. **Phase 6.3 — self-verify + community-trust promotion (suggested, not confirmed)**
-4. **Phase 6.4 — community-publish moderation visibility (Avo + dashboard)**
-5. **Phase 6.5 — web community scan entrypoint (open /ingest + new-restaurant + web verify)**
-6. **Phase 6.6 — mobile community scan entrypoint**
-7. **Phase 7.1 — wire the real camera capture (expo-camera)** (`docs/plans/phase-7.md`)
-8. **Phase 7.2 — real mobile home screen (search + near-me + scan CTA)**
-9. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
-10. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
-11. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)**
-12. **Phase 8.3 — Top Picks UI (web)**
-13. **Phase 8.4 — Top Picks UI (mobile)**
-14. **Phase 8.5 — taste onboarding step (web + mobile)**
+1. **Phase 6.6 — mobile community scan entrypoint** (`docs/plans/phase-6.md`)
+2. **Phase 7.1 — wire the real camera capture (expo-camera)** (`docs/plans/phase-7.md`)
+3. **Phase 7.2 — real mobile home screen (search + near-me + scan CTA)**
+4. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
+5. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
+6. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)**
+7. **Phase 8.3 — Top Picks UI (web)**
+8. **Phase 8.4 — Top Picks UI (mobile)**
+9. **Phase 8.5 — taste onboarding step (web + mobile)**
 15. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
 16. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
@@ -101,6 +96,15 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Launch-readiness checklist + loop pause (#184) — `docs/launch-readiness.md` is the human's linear path from "code complete" to launch.
 - ✅ Phase 4.11.0 / 4.11.2-cassette — recorded against Simply Tasty Thai appetizers; ExtractMenuJob integration smoke now real (this PR) — **Phase 4.11 fully complete**
 - ✅ Phase 5.8-wiring — posthog-js + posthog-react-native wired into the 9 funnel events (#218) — code side complete; setting the real `*_POSTHOG_KEY` in Vercel/EAS is launch-readiness step 7
+- ✅ Phases 6–8 — subplans committed (#296)
+- ✅ Phase 6.1 — non-admin ingestion runs + quotas + cost ceiling (#297)
+- ✅ Phase 6.1.1 — ingestion hardening: real cost accrual, quota race, upload caps (#298)
+- ✅ Phase 6.1.2 — pre-fetch quota check + usage on schema failures (#299)
+- ✅ Phase 6.2 — community restaurant creation + pg_trgm dedup (#300)
+- ✅ Phase 6.3 — self-verify + suggested-confidence trust model (#301)
+- ✅ Phase 6.4 — community-publish moderation visibility (#302)
+- ✅ Phase 6.4.1 — moderation gaps: rescan scope, mixed-ai items, run filter (#303)
+- ✅ Phase 6.5 — web community scan entrypoint (this PR)
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,32 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 11:40 — tick #137. **Phase 6.5 shipped — web community
+scan entrypoint.** #303 (6.4.1) merged. This PR (web):
+- 4 new Next proxies: POST /api/restaurants, GET run, GET run items,
+  PATCH item decision (cookie-JWT pattern from Phase 4.1).
+- lib/ingestion.ts: createRestaurant (409 → typed duplicates
+  result), fetchRun/fetchRunItems/decideRunItem,
+  friendlyIngestionError (429 quota / 503 budget / 403 foreign-draft
+  → human copy).
+- /ingest reworked into the 2-step community flow:
+  NewRestaurantPicker (create + "did you mean?" cards + force) →
+  URL/PDF upload → push to NEW /ingest/verify/[runId] page: polls
+  pipeline status (3s), then VerifyItemRow accept/reject list with
+  the 80%-threshold progress line + published banner linking to the
+  restaurant page.
+- Tests: +9 lib (dedupe/force/error mapping), +8 RTL (picker cards,
+  force resubmit, verify row wiring/badge/error).
+War story: vitest 4 flags rejected mock results as unhandled iff
+the mock was cleared in a beforeEach — empirically isolated;
+per-test impls + last-called assertions instead (commented in both
+test files). Also the known Next typedRoutes dynamic-push cast
+(#274 precedent). web vitest 133/133; typecheck 10/10; lint 6/6.
+Roadmap: 6.1–6.5 ticked into Done. Cities note: no cities index
+endpoint exists (Phase-0 stub route), so the picker takes a city
+slug defaulting to durango — fine for the launch market. Next:
+Phase 6.6 mobile entrypoint.
+
 2026-06-12 11:10 — tick #136. **Phase 6.4.1 — three codex P2s from
 #302 fixed forward.** (1) community_published scope now also catches
 seeded restaurants that received a community RE-scan (EXISTS on


### PR DESCRIPTION
## Why

Phase 6.5 (`docs/plans/phase-6.md`) — the API side of anyone-can-scan is fully merged (6.1–6.4); this is the first user-facing surface. A signed-in web user can now create a restaurant, scan its menu, and verify the extraction without an admin or the Avo panel.

## What

- **4 new Next proxies** (cookie-JWT pattern from Phase 4.1): `POST /api/restaurants`, `GET /api/ingestion_runs/:id`, `GET .../items`, `PATCH .../items/:itemId`.
- **`lib/ingestion.ts`**: `createRestaurant` returns a typed union — `created` or `duplicates` (409 is a flow state, not an error); `fetchRun`/`fetchRunItems`/`decideRunItem`; `friendlyIngestionError` maps the Phase 6.1 guardrails to human copy (429 quota with limit, 503 daily budget, 403 someone-else's-draft).
- **`/ingest` reworked** into the two-step community flow: `NewRestaurantPicker` (name/city/address form → did-you-mean candidate cards → "use this one" or force-create) then URL/PDF upload. Successful runs route to…
- **New `/ingest/verify/[runId]` page**: polls the pipeline with stage labels ("Reading the menu…", "Matching ingredients…"), then renders `VerifyItemRow` accept/reject cards with payload chips, a "N of M decided — accept at least 80% to publish" progress line, and a published banner linking to the live restaurant page.
- Manual-UUID entry kept behind a `<details>` for power users.

## Test plan

- [x] `pnpm --filter @biteworthy/web test` — 133/133 (+17: lib dedupe/force/error-mapping; RTL picker candidates + force resubmit + blank-name validation; verify row chips/wiring/badge/error)
- [x] `pnpm typecheck` 10/10, `pnpm lint` 6/6

## Notes

- **vitest 4 quirk, empirically isolated**: a rejected mock result is flagged as an unhandled error iff the mock was cleared in a `beforeEach` (same code passes without the clear). Tests use per-test impls + `toHaveBeenLastCalledWith` instead; commented in both test files.
- **No cities endpoint exists** (`resources :cities` routes to a Phase-0 stub with no controller), so the picker takes a city-slug input defaulting to `durango` — right for the launch market; a cities index can ride along later.
- Next typedRoutes needed the `as Route` cast for the dynamic push (#274 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)