### PR TITLE
feat(mobile): stitch the scan-to-menu flow end-to-end (Phase 7.3)

### DIFF
--- a/apps/mobile/__tests__/screens/home.render.test.tsx
+++ b/apps/mobile/__tests__/screens/home.render.test.tsx
@@ -49,7 +49,7 @@ describe('Home (Phase 7.2)', () => {
     expect(screen.getByText('119 W College Dr · Durango, CO')).toBeTruthy();
   });
 
-  it('typing re-searches (debounced) and a miss suggests scanning', async () => {
+  it('typing re-searches (debounced) and a miss offers a scan CTA carrying the name', async () => {
     mockSearch.mockResolvedValueOnce([ninis]).mockResolvedValueOnce([]);
     render(<Home />);
     await waitFor(() => expect(screen.getByText('Ninis Taqueria')).toBeTruthy());
@@ -57,18 +57,20 @@ describe('Home (Phase 7.2)', () => {
     fireEvent.changeText(screen.getByLabelText('restaurant-search'), 'zanzibar');
 
     await waitFor(() => expect(mockSearch).toHaveBeenLastCalledWith('zanzibar'));
-    await waitFor(() =>
-      expect(screen.getByText('No matches for “zanzibar”. Scan its menu to add it!')).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByLabelText('scan-miss-cta')).toBeTruthy());
+
+    // Phase 7.3 — the miss CTA prefills the new-restaurant form.
+    fireEvent.press(screen.getByLabelText('scan-miss-cta'));
+    expect(mockPush).toHaveBeenCalledWith('/ingest?name=zanzibar');
   });
 
-  it('tapping a row opens that restaurant menu', async () => {
+  it('tapping a row opens that restaurant menu with from=search', async () => {
     mockSearch.mockResolvedValue([ninis]);
     render(<Home />);
     await waitFor(() => expect(screen.getByText('Ninis Taqueria')).toBeTruthy());
 
     fireEvent.press(screen.getByLabelText('restaurant-ninis-1'));
-    expect(mockPush).toHaveBeenCalledWith('/restaurants/rest-1');
+    expect(mockPush).toHaveBeenCalledWith('/restaurants/rest-1?from=search');
   });
 
   it('scan CTA and profile link route to /ingest and /onboarding', async () => {

--- a/apps/mobile/__tests__/screens/ingest.render.test.tsx
+++ b/apps/mobile/__tests__/screens/ingest.render.test.tsx
@@ -7,13 +7,16 @@
  */
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
+// Phase 7.3 — route params are mutable per test (search-miss prefill,
+// re-scan preselect).
+let mockParams: Record<string, string> = {};
 jest.mock('expo-router', () => ({
   router: {
     push: (...args: unknown[]) => mockPush(...args),
     replace: (...args: unknown[]) => mockReplace(...args),
     back: jest.fn(),
   },
-  useLocalSearchParams: () => ({}),
+  useLocalSearchParams: () => mockParams,
   Link: 'Link',
 }));
 
@@ -68,6 +71,7 @@ describe('IngestScreen (Phase 6.6)', () => {
     mockUpload.mockClear();
     mockTakePicture.mockClear();
     mockRequestPermission.mockClear();
+    mockParams = {};
     mockPermission = { granted: true, canAskAgain: true };
     mockTakePicture.mockResolvedValue({ uri: 'file:///captured/page-1.jpg' });
   });
@@ -143,6 +147,25 @@ describe('IngestScreen (Phase 6.6)', () => {
         pages: [expect.objectContaining({ uri: 'file:///captured/page-1.jpg' })],
       }),
     );
+  });
+
+  describe('stitched entry points (Phase 7.3)', () => {
+    it('?restaurantId + ?restaurantName preselect the restaurant (re-scan flow)', async () => {
+      mockParams = { restaurantId: 'r-5', restaurantName: 'Home Slice Pizza' };
+      render(<IngestScreen />);
+      await flush();
+
+      expect(screen.getByText('Scanning for Home Slice Pizza')).toBeTruthy();
+      expect(screen.queryByLabelText('new-restaurant-name')).toBeNull();
+    });
+
+    it('?name= prefills the new-restaurant form (home search-miss)', async () => {
+      mockParams = { name: 'Zanzibar Cafe' };
+      render(<IngestScreen />);
+      await flush();
+
+      expect(screen.getByLabelText('new-restaurant-name').props.value).toBe('Zanzibar Cafe');
+    });
   });
 
   describe('camera permissions (Phase 7.1)', () => {

--- a/apps/mobile/__tests__/screens/restaurant-screen.render.test.tsx
+++ b/apps/mobile/__tests__/screens/restaurant-screen.render.test.tsx
@@ -1,13 +1,37 @@
 // Mock expo-router so importing the screen module doesn't pull the
-// full Stack/Tabs runtime — we only need its named exports here.
+// full Stack/Tabs runtime. Params are mutable per test (the helper
+// tests don't need any; the Phase 7.3 full-screen tests do).
+const mockPush = jest.fn();
+let mockParams: Record<string, string> = {};
 jest.mock('expo-router', () => ({
-  router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
-  useLocalSearchParams: () => ({}),
+  router: {
+    push: (...args: unknown[]) => mockPush(...args),
+    replace: jest.fn(),
+    back: jest.fn(),
+  },
+  useLocalSearchParams: () => mockParams,
   Link: 'Link',
 }));
 
-import { render, screen } from '@testing-library/react-native';
-import { HiddenReasonChip, StrictnessToggle } from '../../app/restaurants/[id]';
+jest.mock('../../lib/auth', () => ({
+  getJwt: jest.fn(() => Promise.resolve(undefined)),
+}));
+
+const mockFetchRestaurant = jest.fn();
+const mockFetchItems = jest.fn();
+jest.mock('../../lib/api/restaurants', () => ({
+  ...jest.requireActual('../../lib/api/restaurants'),
+  fetchRestaurant: (...args: unknown[]) => mockFetchRestaurant(...args),
+  fetchRestaurantItems: (...args: unknown[]) => mockFetchItems(...args),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import RestaurantScreen, {
+  HiddenReasonChip,
+  StrictnessToggle,
+} from '../../app/restaurants/[id]';
+import { TrackerContext } from '../../lib/tracker-context';
+import type { Tracker } from '@biteworthy/analytics';
 
 /**
  * Phase post-5 — first JSX render tests for the mobile app.
@@ -84,5 +108,65 @@ describe('StrictnessToggle (mobile)', () => {
     const relaxed = screen.getByLabelText('strictness-relaxed');
     expect(relaxed.props.accessibilityState).toMatchObject({ selected: false, disabled: true });
     expect(screen.getByTestId('strictness-spinner')).toBeOnTheScreen();
+  });
+});
+
+describe('RestaurantScreen scan-loop wiring (Phase 7.3)', () => {
+  const restaurant = {
+    id: 'rest-1',
+    slug: 'ninis-1',
+    name: 'Ninis Taqueria',
+    about: null,
+    phone: null,
+    website: null,
+    status: 'published',
+    city: { id: 'city-1', slug: 'durango', name: 'Durango', region: 'CO' },
+  };
+  const itemsResponse = {
+    restaurant_id: 'rest-1',
+    filter: {
+      source: 'none',
+      preset_slug: null,
+      strictness: 'balanced',
+      avoid_ingredient_ids: [],
+      avoid_tag_ids: [],
+    },
+    items: [],
+  };
+
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockFetchRestaurant.mockReset();
+    mockFetchItems.mockReset();
+    mockFetchRestaurant.mockResolvedValue(restaurant);
+    mockFetchItems.mockResolvedValue(itemsResponse);
+    mockParams = { id: 'rest-1' };
+  });
+
+  it('"Menu changed? Re-scan" routes to /ingest preselecting this restaurant', async () => {
+    render(<RestaurantScreen />);
+    await waitFor(() => expect(screen.getByText('Ninis Taqueria')).toBeOnTheScreen());
+
+    fireEvent.press(screen.getByLabelText('rescan-menu'));
+    expect(mockPush).toHaveBeenCalledWith(
+      '/ingest?restaurantId=rest-1&restaurantName=Ninis%20Taqueria',
+    );
+  });
+
+  it('fires restaurant_tap with the from param carried by the navigation link', async () => {
+    mockParams = { id: 'rest-1', from: 'scan' };
+    const track = jest.fn();
+    const tracker: Tracker = { track, identify: jest.fn(), reset: jest.fn() };
+    render(
+      <TrackerContext.Provider value={tracker}>
+        <RestaurantScreen />
+      </TrackerContext.Provider>,
+    );
+    await waitFor(() => expect(screen.getByText('Ninis Taqueria')).toBeOnTheScreen());
+
+    expect(track).toHaveBeenCalledWith('restaurant_tap', {
+      restaurant_slug: 'rest-1',
+      from: 'scan',
+    });
   });
 });

--- a/apps/mobile/__tests__/screens/verify.render.test.tsx
+++ b/apps/mobile/__tests__/screens/verify.render.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Phase 7.3 — the verify screen is the last leg of the scan loop:
+ * pipeline progress (stage copy) → swipe deck → deep-link into the
+ * user's own filtered menu. Mocks follow the ingest.render.test.tsx
+ * pattern (mock-prefixed vars + arrow indirection for the hoist).
+ */
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  router: {
+    push: (...args: unknown[]) => mockPush(...args),
+    replace: (...args: unknown[]) => mockReplace(...args),
+    back: jest.fn(),
+  },
+  useLocalSearchParams: () => ({ runId: 'run-77' }),
+  Link: 'Link',
+}));
+
+jest.mock('../../lib/auth', () => ({
+  getJwt: jest.fn(() => Promise.resolve('jwt-1')),
+}));
+
+const mockGetRun = jest.fn();
+const mockListItems = jest.fn();
+const mockDecide = jest.fn();
+jest.mock('../../lib/api/ingestion-runs', () => ({
+  ...jest.requireActual('../../lib/api/ingestion-runs'),
+  getIngestionRun: (...args: unknown[]) => mockGetRun(...args),
+  listIngestionItems: (...args: unknown[]) => mockListItems(...args),
+  decideIngestionItem: (...args: unknown[]) => mockDecide(...args),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import VerifyScreen from '../../app/ingest/verify';
+
+const run = (status: string) => ({
+  id: 'run-77',
+  status,
+  input_kind: 'photo',
+  restaurant_id: 'rest-1',
+  state_history: {},
+  failure_message: null,
+  api_cost_cents: 0,
+  latency_ms: null,
+  input_count: 1,
+  ingestion_items_count: 1,
+  created_at: '2026-06-12T00:00:00Z',
+  updated_at: '2026-06-12T00:00:00Z',
+});
+
+const pendingItem = {
+  id: 'ii-1',
+  ingestion_run_id: 'run-77',
+  item_id: null,
+  name: 'Carnitas Taco',
+  description: 'Slow-braised pork',
+  section_name: 'Tacos',
+  decision: 'pending',
+  decided_at: null,
+  ingredients_payload: [{ slug: 'pork', confidence: 0.95 }],
+  tags_payload: [],
+  unresolved_ingredients: [],
+  unresolved_tags: [],
+};
+
+describe('VerifyScreen (Phase 7.3)', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockGetRun.mockReset();
+    mockListItems.mockReset();
+    mockDecide.mockReset();
+  });
+
+  it('maps pipeline stages to human progress copy', async () => {
+    mockGetRun.mockResolvedValue(run('extracting'));
+    render(<VerifyScreen />);
+
+    await waitFor(() => expect(screen.getByText('Reading the menu…')).toBeTruthy());
+  });
+
+  it('finishing the deck on an auto-published run celebrates and deep-links to the menu', async () => {
+    // Poll sees staged; the deck-done refetch sees the 80% auto-publish.
+    mockGetRun.mockResolvedValueOnce(run('staged')).mockResolvedValueOnce(run('published'));
+    mockListItems.mockResolvedValue([pendingItem]);
+    mockDecide.mockResolvedValue({ ...pendingItem, decision: 'accepted' });
+    render(<VerifyScreen />);
+
+    await waitFor(() => expect(screen.getByText('Carnitas Taco')).toBeTruthy());
+    fireEvent.press(screen.getByLabelText('accept'));
+
+    await waitFor(() => expect(screen.getByText('Menu published! 🎉')).toBeTruthy());
+    expect(mockDecide).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: 'run-77', itemId: 'ii-1', decision: 'accepted' }),
+    );
+
+    fireEvent.press(screen.getByLabelText('view-menu'));
+    expect(mockReplace).toHaveBeenCalledWith('/restaurants/rest-1?from=scan');
+  });
+
+  it('below the publish threshold the done screen still links to the restaurant', async () => {
+    // Both the poll and the deck-done refetch see staged (< 80% accepted).
+    mockGetRun.mockResolvedValue(run('staged'));
+    mockListItems.mockResolvedValue([pendingItem]);
+    mockDecide.mockResolvedValue({ ...pendingItem, decision: 'rejected' });
+    render(<VerifyScreen />);
+
+    await waitFor(() => expect(screen.getByText('Carnitas Taco')).toBeTruthy());
+    fireEvent.press(screen.getByLabelText('reject'));
+
+    await waitFor(() => expect(screen.getByText('All done!')).toBeTruthy());
+    expect(screen.getByLabelText('view-menu')).toBeTruthy();
+  });
+
+  it('"nothing to verify" still offers the menu link', async () => {
+    mockGetRun.mockResolvedValue(run('published'));
+    mockListItems.mockResolvedValue([]);
+    render(<VerifyScreen />);
+
+    await waitFor(() => expect(screen.getByText('Nothing to verify')).toBeTruthy());
+    fireEvent.press(screen.getByLabelText('view-menu'));
+    expect(mockReplace).toHaveBeenCalledWith('/restaurants/rest-1?from=scan');
+  });
+});

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -87,7 +87,7 @@ export default function Home() {
           renderItem={({ item }) => (
             <Pressable
               accessibilityLabel={`restaurant-${item.slug}`}
-              onPress={() => router.push(`/restaurants/${item.id}`)}
+              onPress={() => router.push(`/restaurants/${item.id}?from=search`)}
               style={styles.row}
             >
               <Text style={styles.rowName}>{item.name}</Text>
@@ -95,11 +95,21 @@ export default function Home() {
             </Pressable>
           )}
           ListEmptyComponent={
-            <Text style={styles.empty}>
-              {query
-                ? `No matches for “${query}”. Scan its menu to add it!`
-                : 'No restaurants yet — be the first to scan a menu.'}
-            </Text>
+            query ? (
+              // Phase 7.3 — the search-miss is the front door of the
+              // scan loop: carry the typed name into the
+              // new-restaurant form so the user doesn't retype it.
+              <Pressable
+                accessibilityLabel="scan-miss-cta"
+                onPress={() => router.push(`/ingest?name=${encodeURIComponent(query.trim())}`)}
+                style={styles.missCta}
+              >
+                <Text style={styles.empty}>No matches for “{query}”.</Text>
+                <Text style={styles.missCtaText}>Can’t find it? Scan its menu to add it →</Text>
+              </Pressable>
+            ) : (
+              <Text style={styles.empty}>No restaurants yet — be the first to scan a menu.</Text>
+            )
           }
         />
       )}
@@ -169,6 +179,14 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: fontSize.base,
     paddingVertical: space['4'],
+  },
+  missCta: {
+    gap: space['1'],
+  },
+  missCtaText: {
+    color: colors.bite,
+    fontWeight: '600',
+    fontSize: fontSize.base,
   },
   error: {
     color: colors.textMuted,

--- a/apps/mobile/app/ingest/_RestaurantPicker.tsx
+++ b/apps/mobile/app/ingest/_RestaurantPicker.tsx
@@ -18,11 +18,14 @@ import { friendlyScanError } from '../../lib/api/ingestion-runs';
 export function RestaurantPicker({
   jwt,
   onPicked,
+  initialName,
 }: {
   jwt: string;
   onPicked: (restaurant: { id: string; name: string }) => void;
+  /** Phase 7.3 — prefilled from the home search-miss query. */
+  initialName?: string;
 }) {
-  const [name, setName] = useState('');
+  const [name, setName] = useState(initialName ?? '');
   const [citySlug, setCitySlug] = useState('durango');
   const [street, setStreet] = useState('');
   const [candidates, setCandidates] = useState<DuplicateCandidate[] | null>(null);

--- a/apps/mobile/app/ingest/index.tsx
+++ b/apps/mobile/app/ingest/index.tsx
@@ -10,7 +10,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
@@ -29,9 +29,21 @@ import { RestaurantPicker } from './_RestaurantPicker';
  * then land on the swipe-verify screen (Phase 2.7) for your own run
  * (Phase 6.3 self-verify). Guardrail errors (Phase 6.1) render as
  * human copy via friendlyScanError.
+ * Phase 7.3 — stitched entry points: `?name=` (home search-miss)
+ * prefills the new-restaurant form; `?restaurantId=&restaurantName=`
+ * (the menu screen's re-scan action) skips the picker entirely.
  */
 export default function IngestScreen() {
-  const [restaurant, setRestaurant] = useState<{ id: string; name: string } | null>(null);
+  const params = useLocalSearchParams<{
+    name?: string;
+    restaurantId?: string;
+    restaurantName?: string;
+  }>();
+  const [restaurant, setRestaurant] = useState<{ id: string; name: string } | null>(() =>
+    params.restaurantId && params.restaurantName
+      ? { id: params.restaurantId, name: params.restaurantName }
+      : null,
+  );
   const [manualId, setManualId] = useState('');
   const [jwt, setJwt] = useState<string | null>(null);
   const [pages, setPages] = useState<CapturedPage[]>([]);
@@ -159,7 +171,9 @@ export default function IngestScreen() {
         </Pressable>
       ) : (
         <>
-          {jwt && <RestaurantPicker jwt={jwt} onPicked={setRestaurant} />}
+          {jwt && (
+            <RestaurantPicker jwt={jwt} onPicked={setRestaurant} initialName={params.name} />
+          )}
           <TextInput
             accessibilityLabel="restaurant-id"
             placeholder="…or paste a restaurant UUID"

--- a/apps/mobile/app/ingest/verify.tsx
+++ b/apps/mobile/app/ingest/verify.tsx
@@ -22,6 +22,14 @@ import {
 
 const POLL_INTERVAL_MS = 2_000;
 
+// Phase 7.3 — human copy per pipeline stage so the wait reads as
+// progress, not a stuck spinner. Keys are IngestionRunPayload statuses.
+const STAGE_COPY: Record<string, string> = {
+  queued: 'Waiting in line…',
+  extracting: 'Reading the menu…',
+  resolving: 'Matching ingredients & tags…',
+};
+
 /**
  * Phase 2.7 + 4.1 — swipe-verify deck.
  *
@@ -94,6 +102,24 @@ export default function VerifyScreen() {
 
   const current = items[cursor];
 
+  // Phase 7.3 — finishing the deck may trip the 80% auto-publish.
+  // Refetch once so the done screen knows whether to celebrate.
+  const deckDone = items.length > 0 && cursor >= items.length;
+  useEffect(() => {
+    if (!deckDone || !jwt) return;
+    let cancelled = false;
+    getIngestionRun(runId, { jwt })
+      .then((fresh) => {
+        if (!cancelled) setRun(fresh);
+      })
+      .catch(() => {
+        // Non-fatal — the done screen falls back to the staged copy.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [deckDone, runId, jwt]);
+
   const decide = useCallback(
     async (decision: 'accepted' | 'rejected' | 'edited') => {
       if (!current || !jwt) return;
@@ -162,7 +188,7 @@ export default function VerifyScreen() {
     return (
       <View style={styles.container}>
         <ActivityIndicator size="large" color={colors.bite} testID="extracting-loading" />
-        <Text style={styles.headline}>{run.status}…</Text>
+        <Text style={styles.headline}>{STAGE_COPY[run.status] ?? `${run.status}…`}</Text>
         <Text style={styles.body}>
           Polling every {POLL_INTERVAL_MS / 1000}s. The deck opens as soon as the AI finishes.
         </Text>
@@ -177,18 +203,25 @@ export default function VerifyScreen() {
         <Text style={styles.body}>
           Either every item is already decided, or the run produced no items.
         </Text>
+        <ViewMenuButton restaurantId={run.restaurant_id} />
       </View>
     );
   }
 
   if (!current) {
+    // Phase 7.3 — the end of the scan loop: deep-link into the
+    // user's own filtered view of the menu they just scanned.
+    const published = run.status === 'published';
     return (
       <View style={styles.container}>
-        <Text style={styles.headline}>All done!</Text>
+        <Text style={styles.headline}>{published ? 'Menu published! 🎉' : 'All done!'}</Text>
         <Text style={styles.body}>
-          You decided on {items.length} item{items.length === 1 ? '' : 's'}. The run will
-          auto-publish at the 80% threshold.
+          {published
+            ? 'Your scan is live. See it filtered to your preferences:'
+            : `You decided on ${items.length} item${items.length === 1 ? '' : 's'}. The run ` +
+              'auto-publishes at the 80% threshold — you can open the restaurant now.'}
         </Text>
+        <ViewMenuButton restaurantId={run.restaurant_id} />
       </View>
     );
   }
@@ -293,6 +326,18 @@ export default function VerifyScreen() {
   );
 }
 
+function ViewMenuButton({ restaurantId }: { restaurantId: string }) {
+  return (
+    <Pressable
+      accessibilityLabel="view-menu"
+      onPress={() => router.replace(`/restaurants/${restaurantId}?from=scan`)}
+      style={styles.viewMenuButton}
+    >
+      <Text style={styles.viewMenuText}>🍽 See the menu</Text>
+    </Pressable>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -368,6 +413,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   actionText: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.base,
+  },
+  viewMenuButton: {
+    backgroundColor: colors.bite,
+    paddingVertical: space['4'],
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  viewMenuText: {
     color: colors.bg,
     fontWeight: '700',
     fontSize: fontSize.base,

--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -8,7 +8,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
   applyOverrides,
@@ -50,12 +50,12 @@ const STRICTNESSES: Strictness[] = ['relaxed', 'balanced', 'strict'];
 
 export default function RestaurantScreen() {
   const tracker = useTracker();
-  const params = useLocalSearchParams<{ id: string }>();
+  const params = useLocalSearchParams<{ id: string; from?: string }>();
   const id = String(params.id ?? '');
-  // Phase 5.8 — fire restaurant_tap once per id mount; the from
-  // value defaults to 'direct' since mobile lists currently don't
-  // pass a source param. Funnel queries can grow more granularity
-  // later by adding `from` to the navigation links.
+  // Phase 5.8 — fire restaurant_tap once per id mount. Phase 7.3 —
+  // navigation links now pass `?from=` (search | scan); default
+  // stays 'direct' for deep links and older entry points.
+  const tapFrom = params.from || 'direct';
   const tapFiredRef = useRef(false);
   // Phase 4.1: pull the JWT from the keychain on mount; if absent
   // the page still loads (anonymous browse), but personalized filter
@@ -127,7 +127,7 @@ export default function RestaurantScreen() {
         });
         if (!tapFiredRef.current) {
           tapFiredRef.current = true;
-          tracker.track('restaurant_tap', { restaurant_slug: id, from: 'direct' });
+          tracker.track('restaurant_tap', { restaurant_slug: id, from: tapFrom });
         }
       })
       .catch((e) => {
@@ -225,6 +225,7 @@ export default function RestaurantScreen() {
         }}
       />
       <ShareLinkButton slug={restaurant.slug} filter={filter} />
+      <RescanButton restaurantId={restaurant.id} restaurantName={restaurant.name} />
 
       {overriddenSections.map((section) => (
         <SectionBlock
@@ -321,6 +322,31 @@ function ShareLinkButton({ slug, filter }: { slug: string; filter: FilterSummary
       style={styles.shareButton}
     >
       <Text style={styles.shareText}>🔗 Share filter</Text>
+    </Pressable>
+  );
+}
+
+// Phase 7.3 — re-scan entry: starts a new ingestion run against THIS
+// restaurant (the ingest screen skips its picker when both params are
+// present). Phase 6.2's ownership rules still apply server-side.
+function RescanButton({
+  restaurantId,
+  restaurantName,
+}: {
+  restaurantId: string;
+  restaurantName: string;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel="rescan-menu"
+      onPress={() =>
+        router.push(
+          `/ingest?restaurantId=${restaurantId}&restaurantName=${encodeURIComponent(restaurantName)}`,
+        )
+      }
+      style={styles.shareButton}
+    >
+      <Text style={styles.shareText}>📷 Menu changed? Re-scan</Text>
     </Pressable>
   );
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,7 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 7.3 — stitch the scan-to-menu flow end-to-end**
-5. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
+1. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
 6. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)**
 7. **Phase 8.3 — Top Picks UI (web)**
 8. **Phase 8.4 — Top Picks UI (mobile)**
@@ -104,7 +103,8 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 6.5 — web community scan entrypoint (#304)
 - ✅ Phase 6.6 — mobile community scan entrypoint (#305) — **Phase 6 feature-complete: anyone-can-scan on both surfaces**
 - ✅ Phase 7.1 — real expo-camera capture via ref (#306)
-- ✅ Phase 7.2 — real mobile home screen: search + scan CTA; near-me deferred pending expo-location (this PR)
+- ✅ Phase 7.2 — real mobile home screen: search + scan CTA; near-me deferred pending expo-location (#307)
+- ✅ Phase 7.3 — scan-to-menu flow stitched: search-miss → prefilled create → capture → stage progress → verify → deep-link to own filtered menu; re-scan entry on the menu screen (this PR) — **Phase 7 feature-complete (device camera pass still pending a human phone test)**
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,29 @@ without spelunking GitHub.
 
 ---
 
+2026-06-12 22:55 — tick #141. **Phase 7.3 shipped — scan-to-menu flow
+stitched end-to-end. PHASE 7 FEATURE-COMPLETE.** #307 (7.2)
+auto-merged on green. This PR (all mobile):
+- Home search-miss is now a CTA carrying the typed name →
+  /ingest?name=… prefills the new-restaurant form; result rows pass
+  ?from=search.
+- /ingest accepts ?restaurantId&restaurantName (skips the picker) —
+  used by the new "📷 Menu changed? Re-scan" entry on the restaurant
+  screen (server-side Phase 6.2 ownership rules unchanged).
+- Verify screen: pipeline stages render human copy ("Reading the
+  menu…" / "Matching ingredients & tags…"); finishing the deck
+  refetches the run and deep-links to /restaurants/:id?from=scan —
+  celebratory copy when the 80% auto-publish tripped, threshold
+  explainer otherwise; "nothing to verify" also links out.
+- restaurant_tap now uses the carried ?from (search | scan; default
+  direct) — existing event, no taxonomy change.
+- Tests: +2 ingest entry-point specs, new verify.render.test.tsx
+  (4 specs: stage copy, published deep-link, sub-threshold link,
+  nothing-to-verify), +2 full-screen restaurant specs (re-scan
+  route, from-param tracking), home specs updated. Mobile jest
+  113/113 (+11); typecheck + lint green. No API changes.
+Next: Phase 8.1 taste signal schema + profile API.
+
 2026-06-12 19:05 — tick #140. **Phase 7.2 shipped — real mobile home
 screen.** The Phase-0 "Pre-MVP" placeholder is gone: debounced
 (300ms) restaurant search → tap into the filtered menu, scan CTA →


### PR DESCRIPTION
## What

Phase 7.3 (`docs/plans/phase-7.md`) — the end-to-end ribbon tying Phase 6.6 (community scan) + 7.1 (real camera) + 7.2 (home search) together. **This completes Phase 7.**

The demo path: search a restaurant on home → miss → tap the new scan CTA (carries the typed name) → create the restaurant (form prefilled) → photograph pages → watch human-readable extraction progress → swipe-verify → land on **your own filtered view of the menu you just scanned**.

- **Home (`app/index.tsx`)**: the search-miss empty state is now a pressable CTA → `/ingest?name=<query>`; result rows navigate with `?from=search`.
- **Ingest (`app/ingest/index.tsx` + `_RestaurantPicker.tsx`)**: accepts `?name=` (prefills the new-restaurant form) and `?restaurantId=&restaurantName=` (skips the picker entirely — the re-scan path). Phase 6.2 ownership rules are untouched server-side.
- **Verify (`app/ingest/verify.tsx`)**: pipeline stages map to human copy ("Reading the menu…", "Matching ingredients & tags…"). Finishing the deck refetches the run: if the 80% auto-publish tripped → "Menu published! 🎉" with a deep link to `/restaurants/:id?from=scan`; below threshold → explainer + the same link. "Nothing to verify" links out too.
- **Restaurant screen (`app/restaurants/[id].tsx`)**: new "📷 Menu changed? Re-scan" action → `/ingest` with this restaurant preselected. `restaurant_tap` now uses the carried `?from` (`search` | `scan`, default `direct`) — an **existing** event payload field, no taxonomy change.

## Tests

- +2 ingest entry-point specs (re-scan preselect, name prefill)
- New `verify.render.test.tsx` — 4 specs: stage copy mapping, published-run deep-link (happy path reaches the restaurant route), sub-threshold done state, nothing-to-verify link
- +2 full-screen restaurant specs (re-scan route target, `from`-param tracking via injected tracker)
- Home specs updated for the CTA + `from=search`
- Mobile jest **113/113** (+11); `pnpm typecheck` 10/10; `pnpm lint` 6/6. No API changes.

## Honest caveats

- Verified in jest with camera/API mocked; the full on-device flow (real camera → real pipeline) still needs the human phone test already noted on #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)