### PR TITLE
feat(mobile): wire real camera capture via CameraView ref

### DIFF
--- a/apps/mobile/__tests__/screens/ingest.render.test.tsx
+++ b/apps/mobile/__tests__/screens/ingest.render.test.tsx
@@ -17,10 +17,27 @@ jest.mock('expo-router', () => ({
   Link: 'Link',
 }));
 
-jest.mock('expo-camera', () => ({
-  CameraView: 'CameraView',
-  useCameraPermissions: () => [{ granted: true }, jest.fn()],
-}));
+// Phase 7.1 — the screen captures through the CameraView ref, so the
+// mock exposes takePictureAsync via useImperativeHandle. Permission
+// state is mutable per test.
+const mockTakePicture = jest.fn();
+const mockRequestPermission = jest.fn();
+let mockPermission: { granted: boolean; canAskAgain: boolean } | null = {
+  granted: true,
+  canAskAgain: true,
+};
+jest.mock('expo-camera', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    CameraView: React.forwardRef((_props: unknown, ref: React.Ref<unknown>) => {
+      React.useImperativeHandle(ref, () => ({
+        takePictureAsync: (...args: unknown[]) => mockTakePicture(...args),
+      }));
+      return null;
+    }),
+    useCameraPermissions: () => [mockPermission, mockRequestPermission],
+  };
+});
 
 jest.mock('../../lib/auth', () => ({
   getJwt: jest.fn(() => Promise.resolve('jwt-1')),
@@ -49,6 +66,10 @@ describe('IngestScreen (Phase 6.6)', () => {
     mockReplace.mockClear();
     mockCreateRestaurant.mockClear();
     mockUpload.mockClear();
+    mockTakePicture.mockClear();
+    mockRequestPermission.mockClear();
+    mockPermission = { granted: true, canAskAgain: true };
+    mockTakePicture.mockResolvedValue({ uri: 'file:///captured/page-1.jpg' });
   });
 
   it('asks "Which restaurant?" with the picker until one is chosen', async () => {
@@ -106,16 +127,58 @@ describe('IngestScreen (Phase 6.6)', () => {
     fireEvent.press(screen.getByLabelText('create-restaurant'));
     await waitFor(() => expect(screen.getByText("Scanning for Maria's Tacos")).toBeTruthy());
 
-    // Capture one page through the (mocked) camera.
+    // Capture one page through the (mocked) camera ref.
     fireEvent.press(screen.getByLabelText('open-camera'));
     fireEvent.press(screen.getByLabelText('capture-page'));
+    await waitFor(() => expect(mockTakePicture).toHaveBeenCalled());
     fireEvent.press(screen.getByLabelText('upload-all'));
 
     await waitFor(() =>
       expect(mockPush).toHaveBeenCalledWith('/ingest/verify?runId=run-77'),
     );
     expect(mockUpload).toHaveBeenCalledWith(
-      expect.objectContaining({ restaurantId: 'r-1', jwt: 'jwt-1' }),
+      expect.objectContaining({
+        restaurantId: 'r-1',
+        jwt: 'jwt-1',
+        pages: [expect.objectContaining({ uri: 'file:///captured/page-1.jpg' })],
+      }),
     );
+  });
+
+  describe('camera permissions (Phase 7.1)', () => {
+    it('soft denial shows the grant button wired to requestPermission', async () => {
+      mockPermission = { granted: false, canAskAgain: true };
+      render(<IngestScreen />);
+      await flush();
+
+      fireEvent.press(screen.getByLabelText('open-camera'));
+      fireEvent.press(screen.getByLabelText('grant-camera'));
+
+      expect(mockRequestPermission).toHaveBeenCalled();
+    });
+
+    it('hard denial (canAskAgain false) offers Open Settings instead', async () => {
+      mockPermission = { granted: false, canAskAgain: false };
+      render(<IngestScreen />);
+      await flush();
+
+      fireEvent.press(screen.getByLabelText('open-camera'));
+
+      expect(screen.getByLabelText('open-settings')).toBeTruthy();
+      expect(screen.queryByLabelText('grant-camera')).toBeNull();
+    });
+
+    it('a capture that returns no photo leaves the page strip empty', async () => {
+      mockTakePicture.mockResolvedValue(undefined);
+      render(<IngestScreen />);
+      await flush();
+
+      fireEvent.press(screen.getByLabelText('open-camera'));
+      fireEvent.press(screen.getByLabelText('capture-page'));
+      await waitFor(() => expect(mockTakePicture).toHaveBeenCalled());
+
+      // Still in camera view (capture didn't close it), no thumbnails added.
+      expect(screen.getByLabelText('capture-page')).toBeTruthy();
+    });
   });
 });

--- a/apps/mobile/app/ingest/index.tsx
+++ b/apps/mobile/app/ingest/index.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   FlatList,
   Image,
+  Linking,
   Pressable,
   StyleSheet,
   Text,
@@ -37,6 +38,9 @@ export default function IngestScreen() {
   const [cameraOpen, setCameraOpen] = useState(false);
   const [permission, requestPermission] = useCameraPermissions();
   const [uploading, setUploading] = useState(false);
+  // Phase 7.1 — the real capture goes through this ref.
+  const cameraRef = useRef<CameraView>(null);
+  const [capturing, setCapturing] = useState(false);
 
   const restaurantId = restaurant?.id ?? manualId;
 
@@ -47,9 +51,24 @@ export default function IngestScreen() {
     });
   }, []);
 
-  const onCapture = (uri: string) => {
-    setPages((prev) => [...prev, { uri, mimeType: 'image/jpeg' }]);
-    setCameraOpen(false);
+  // Phase 7.1 — real capture via the CameraView ref (was a mock URI
+  // in the Phase 2.6 skeleton). quality 0.7 keeps a typical menu page
+  // well under the 10 MB per-file cap while staying readable for the
+  // vision model.
+  const onCapturePress = async () => {
+    if (capturing) return;
+    try {
+      setCapturing(true);
+      const photo = await cameraRef.current?.takePictureAsync({ quality: 0.7 });
+      if (photo?.uri) {
+        setPages((prev) => [...prev, { uri: photo.uri, mimeType: 'image/jpeg' }]);
+        setCameraOpen(false);
+      }
+    } catch (e) {
+      Alert.alert('Capture failed', (e as Error).message);
+    } finally {
+      setCapturing(false);
+    }
   };
 
   const onDelete = (i: number) => {
@@ -85,31 +104,43 @@ export default function IngestScreen() {
   if (cameraOpen) {
     if (!permission) return <View testID="camera-permission-loading" />;
     if (!permission.granted) {
+      // Phase 7.1 — when the OS won't re-prompt (canAskAgain false),
+      // the only path is the system settings screen.
+      const hardDenied = !permission.canAskAgain;
       return (
         <View style={styles.container}>
           <Text style={styles.headline}>Camera permission needed</Text>
-          <Pressable onPress={requestPermission} style={styles.primaryButton}>
-            <Text style={styles.primaryButtonText}>Grant access</Text>
+          <Text style={styles.permissionBody}>
+            BiteWorthy uses the camera only to photograph menu pages you choose to
+            scan. Photos upload to extract dishes — nothing records in the background.
+          </Text>
+          <Pressable
+            accessibilityLabel={hardDenied ? 'open-settings' : 'grant-camera'}
+            onPress={hardDenied ? () => void Linking.openSettings() : requestPermission}
+            style={styles.primaryButton}
+          >
+            <Text style={styles.primaryButtonText}>
+              {hardDenied ? 'Open Settings' : 'Grant access'}
+            </Text>
+          </Pressable>
+          <Pressable accessibilityLabel="camera-back" onPress={() => setCameraOpen(false)}>
+            <Text style={styles.changeLink}>Back</Text>
           </Pressable>
         </View>
       );
     }
     return (
       <View style={{ flex: 1 }}>
-        <CameraView
-          style={{ flex: 1 }}
-          facing="back"
-          onCameraReady={() => {}}
-          // The actual capture is wired in via a ref in production —
-          // this skeleton shows the structure; fine-grained capture
-          // gestures land alongside the real on-device testing pass.
-        />
+        <CameraView ref={cameraRef} style={{ flex: 1 }} facing="back" />
         <Pressable
           accessibilityLabel="capture-page"
-          style={styles.captureButton}
-          onPress={() => onCapture(`file:///mock/page-${pages.length + 1}.jpg`)}
+          style={[styles.captureButton, capturing && styles.disabled]}
+          disabled={capturing}
+          onPress={() => void onCapturePress()}
         >
-          <Text style={styles.captureButtonText}>📸 Capture page</Text>
+          <Text style={styles.captureButtonText}>
+            {capturing ? '⏳ Capturing…' : '📸 Capture page'}
+          </Text>
         </Pressable>
       </View>
     );
@@ -225,6 +256,11 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     textDecorationLine: 'underline',
     fontSize: fontSize.sm,
+  },
+  permissionBody: {
+    color: colors.textMuted,
+    fontSize: fontSize.base,
+    lineHeight: 22,
   },
   primaryButton: {
     backgroundColor: colors.bite,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,10 +22,8 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 6.6 — mobile community scan entrypoint** (`docs/plans/phase-6.md`)
-2. **Phase 7.1 — wire the real camera capture (expo-camera)** (`docs/plans/phase-7.md`)
-3. **Phase 7.2 — real mobile home screen (search + near-me + scan CTA)**
-4. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
+1. **Phase 7.2 — real mobile home screen (search + near-me + scan CTA)** (`docs/plans/phase-7.md`)
+2. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
 5. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
 6. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)**
 7. **Phase 8.3 — Top Picks UI (web)**
@@ -104,7 +102,9 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 6.3 — self-verify + suggested-confidence trust model (#301)
 - ✅ Phase 6.4 — community-publish moderation visibility (#302)
 - ✅ Phase 6.4.1 — moderation gaps: rescan scope, mixed-ai items, run filter (#303)
-- ✅ Phase 6.5 — web community scan entrypoint (this PR)
+- ✅ Phase 6.5 — web community scan entrypoint (#304)
+- ✅ Phase 6.6 — mobile community scan entrypoint (#305) — **Phase 6 feature-complete: anyone-can-scan on both surfaces**
+- ✅ Phase 7.1 — real expo-camera capture via ref (this PR)
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 
@@ -258,6 +258,23 @@ The loop appends here when work surfaces a new task that doesn't
 belong in the current phase. Humans triage these into the appropriate
 phase or "Next up" queue.
 
+- **Onboarding-chip flake recurred (3rd occurrence)** — the test
+  fixed in #199 ("renders a chip per preset once the fetch
+  resolves") timed out again on #304's CI runner (suite took 16.5s;
+  5s per-test cap). The findByLabelText fix helped locally but slow
+  CI runners still trip it. Candidate fixes: bump that test's
+  timeout to 15s, or jest.setTimeout for the file. One-line change;
+  promote on next paused tick or fold into the next mobile PR.
+- **Phase 6.5/6.6 codex P2 followups (web+mobile verify UX)** — from
+  #304's review, all reasonable, none blocking: (1) logged-out users
+  hit the create step before any 401 redirect — picker should
+  redirect like upload does; (2) no edit-before-accept path in the
+  web verify list (API supports `edited`; mobile verify has it);
+  (3) "did you mean" cards offer other users' DRAFTS as reusable
+  targets, which then 403 at scan time — filter candidates to
+  published-or-own; (4) web verify polling stops permanently on one
+  transient fetch failure — retry with backoff. Also applies partly
+  to mobile picker (3). Bundle as Phase 7.0 cleanup PR.
 - **Ingestion + restaurant endpoints lack rswag specs** (noted while
   shipping 6.1/6.2). `POST /ingestion_runs`, `PATCH .../items/:id`,
   `POST /restaurants` aren't in `docs/openapi.json`, so api-types

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,29 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 12:10 — tick #139. **Phase 7.1 shipped — real camera
+capture.** Also logging tick #138 retroactively (its status entry
+was deferred to dodge a same-line squash conflict with #304):
+- Tick #138 / PR #305: **Phase 6.6 mobile community scan flow** —
+  RestaurantPicker ahead of capture (create + did-you-mean rows +
+  force), manual UUID fallback, upload routes into swipe-verify,
+  friendlyScanError copy. mobile jest 94/94 (+12). **PHASE 6
+  COMPLETE — anyone-can-scan works end to end on web + mobile.**
+- Tick #139 / this PR: **Phase 7.1** — the Phase 2.6 mock-URI
+  capture is now real: CameraView ref + takePictureAsync
+  (quality 0.7 keeps pages under the 10 MB cap), capturing busy
+  state, permission rationale copy, and hard-denial
+  (canAskAgain: false) deep-links to system settings via
+  Linking.openSettings. Camera mock upgraded to a forwardRef
+  exposing takePictureAsync. mobile jest 97/97 (+3); typecheck +
+  lint green. Caveat (honest): verified in jest with the camera
+  module mocked — real-device capture still needs a human phone
+  test, noted in the PR.
+- #304 (6.5) merged after a re-run: its CI failure was the KNOWN
+  onboarding flake ("renders a chip per preset", 5s timeout, third
+  occurrence incl. pre-fix) — recurrence noted in Discovered.
+Next: Phase 7.2 real mobile home screen.
+
 2026-06-12 11:40 — tick #137. **Phase 6.5 shipped — web community
 scan entrypoint.** #303 (6.4.1) merged. This PR (web):
 - 4 new Next proxies: POST /api/restaurants, GET run, GET run items,


### PR DESCRIPTION
## Why

Phase 7.1 (`docs/plans/phase-7.md`) — the capture flow has been a skeleton since Phase 2.6: the capture button fabricated a `file:///mock/…` URI. This makes the phone camera real.

## What

- `CameraView` now takes a ref; capture calls `takePictureAsync({ quality: 0.7 })` (keeps a typical menu page well under the 10 MB per-file cap while staying readable for the vision model) with a capturing busy state on the button.
- Permission UX: rationale copy explaining the camera is only for menu pages; soft denial → `requestPermission`; hard denial (`canAskAgain: false`) → **Open Settings** via `Linking.openSettings()`; back link out of the camera.
- Upload path untouched.
- Test camera mock upgraded from a string component to a `forwardRef` exposing `takePictureAsync` via `useImperativeHandle`; upload test now asserts the captured URI flows through to the multipart pages.

## Test plan

- [x] `pnpm --filter @biteworthy/mobile test` — 97/97 (+3: soft-denial grant wiring, hard-denial settings path, no-photo capture leaves the strip empty)
- [x] `pnpm typecheck` 10/10, `pnpm lint` 6/6

## Notes

Honest scope: verified in jest with the camera module mocked — the subplan itself notes CI can only cover the component contract. **Real-device capture needs a human phone test** before this is trusted in the field; the simulator pass is on the launch-readiness list anyway.

Also in this PR (docs): status ticks #138–#139, roadmap 6.6 + 7.1 ticked, the recurring onboarding-flake noted in Discovered (3rd occurrence — one-line timeout fix queued), and the four codex UX followups from #304 logged as a bundled cleanup item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)