### PR TITLE
feat(mobile): community scan flow — restaurant picker, dedup rows, verify routing

### DIFF
--- a/apps/mobile/__tests__/lib/create-restaurant.test.ts
+++ b/apps/mobile/__tests__/lib/create-restaurant.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Phase 6.6 — createRestaurant (mobile) + friendlyScanError mapping.
+ */
+import {
+  createRestaurant,
+  RestaurantCreateError,
+} from '../../lib/api/restaurants';
+import {
+  friendlyScanError,
+  IngestionUploadError,
+} from '../../lib/api/ingestion-runs';
+
+function fakeFetch(status: number, body: unknown) {
+  return jest.fn(async () =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Response,
+  );
+}
+
+describe('createRestaurant', () => {
+  it('POSTs with the JWT and returns created on 201', async () => {
+    const fetchImpl = fakeFetch(201, { id: 'r-1', slug: 'marias', name: "Maria's", status: 'draft' });
+
+    const result = await createRestaurant({
+      name: "Maria's",
+      citySlug: 'durango',
+      jwt: 'jwt-1',
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      kind: 'created',
+      restaurant: { id: 'r-1', slug: 'marias', name: "Maria's", status: 'draft' },
+    });
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toContain('/api/v1/restaurants');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jwt-1');
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      name: "Maria's",
+      city_slug: 'durango',
+    });
+  });
+
+  it('returns duplicates on 409 instead of throwing', async () => {
+    const candidates = [
+      { id: 'r-9', slug: 'marias', name: "Maria's Tacos", status: 'published', street: null },
+    ];
+    const fetchImpl = fakeFetch(409, { error: 'possible_duplicate', candidates });
+
+    const result = await createRestaurant({
+      name: 'Marias Taco',
+      citySlug: 'durango',
+      jwt: 'jwt-1',
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ kind: 'duplicates', candidates });
+  });
+
+  it('sends force "true" when overriding', async () => {
+    const fetchImpl = fakeFetch(201, { id: 'r-2', slug: 'x', name: 'X', status: 'draft' });
+
+    await createRestaurant({ name: 'X', citySlug: 'durango', force: true, jwt: 'jwt-1', fetchImpl });
+
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string).force).toBe('true');
+  });
+
+  it('throws RestaurantCreateError on other failures', async () => {
+    const fetchImpl = fakeFetch(404, { error: 'unknown_city' });
+
+    await expect(
+      createRestaurant({ name: 'X', citySlug: 'atlantis', jwt: 'jwt-1', fetchImpl }),
+    ).rejects.toBeInstanceOf(RestaurantCreateError);
+  });
+});
+
+describe('friendlyScanError', () => {
+  it('maps 429 with the limit from the body', () => {
+    const err = new IngestionUploadError(429, { error: 'quota_exceeded', limit: 5 });
+    expect(friendlyScanError(err)).toBe('Daily scan limit reached (5/day) — try again tomorrow.');
+  });
+
+  it('maps 503 budget exhaustion', () => {
+    const err = new IngestionUploadError(503, { error: 'cost_ceiling_reached' });
+    expect(friendlyScanError(err)).toMatch(/budget is used up/);
+  });
+
+  it('maps 403 foreign-draft', () => {
+    const err = new RestaurantCreateError(403, { error: 'forbidden_restaurant' });
+    expect(friendlyScanError(err)).toMatch(/someone else's draft/);
+  });
+
+  it('falls back to the raw message', () => {
+    expect(friendlyScanError(new Error('boom'))).toBe('boom');
+  });
+});

--- a/apps/mobile/__tests__/screens/ingest.render.test.tsx
+++ b/apps/mobile/__tests__/screens/ingest.render.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Phase 6.6 — community scan flow on mobile. Covers the
+ * RestaurantPicker step (create → dedup rows → pick/force) and the
+ * upload → swipe-verify navigation. Mocks follow the
+ * onboarding.render.test.tsx pattern (mock-prefixed vars + arrow
+ * indirection for the hoist).
+ */
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  router: {
+    push: (...args: unknown[]) => mockPush(...args),
+    replace: (...args: unknown[]) => mockReplace(...args),
+    back: jest.fn(),
+  },
+  useLocalSearchParams: () => ({}),
+  Link: 'Link',
+}));
+
+jest.mock('expo-camera', () => ({
+  CameraView: 'CameraView',
+  useCameraPermissions: () => [{ granted: true }, jest.fn()],
+}));
+
+jest.mock('../../lib/auth', () => ({
+  getJwt: jest.fn(() => Promise.resolve('jwt-1')),
+}));
+
+const mockCreateRestaurant = jest.fn();
+jest.mock('../../lib/api/restaurants', () => ({
+  ...jest.requireActual('../../lib/api/restaurants'),
+  createRestaurant: (...args: unknown[]) => mockCreateRestaurant(...args),
+}));
+
+const mockUpload = jest.fn();
+jest.mock('../../lib/api/ingestion-runs', () => ({
+  ...jest.requireActual('../../lib/api/ingestion-runs'),
+  uploadIngestionRun: (...args: unknown[]) => mockUpload(...args),
+}));
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import IngestScreen from '../../app/ingest/index';
+
+const flush = () => act(async () => {});
+
+describe('IngestScreen (Phase 6.6)', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockCreateRestaurant.mockClear();
+    mockUpload.mockClear();
+  });
+
+  it('asks "Which restaurant?" with the picker until one is chosen', async () => {
+    render(<IngestScreen />);
+    await flush();
+
+    expect(screen.getByText('Which restaurant?')).toBeTruthy();
+    expect(screen.getByLabelText('new-restaurant-name')).toBeTruthy();
+    expect(screen.getByLabelText('restaurant-id')).toBeTruthy(); // manual fallback
+  });
+
+  it('creating a restaurant flips the headline to "Scanning for …"', async () => {
+    mockCreateRestaurant.mockResolvedValue({
+      kind: 'created',
+      restaurant: { id: 'r-1', slug: 'marias', name: "Maria's Tacos", status: 'draft' },
+    });
+    render(<IngestScreen />);
+    await flush();
+
+    fireEvent.changeText(screen.getByLabelText('new-restaurant-name'), "Maria's Tacos");
+    fireEvent.press(screen.getByLabelText('create-restaurant'));
+
+    await waitFor(() => expect(screen.getByText("Scanning for Maria's Tacos")).toBeTruthy());
+  });
+
+  it('renders dedup rows and picking one selects the existing restaurant', async () => {
+    mockCreateRestaurant.mockResolvedValue({
+      kind: 'duplicates',
+      candidates: [
+        { id: 'r-9', slug: 'marias', name: "Maria's Tacos", status: 'published', street: '742 Main Ave' },
+      ],
+    });
+    render(<IngestScreen />);
+    await flush();
+
+    fireEvent.changeText(screen.getByLabelText('new-restaurant-name'), 'Marias Taco');
+    fireEvent.press(screen.getByLabelText('create-restaurant'));
+
+    await waitFor(() => expect(screen.getByText('Did you mean one of these?')).toBeTruthy());
+    fireEvent.press(screen.getByLabelText('use-candidate-marias'));
+
+    expect(screen.getByText("Scanning for Maria's Tacos")).toBeTruthy();
+  });
+
+  it('upload routes to swipe-verify with the run id', async () => {
+    mockCreateRestaurant.mockResolvedValue({
+      kind: 'created',
+      restaurant: { id: 'r-1', slug: 'marias', name: "Maria's Tacos", status: 'draft' },
+    });
+    mockUpload.mockResolvedValue({ id: 'run-77', status: 'extracting' });
+    render(<IngestScreen />);
+    await flush();
+
+    fireEvent.changeText(screen.getByLabelText('new-restaurant-name'), "Maria's Tacos");
+    fireEvent.press(screen.getByLabelText('create-restaurant'));
+    await waitFor(() => expect(screen.getByText("Scanning for Maria's Tacos")).toBeTruthy());
+
+    // Capture one page through the (mocked) camera.
+    fireEvent.press(screen.getByLabelText('open-camera'));
+    fireEvent.press(screen.getByLabelText('capture-page'));
+    fireEvent.press(screen.getByLabelText('upload-all'));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith('/ingest/verify?runId=run-77'),
+    );
+    expect(mockUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ restaurantId: 'r-1', jwt: 'jwt-1' }),
+    );
+  });
+});

--- a/apps/mobile/app/ingest/_RestaurantPicker.tsx
+++ b/apps/mobile/app/ingest/_RestaurantPicker.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import {
+  createRestaurant,
+  type DuplicateCandidate,
+} from '../../lib/api/restaurants';
+import { friendlyScanError } from '../../lib/api/ingestion-runs';
+
+/**
+ * Phase 6.6 — the "which restaurant?" step of the mobile scan flow
+ * (twin of web's _NewRestaurantPicker). Creates a draft restaurant
+ * with the Phase 6.2 dedup guard rendered as "did you mean…?" rows.
+ *
+ * City slug is a free input defaulting to the launch market — there
+ * is no cities index endpoint yet (Phase-0 stub route).
+ */
+export function RestaurantPicker({
+  jwt,
+  onPicked,
+}: {
+  jwt: string;
+  onPicked: (restaurant: { id: string; name: string }) => void;
+}) {
+  const [name, setName] = useState('');
+  const [citySlug, setCitySlug] = useState('durango');
+  const [street, setStreet] = useState('');
+  const [candidates, setCandidates] = useState<DuplicateCandidate[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (force: boolean) => {
+    setError(null);
+    if (!name.trim()) {
+      setError('Restaurant name is required.');
+      return;
+    }
+    try {
+      setSubmitting(true);
+      const result = await createRestaurant({
+        name: name.trim(),
+        citySlug: citySlug.trim(),
+        street: street.trim() || undefined,
+        force,
+        jwt,
+      });
+      if (result.kind === 'duplicates') {
+        setCandidates(result.candidates);
+        return;
+      }
+      setCandidates(null);
+      onPicked({ id: result.restaurant.id, name: result.restaurant.name });
+    } catch (e) {
+      setError(friendlyScanError(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View style={styles.wrap}>
+      <TextInput
+        accessibilityLabel="new-restaurant-name"
+        placeholder="Restaurant name (e.g. Maria's Tacos)"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <View style={styles.row}>
+        <TextInput
+          accessibilityLabel="new-restaurant-city"
+          placeholder="City slug"
+          value={citySlug}
+          onChangeText={setCitySlug}
+          autoCapitalize="none"
+          style={[styles.input, styles.rowItem]}
+        />
+        <TextInput
+          accessibilityLabel="new-restaurant-street"
+          placeholder="Street (optional)"
+          value={street}
+          onChangeText={setStreet}
+          style={[styles.input, styles.rowItem]}
+        />
+      </View>
+      <Pressable
+        accessibilityLabel="create-restaurant"
+        onPress={() => void submit(false)}
+        disabled={submitting}
+        style={[styles.button, submitting && styles.disabled]}
+      >
+        <Text style={styles.buttonText}>{submitting ? 'Checking…' : 'Create restaurant'}</Text>
+      </Pressable>
+
+      {error && (
+        <Text accessibilityRole="alert" style={styles.error}>
+          {error}
+        </Text>
+      )}
+
+      {candidates && candidates.length > 0 && (
+        <View style={styles.candidates} accessibilityLabel="possible-duplicates">
+          <Text style={styles.candidatesTitle}>Did you mean one of these?</Text>
+          {candidates.map((c) => (
+            <Pressable
+              key={c.id}
+              accessibilityLabel={`use-candidate-${c.slug}`}
+              onPress={() => onPicked({ id: c.id, name: c.name })}
+              style={styles.candidateRow}
+            >
+              <View style={{ flex: 1 }}>
+                <Text style={styles.candidateName}>{c.name}</Text>
+                <Text style={styles.candidateMeta}>
+                  {c.street ?? 'No address on file'} · {c.status}
+                </Text>
+              </View>
+              <Text style={styles.candidateUse}>Use this</Text>
+            </Pressable>
+          ))}
+          <Pressable
+            accessibilityLabel="create-anyway"
+            onPress={() => void submit(true)}
+            disabled={submitting}
+          >
+            <Text style={styles.createAnyway}>None of these — create “{name}” anyway</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { gap: space['3'] },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: space['3'],
+    fontSize: fontSize.base,
+    color: colors.text,
+  },
+  row: { flexDirection: 'row', gap: space['3'] },
+  rowItem: { flex: 1 },
+  button: {
+    backgroundColor: colors.bite,
+    paddingVertical: space['3'],
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  buttonText: { color: colors.bg, fontWeight: '700', fontSize: fontSize.base },
+  disabled: { opacity: 0.5 },
+  error: { color: '#c0392b', fontSize: fontSize.sm },
+  candidates: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 12,
+    padding: space['3'],
+    gap: space['3'],
+    backgroundColor: colors.bgAlt,
+  },
+  candidatesTitle: { fontWeight: '700', color: colors.text, fontSize: fontSize.base },
+  candidateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space['3'],
+    paddingVertical: space['2'],
+  },
+  candidateName: { fontWeight: '600', color: colors.text },
+  candidateMeta: { color: colors.textMuted, fontSize: fontSize.sm },
+  candidateUse: { color: colors.bite, fontWeight: '700' },
+  createAnyway: {
+    color: colors.text,
+    textDecorationLine: 'underline',
+    fontSize: fontSize.sm,
+  },
+});

--- a/apps/mobile/app/ingest/index.tsx
+++ b/apps/mobile/app/ingest/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Alert,
   FlatList,
@@ -13,30 +13,39 @@ import { router } from 'expo-router';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
+  friendlyScanError,
   uploadIngestionRun,
+  IngestionUploadError,
   type CapturedPage,
 } from '../../lib/api/ingestion-runs';
 import { getJwt } from '../../lib/auth';
+import { RestaurantPicker } from './_RestaurantPicker';
 
 /**
  * Phase 2.6 — multi-page menu capture.
- *
- * Flow:
- *  1. Admin types a restaurant_id into the input (Phase 2.6 ships
- *     this as a bare UUID input; the picker UX comes when restaurants
- *     have a search endpoint, scheduled for Phase 3).
- *  2. Tap "scan menu" → camera opens.
- *  3. Take a photo → it's added to `pages[]` as a thumbnail.
- *  4. Repeat for each page; tap a thumbnail to retake.
- *  5. "Upload all" POSTs to /api/v1/ingestion_runs.
- *  6. Navigation to a polling/swipe-verify screen lands in 2.7.
+ * Phase 6.6 — community scan flow: pick or create the restaurant
+ * (Phase 6.2 dedup as "did you mean…?" rows), capture pages, upload,
+ * then land on the swipe-verify screen (Phase 2.7) for your own run
+ * (Phase 6.3 self-verify). Guardrail errors (Phase 6.1) render as
+ * human copy via friendlyScanError.
  */
 export default function IngestScreen() {
-  const [restaurantId, setRestaurantId] = useState('');
+  const [restaurant, setRestaurant] = useState<{ id: string; name: string } | null>(null);
+  const [manualId, setManualId] = useState('');
+  const [jwt, setJwt] = useState<string | null>(null);
   const [pages, setPages] = useState<CapturedPage[]>([]);
   const [cameraOpen, setCameraOpen] = useState(false);
   const [permission, requestPermission] = useCameraPermissions();
   const [uploading, setUploading] = useState(false);
+
+  const restaurantId = restaurant?.id ?? manualId;
+
+  useEffect(() => {
+    void getJwt().then((token) => {
+      if (token) setJwt(token);
+      else router.replace('/login?next=%2Fingest');
+    });
+  }, []);
 
   const onCapture = (uri: string) => {
     setPages((prev) => [...prev, { uri, mimeType: 'image/jpeg' }]);
@@ -49,10 +58,9 @@ export default function IngestScreen() {
 
   const onUpload = async () => {
     if (!restaurantId || pages.length === 0) {
-      Alert.alert('Missing info', 'Restaurant id and at least one page are required.');
+      Alert.alert('Missing info', 'Pick a restaurant and capture at least one page.');
       return;
     }
-    const jwt = await getJwt();
     if (!jwt) {
       router.replace('/login?next=%2Fingest');
       return;
@@ -60,15 +68,15 @@ export default function IngestScreen() {
     try {
       setUploading(true);
       const run = await uploadIngestionRun({ restaurantId, pages, jwt });
-      Alert.alert('Uploaded', `Run ${run.id.slice(0, 8)}… is now ${run.status}.`);
       setPages([]);
+      // Phase 6.6 — straight into swipe-verify for your own run.
+      router.push(`/ingest/verify?runId=${run.id}`);
     } catch (e) {
-      const message = (e as Error).message;
-      if (message.includes('401')) {
+      if (e instanceof IngestionUploadError && e.status === 401) {
         router.replace('/login?next=%2Fingest');
         return;
       }
-      Alert.alert('Upload failed', message);
+      Alert.alert('Upload failed', friendlyScanError(e));
     } finally {
       setUploading(false);
     }
@@ -109,17 +117,28 @@ export default function IngestScreen() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.eyebrow}>Ingest a menu</Text>
-      <Text style={styles.headline}>Multi-page camera capture</Text>
+      <Text style={styles.eyebrow}>Scan a menu</Text>
+      <Text style={styles.headline}>
+        {restaurant ? `Scanning for ${restaurant.name}` : 'Which restaurant?'}
+      </Text>
 
-      <TextInput
-        accessibilityLabel="restaurant-id"
-        placeholder="Restaurant UUID"
-        value={restaurantId}
-        onChangeText={setRestaurantId}
-        autoCapitalize="none"
-        style={styles.input}
-      />
+      {restaurant ? (
+        <Pressable accessibilityLabel="change-restaurant" onPress={() => setRestaurant(null)}>
+          <Text style={styles.changeLink}>Change restaurant</Text>
+        </Pressable>
+      ) : (
+        <>
+          {jwt && <RestaurantPicker jwt={jwt} onPicked={setRestaurant} />}
+          <TextInput
+            accessibilityLabel="restaurant-id"
+            placeholder="…or paste a restaurant UUID"
+            value={manualId}
+            onChangeText={setManualId}
+            autoCapitalize="none"
+            style={styles.input}
+          />
+        </>
+      )}
 
       <FlatList
         data={pages}
@@ -200,6 +219,12 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: fontSize.base,
     paddingVertical: space['4'],
+  },
+  changeLink: {
+    color: colors.bite,
+    fontWeight: '600',
+    textDecorationLine: 'underline',
+    fontSize: fontSize.sm,
   },
   primaryButton: {
     backgroundColor: colors.bite,

--- a/apps/mobile/lib/api/ingestion-runs.ts
+++ b/apps/mobile/lib/api/ingestion-runs.ts
@@ -204,3 +204,25 @@ export async function uploadIngestionRun(opts: UploadOptions): Promise<Ingestion
 
   return (await res.json()) as IngestionRunPayload;
 }
+
+/**
+ * Phase 6.6 — human copy for the Phase 6.1 guardrails. Works for any
+ * error carrying {status, body} (IngestionUploadError and
+ * RestaurantCreateError both do).
+ */
+export function friendlyScanError(err: unknown): string {
+  const e = err as { status?: number; body?: { error?: string; limit?: number } | null };
+  if (typeof e?.status === 'number') {
+    if (e.status === 429) {
+      const limit = e.body?.limit;
+      return `Daily scan limit reached${limit ? ` (${limit}/day)` : ''} — try again tomorrow.`;
+    }
+    if (e.status === 503) {
+      return "Today's community scanning budget is used up — try again tomorrow.";
+    }
+    if (e.status === 403 && e.body?.error === 'forbidden_restaurant') {
+      return "That restaurant is someone else's draft — pick a published restaurant or create your own.";
+    }
+  }
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -157,3 +157,79 @@ export async function clearNeverHide(
   if (!res.ok) throw new RestaurantFetchError(res.status, `clearNeverHide ${itemId} failed: ${res.status}`);
   return (await res.json()) as { item_id: string; overridden_by_user: boolean };
 }
+
+/**
+ * Phase 6.6 — community restaurant creation (mobile twin of the web
+ * flow). 409 possible_duplicate is a flow state, not an error: the
+ * caller renders the candidates as "did you mean…?" rows.
+ */
+
+export interface DuplicateCandidate {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  street: string | null;
+}
+
+export interface CreatedRestaurant {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+}
+
+export type CreateRestaurantResult =
+  | { kind: 'created'; restaurant: CreatedRestaurant }
+  | { kind: 'duplicates'; candidates: DuplicateCandidate[] };
+
+export class RestaurantCreateError extends Error {
+  status: number;
+  body: unknown;
+  constructor(status: number, body: unknown) {
+    super(`Restaurant create failed: ${status}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export async function createRestaurant(opts: {
+  name: string;
+  citySlug: string;
+  street?: string;
+  postalCode?: string;
+  force?: boolean;
+  jwt: string;
+  fetchImpl?: typeof fetch;
+}): Promise<CreateRestaurantResult> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/restaurants`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${opts.jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: opts.name,
+      city_slug: opts.citySlug,
+      street: opts.street,
+      postal_code: opts.postalCode,
+      force: opts.force ? 'true' : undefined,
+    }),
+  });
+
+  if (res.status === 409) {
+    const body = (await res.json()) as { candidates: DuplicateCandidate[] };
+    return { kind: 'duplicates', candidates: body.candidates ?? [] };
+  }
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new RestaurantCreateError(res.status, body);
+  }
+  return { kind: 'created', restaurant: (await res.json()) as CreatedRestaurant };
+}


### PR DESCRIPTION
## Why

Phase 6.6 (`docs/plans/phase-6.md`) — the mobile twin of #304, completing Phase 6. With this, the full community loop (create restaurant → scan → verify → live) works on both surfaces.

## What

- **`_RestaurantPicker`** (new component, expo-router private-file convention): name/city/street form → `createRestaurant` → "Did you mean one of these?" rows with use-this / create-anyway (force), mirroring web's picker. City slug free-input defaulting to `durango` (no cities endpoint — same note as #304).
- **`lib/api/restaurants.ts`**: `createRestaurant` with the 409-as-flow-state union (`created` | `duplicates`); `RestaurantCreateError` for real failures.
- **`lib/api/ingestion-runs.ts`**: `friendlyScanError` — 429 quota (with limit), 503 daily budget, 403 foreign-draft → human copy; works for both error classes.
- **`/ingest` screen rework**: headline asks "Which restaurant?" until picked, then "Scanning for <name>" with a change link; manual UUID input kept as fallback; JWT loaded on mount (redirects to login when absent); **upload success now routes straight into the Phase 2.7 swipe-verify screen** (`/ingest/verify?runId=…`) instead of dead-ending in an Alert — Phase 6.3 made self-verify legal for the run's creator.

## Test plan

- [x] `pnpm --filter @biteworthy/mobile test` — 94/94 (+12: createRestaurant 201/409/force/error, friendlyScanError 4 mappings, screen picker render, created→headline flip, dedup-row pick, capture→upload→verify navigation with restaurantId+jwt asserted)
- [x] `pnpm typecheck` 10/10, `pnpm lint` 6/6

## Notes

- Status-log entry intentionally deferred one PR: #304 is still in CI and both would insert at the same status.md line — the squash would conflict. Next docs commit carries both ticks.
- The camera capture itself is still the Phase 2.6 skeleton (mock URI) — wiring the real ref is **Phase 7.1**, next in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)