### PR TITLE
feat(mobile): real home screen — restaurant search + scan CTA (Phase 7.2)

### DIFF
--- a/apps/api/app/controllers/api/v1/restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/restaurants_controller.rb
@@ -16,8 +16,27 @@ module Api
     # answers "did you mean…?" with 409 + candidates before creating a
     # near-duplicate in the same city. `force: true` (sent after the
     # client has shown the candidates) skips the guard.
+    # GET /api/v1/restaurants (Phase 7.2) — public list/search backing
+    # the mobile home screen. `?q=` is a case-insensitive substring
+    # match on name. The route existed since Phase 0 but the action
+    # never did — hitting it 500'd. Capped at 25 rows, name-ordered.
     class RestaurantsController < BaseController
-      skip_before_action :authenticate_user!, only: [:show]
+      skip_before_action :authenticate_user!, only: [:show, :index]
+
+      INDEX_LIMIT = 25
+
+      def index
+        scope = Restaurant.published.includes(:city, :addresses)
+        q = params[:q].to_s.strip
+        if q.present?
+          scope = scope.where(
+            "restaurants.name ILIKE ?",
+            "%#{Restaurant.sanitize_sql_like(q)}%"
+          )
+        end
+        restaurants = scope.order(:name).limit(INDEX_LIMIT)
+        render json: { restaurants: restaurants.map { |r| serialize_summary(r) } }
+      end
 
       # Calibrated against pg_trgm similarity() on realistic pairs:
       # true duplicates ("Maria's Tacos"/"Marias Taco" 0.53,
@@ -70,6 +89,23 @@ module Api
       end
 
       private
+
+      # Lighter than #serialize — list rows don't need claim fields,
+      # but the home screen wants an address line + coords (the
+      # near-me sort lands with expo-location in a followup).
+      def serialize_summary(r)
+        first_address = r.addresses.first
+        {
+          id:     r.id,
+          slug:   r.slug,
+          name:   r.name,
+          status: r.status,
+          city:   { slug: r.city.slug, name: r.city.name, region: r.city.region },
+          street:    first_address&.street,
+          latitude:  first_address&.latitude&.to_f,
+          longitude: first_address&.longitude&.to_f
+        }
+      end
 
       def duplicate_candidates(name, city)
         Restaurant

--- a/apps/api/spec/requests/api/v1/restaurants_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants_spec.rb
@@ -60,3 +60,54 @@ RSpec.describe "GET /api/v1/restaurants/:id", type: :request do
     end
   end
 end
+
+# Phase 7.2 — list/search backing the mobile home screen. The :index
+# route existed since Phase 0 but had no action (latent 500).
+RSpec.describe "Restaurants index API", type: :request do
+  let!(:city) { create(:city, slug: "durango") }
+
+  it "lists published restaurants with city + address summary, anonymous OK" do
+    r = create(:restaurant, :published, name: "Ninis Taqueria", city: city)
+    r.addresses.create!(street: "Main Ave 101", latitude: 37.27, longitude: -107.88)
+    create(:restaurant, status: "draft", name: "Hidden Draft", city: city)
+
+    get "/api/v1/restaurants"
+
+    expect(response).to have_http_status(:ok)
+    rows = response.parsed_body["restaurants"]
+    expect(rows.map { |x| x["name"] }).to eq(["Ninis Taqueria"])
+    expect(rows.first).to include(
+      "street" => "Main Ave 101", "latitude" => 37.27, "longitude" => -107.88
+    )
+    expect(rows.first["city"]).to include("slug" => "durango")
+  end
+
+  it "filters by ?q= case-insensitively on a substring" do
+    create(:restaurant, :published, name: "Thai Kitchen", city: city)
+    create(:restaurant, :published, name: "Himalayan Kitchen", city: city)
+    create(:restaurant, :published, name: "Ninis Taqueria", city: city)
+
+    get "/api/v1/restaurants", params: { q: "kitchen" }
+
+    names = response.parsed_body["restaurants"].map { |x| x["name"] }
+    expect(names).to contain_exactly("Thai Kitchen", "Himalayan Kitchen")
+  end
+
+  it "escapes LIKE wildcards in the query" do
+    create(:restaurant, :published, name: "100% Tacos", city: city)
+    create(:restaurant, :published, name: "Ninis Taqueria", city: city)
+
+    get "/api/v1/restaurants", params: { q: "100%" }
+
+    names = response.parsed_body["restaurants"].map { |x| x["name"] }
+    expect(names).to eq(["100% Tacos"])
+  end
+
+  it "caps the list at 25 rows" do
+    30.times { |i| create(:restaurant, :published, name: "Cafe #{i.to_s.rjust(2, '0')}", city: city) }
+
+    get "/api/v1/restaurants"
+
+    expect(response.parsed_body["restaurants"].length).to eq(25)
+  end
+end

--- a/apps/mobile/__tests__/lib/restaurants.test.ts
+++ b/apps/mobile/__tests__/lib/restaurants.test.ts
@@ -4,10 +4,12 @@ import {
   fetchRestaurantItems,
   groupItemsBySection,
   RestaurantFetchError,
+  searchRestaurants,
   setNeverHide,
   type Restaurant,
   type RestaurantItem,
   type RestaurantItemsResponse,
+  type RestaurantSummary,
 } from '../../lib/api/restaurants';
 
 type FetchCall = Parameters<typeof fetch>;
@@ -172,6 +174,38 @@ describe('groupItemsBySection', () => {
 
   it('returns an empty array for no items', () => {
     expect(groupItemsBySection([])).toEqual([]);
+  });
+});
+
+describe('searchRestaurants (Phase 7.2)', () => {
+  const summary: RestaurantSummary = {
+    id: 'rest-1',
+    slug: 'ninis-1',
+    name: 'Ninis Taqueria',
+    status: 'published',
+    city: { slug: 'durango', name: 'Durango', region: 'CO' },
+    street: '119 W College Dr',
+    latitude: 37.27,
+    longitude: -107.88,
+  };
+
+  it('GETs /api/v1/restaurants with no query when q is blank', async () => {
+    const fetchImpl = fakeFetch(200, { restaurants: [summary] });
+    const rows = await searchRestaurants(undefined, { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toMatch(/\/api\/v1\/restaurants$/);
+    expect(rows).toEqual([summary]);
+  });
+
+  it('URL-encodes ?q= (trimmed) when provided', async () => {
+    const fetchImpl = fakeFetch(200, { restaurants: [] });
+    await searchRestaurants('  home slice ', { fetchImpl });
+    expect(String(fetchImpl.mock.calls[0]![0])).toContain('?q=home%20slice');
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = fakeFetch(500, { error: 'boom' });
+    await expect(searchRestaurants('x', { fetchImpl })).rejects.toThrow('searchRestaurants failed: 500');
   });
 });
 

--- a/apps/mobile/__tests__/screens/home.render.test.tsx
+++ b/apps/mobile/__tests__/screens/home.render.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Phase 7.2 — the real home screen: search published restaurants,
+ * tap a row to open its menu, or jump into the scan flow. Mocks
+ * follow the ingest.render.test.tsx pattern (mock-prefixed vars +
+ * arrow indirection for the hoist).
+ */
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  router: {
+    push: (...args: unknown[]) => mockPush(...args),
+    replace: jest.fn(),
+    back: jest.fn(),
+  },
+  Link: 'Link',
+}));
+
+const mockSearch = jest.fn();
+jest.mock('../../lib/api/restaurants', () => ({
+  ...jest.requireActual('../../lib/api/restaurants'),
+  searchRestaurants: (...args: unknown[]) => mockSearch(...args),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import Home from '../../app/index';
+
+const ninis = {
+  id: 'rest-1',
+  slug: 'ninis-1',
+  name: 'Ninis Taqueria',
+  status: 'published',
+  city: { slug: 'durango', name: 'Durango', region: 'CO' },
+  street: '119 W College Dr',
+  latitude: 37.27,
+  longitude: -107.88,
+};
+
+describe('Home (Phase 7.2)', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockSearch.mockReset();
+  });
+
+  it('loads and lists restaurants on mount (no query)', async () => {
+    mockSearch.mockResolvedValue([ninis]);
+    render(<Home />);
+
+    await waitFor(() => expect(screen.getByText('Ninis Taqueria')).toBeTruthy());
+    expect(mockSearch).toHaveBeenCalledWith('');
+    expect(screen.getByText('119 W College Dr · Durango, CO')).toBeTruthy();
+  });
+
+  it('typing re-searches (debounced) and a miss suggests scanning', async () => {
+    mockSearch.mockResolvedValueOnce([ninis]).mockResolvedValueOnce([]);
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText('Ninis Taqueria')).toBeTruthy());
+
+    fireEvent.changeText(screen.getByLabelText('restaurant-search'), 'zanzibar');
+
+    await waitFor(() => expect(mockSearch).toHaveBeenLastCalledWith('zanzibar'));
+    await waitFor(() =>
+      expect(screen.getByText('No matches for “zanzibar”. Scan its menu to add it!')).toBeTruthy(),
+    );
+  });
+
+  it('tapping a row opens that restaurant menu', async () => {
+    mockSearch.mockResolvedValue([ninis]);
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText('Ninis Taqueria')).toBeTruthy());
+
+    fireEvent.press(screen.getByLabelText('restaurant-ninis-1'));
+    expect(mockPush).toHaveBeenCalledWith('/restaurants/rest-1');
+  });
+
+  it('scan CTA and profile link route to /ingest and /onboarding', async () => {
+    mockSearch.mockResolvedValue([]);
+    render(<Home />);
+    await waitFor(() => expect(screen.getByLabelText('scan-cta')).toBeTruthy());
+
+    fireEvent.press(screen.getByLabelText('scan-cta'));
+    expect(mockPush).toHaveBeenCalledWith('/ingest');
+
+    fireEvent.press(screen.getByLabelText('profile-link'));
+    expect(mockPush).toHaveBeenCalledWith('/onboarding');
+  });
+
+  it('shows a friendly error when the API is unreachable', async () => {
+    mockSearch.mockRejectedValue(new Error('network down'));
+    render(<Home />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn’t load restaurants/)).toBeTruthy(),
+    );
+  });
+});

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,14 +1,119 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { router } from 'expo-router';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import { searchRestaurants, type RestaurantSummary } from '../lib/api/restaurants';
+
+/**
+ * Phase 7.2 — the real home screen. Search published restaurants
+ * (server-side ILIKE via ?q=), tap a row to open its filtered menu,
+ * or jump straight into the scan flow when the place isn't listed
+ * yet. "Near me" sorting is deferred — it needs expo-location and a
+ * permissions pass; the API already returns lat/lng for it.
+ */
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 export default function Home() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<RestaurantSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+    const timer = setTimeout(
+      () => {
+        searchRestaurants(query)
+          .then((restaurants) => {
+            if (cancelled) return;
+            setResults(restaurants);
+            setLoading(false);
+          })
+          .catch(() => {
+            if (cancelled) return;
+            setError(true);
+            setLoading(false);
+          });
+      },
+      // No debounce for the initial unfiltered load — only for typing.
+      query ? SEARCH_DEBOUNCE_MS : 0,
+    );
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  const meta = (r: RestaurantSummary) => {
+    const place = `${r.city.name}, ${r.city.region}`;
+    return r.street ? `${r.street} · ${place}` : place;
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.eyebrow}>BiteWorthy</Text>
-      <Text style={styles.headline}>Scan any menu, see only what you can eat.</Text>
-      <Text style={styles.body}>
-        Pre-MVP. Camera capture and the dietary filter land in the next phases.
-      </Text>
+      <Text style={styles.headline}>Where are you eating?</Text>
+
+      <TextInput
+        accessibilityLabel="restaurant-search"
+        placeholder="Search restaurants…"
+        value={query}
+        onChangeText={setQuery}
+        autoCapitalize="none"
+        autoCorrect={false}
+        style={styles.input}
+      />
+
+      {loading ? (
+        <ActivityIndicator accessibilityLabel="search-loading" color={colors.bite} />
+      ) : error ? (
+        <Text style={styles.error}>Couldn’t load restaurants. Pull to retry or check your connection.</Text>
+      ) : (
+        <FlatList
+          data={results}
+          keyExtractor={(r) => r.id}
+          style={styles.list}
+          renderItem={({ item }) => (
+            <Pressable
+              accessibilityLabel={`restaurant-${item.slug}`}
+              onPress={() => router.push(`/restaurants/${item.id}`)}
+              style={styles.row}
+            >
+              <Text style={styles.rowName}>{item.name}</Text>
+              <Text style={styles.rowMeta}>{meta(item)}</Text>
+            </Pressable>
+          )}
+          ListEmptyComponent={
+            <Text style={styles.empty}>
+              {query
+                ? `No matches for “${query}”. Scan its menu to add it!`
+                : 'No restaurants yet — be the first to scan a menu.'}
+            </Text>
+          }
+        />
+      )}
+
+      <Pressable
+        accessibilityLabel="scan-cta"
+        onPress={() => router.push('/ingest')}
+        style={styles.primaryButton}
+      >
+        <Text style={styles.primaryButtonText}>📷 Scan a menu</Text>
+      </Pressable>
+      <Pressable accessibilityLabel="profile-link" onPress={() => router.push('/onboarding')}>
+        <Text style={styles.profileLink}>Dietary preferences</Text>
+      </Pressable>
     </View>
   );
 }
@@ -16,10 +121,11 @@ export default function Home() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    paddingTop: 60,
     paddingHorizontal: space['6'],
-    justifyContent: 'center',
+    paddingBottom: space['6'],
     backgroundColor: colors.bg,
-    gap: space['4'],
+    gap: space['3'],
   },
   eyebrow: {
     color: colors.bite,
@@ -29,13 +135,62 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   headline: {
-    fontSize: fontSize['3xl'],
+    fontSize: fontSize['2xl'],
     fontWeight: '700',
     color: colors.text,
-    lineHeight: 38,
   },
-  body: {
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 8,
+    padding: space['3'],
     fontSize: fontSize.base,
+    color: colors.text,
+  },
+  list: {
+    flex: 1,
+  },
+  row: {
+    paddingVertical: space['3'],
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  rowName: {
+    fontSize: fontSize.base,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  rowMeta: {
+    fontSize: fontSize.sm,
     color: colors.textMuted,
+    marginTop: 2,
+  },
+  empty: {
+    color: colors.textMuted,
+    fontSize: fontSize.base,
+    paddingVertical: space['4'],
+  },
+  error: {
+    color: colors.textMuted,
+    fontSize: fontSize.base,
+    paddingVertical: space['4'],
+  },
+  primaryButton: {
+    backgroundColor: colors.bite,
+    paddingVertical: space['4'],
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.base,
+  },
+  profileLink: {
+    color: colors.bite,
+    fontWeight: '600',
+    textDecorationLine: 'underline',
+    fontSize: fontSize.sm,
+    textAlign: 'center',
   },
 });

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -233,3 +233,30 @@ export async function createRestaurant(opts: {
   }
   return { kind: 'created', restaurant: (await res.json()) as CreatedRestaurant };
 }
+
+/**
+ * Phase 7.2 — list/search for the home screen. `q` is a
+ * case-insensitive substring match; server caps at 25 rows.
+ */
+export interface RestaurantSummary {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  city: { slug: string; name: string; region: string };
+  street: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+export async function searchRestaurants(
+  q?: string,
+  opts: FetchOptions = {},
+): Promise<RestaurantSummary[]> {
+  const { fetchImpl = fetch } = opts;
+  const query = q?.trim() ? `?q=${encodeURIComponent(q.trim())}` : '';
+  const res = await fetchImpl(`${API_BASE}/api/v1/restaurants${query}`);
+  if (!res.ok) throw new Error(`searchRestaurants failed: ${res.status}`);
+  const json = (await res.json()) as { restaurants: RestaurantSummary[] };
+  return json.restaurants;
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,7 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 7.2 — real mobile home screen (search + near-me + scan CTA)** (`docs/plans/phase-7.md`)
-2. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
+1. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
 5. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
 6. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)**
 7. **Phase 8.3 — Top Picks UI (web)**
@@ -104,7 +103,8 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 6.4.1 — moderation gaps: rescan scope, mixed-ai items, run filter (#303)
 - ✅ Phase 6.5 — web community scan entrypoint (#304)
 - ✅ Phase 6.6 — mobile community scan entrypoint (#305) — **Phase 6 feature-complete: anyone-can-scan on both surfaces**
-- ✅ Phase 7.1 — real expo-camera capture via ref (this PR)
+- ✅ Phase 7.1 — real expo-camera capture via ref (#306)
+- ✅ Phase 7.2 — real mobile home screen: search + scan CTA; near-me deferred pending expo-location (this PR)
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,20 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 19:05 — tick #140. **Phase 7.2 shipped — real mobile home
+screen.** The Phase-0 "Pre-MVP" placeholder is gone: debounced
+(300ms) restaurant search → tap into the filtered menu, scan CTA →
+/ingest, profile link → /onboarding; search-miss copy nudges toward
+scanning. API: implemented the GET /api/v1/restaurants index that
+was routed since Phase 0 but had no action (500'd) — published
+scope, ?q= ILIKE with sanitize_sql_like, 25-row cap, summary
+serializer incl. lat/lng for the deferred near-me sort
+(expo-location followup). +4 request specs (440 examples green),
++3 lib specs, +5 home.render specs (mobile jest 102/102); typecheck,
+lint, brakeman all green. #306 (7.1) auto-merged on green while this
+was in flight; branch rebased onto it. Next: Phase 7.3 stitch the
+scan-to-menu flow end-to-end.
+
 2026-06-12 12:10 — tick #139. **Phase 7.1 shipped — real camera
 capture.** Also logging tick #138 retroactively (its status entry
 was deferred to dodge a same-line squash conflict with #304):


### PR DESCRIPTION
## What

Phase 7.2 (`docs/plans/phase-7.md`): replaces the Phase-0 "Pre-MVP" mobile home placeholder with the real entry point.

**Mobile (`apps/mobile/app/index.tsx`)**
- Debounced (300ms) restaurant search → tap a row to open the filtered menu at `/restaurants/[id]`
- Scan CTA → `/ingest`; "Dietary preferences" link → `/onboarding`
- Search-miss empty state nudges toward scanning the menu ("No matches for X. Scan its menu to add it!")
- Near-me sorting deferred — needs expo-location + a permissions pass; the API already returns lat/lng for it

**API (`restaurants_controller.rb`)**
- Implements `GET /api/v1/restaurants` — the route existed since Phase 0 with **no controller action** (hitting it 500'd)
- Published scope, `?q=` case-insensitive substring search (`ILIKE` with `sanitize_sql_like` so `%`/`_` are literal), name-ordered, capped at 25 rows
- Summary serializer: id/slug/name/status/city + first-address street/lat/lng

**Lib (`apps/mobile/lib/api/restaurants.ts`)**
- `searchRestaurants(q?)` + `RestaurantSummary`

## Tests

- +4 request specs (published-only fields, `?q=` case-insensitive, LIKE wildcard escape via a "100%" restaurant, 25-row cap) — full API suite **440 examples, 0 failures**
- +3 lib specs (no-query URL, trim+encode, non-2xx throw)
- +5 screen specs in `home.render.test.tsx` (mount load, debounced re-search + miss copy, row navigation, CTA/profile routes, error state) — mobile jest **102/102**
- `pnpm typecheck` 10/10, `pnpm lint` 6/6, brakeman 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)