### PR TITLE
feat(api): taste signal schema + profile API (Phase 8.1)

### DIFF
--- a/apps/api/app/controllers/api/v1/profiles_controller.rb
+++ b/apps/api/app/controllers/api/v1/profiles_controller.rb
@@ -54,7 +54,13 @@ module Api
           :dietary_profile_slug,
           avoid_ingredient_ids: [],
           avoid_tag_ids:        [],
-          prefer_tag_ids:       []
+          prefer_tag_ids:       [],
+          # Phase 8.1 — taste signals (soft: rank, never hide). Same
+          # wholesale-replacement semantics as the avoid arrays.
+          liked_ingredient_ids:    [],
+          liked_tag_ids:           [],
+          disliked_ingredient_ids: [],
+          disliked_tag_ids:        []
         )
       end
 
@@ -74,6 +80,10 @@ module Api
           avoid_ingredient_ids: profile.avoid_ingredient_ids,
           avoid_tag_ids:        profile.avoid_tag_ids,
           prefer_tag_ids:       profile.prefer_tag_ids,
+          liked_ingredient_ids:    profile.liked_ingredient_ids,
+          liked_tag_ids:           profile.liked_tag_ids,
+          disliked_ingredient_ids: profile.disliked_ingredient_ids,
+          disliked_tag_ids:        profile.disliked_tag_ids,
           strictness:           profile.strictness,
           primary_dietary_profile: dietary_profile_summary(profile.primary_dietary_profile)
         }

--- a/apps/api/app/models/user_profile.rb
+++ b/apps/api/app/models/user_profile.rb
@@ -1,8 +1,45 @@
 class UserProfile < ApplicationRecord
   STRICTNESS = %w[relaxed balanced strict].freeze
 
+  # Phase 8.1 — the four taste-signal arrays. Taste is SOFT: it ranks
+  # the safe items (Top Picks), it never hides. The avoid arrays are
+  # the hard safety filter; an id present in an avoid list is simply
+  # ignored by scoring (filter wins — not a validation error).
+  TASTE_FIELDS = {
+    liked_ingredient_ids:    :ingredient,
+    liked_tag_ids:           :tag,
+    disliked_ingredient_ids: :ingredient,
+    disliked_tag_ids:        :tag
+  }.freeze
+
   belongs_to :user
   belongs_to :primary_dietary_profile, class_name: "DietaryProfile", optional: true
 
   validates :strictness, inclusion: { in: STRICTNESS }
+  validate :taste_signals_disjoint
+  validate :taste_ids_exist
+
+  private
+
+  # "I love it AND I hate it" is a client bug, not a preference —
+  # scoring would silently cancel the terms out. Fail loud instead.
+  def taste_signals_disjoint
+    if (liked_ingredient_ids & disliked_ingredient_ids).any?
+      errors.add(:liked_ingredient_ids, "cannot also appear in disliked_ingredient_ids")
+    end
+    if (liked_tag_ids & disliked_tag_ids).any?
+      errors.add(:liked_tag_ids, "cannot also appear in disliked_tag_ids")
+    end
+  end
+
+  def taste_ids_exist
+    TASTE_FIELDS.each do |attr, kind|
+      ids = self[attr].compact.uniq
+      next if ids.empty?
+
+      klass   = kind == :ingredient ? Ingredient : Tag
+      missing = ids - klass.where(id: ids).pluck(:id)
+      errors.add(attr, "contains unknown #{kind} ids: #{missing.join(', ')}") if missing.any?
+    end
+  end
 end

--- a/apps/api/db/migrate/20260613002000_add_taste_signals_to_user_profiles.rb
+++ b/apps/api/db/migrate/20260613002000_add_taste_signals_to_user_profiles.rb
@@ -1,0 +1,12 @@
+# Phase 8.1 — taste signals. Soft preferences that RANK the safe
+# items (Top Picks); they never hide anything — that's what the avoid
+# arrays are for. Read-side only in the ranking query (no membership
+# lookups against these from other rows), so no GIN indexes.
+class AddTasteSignalsToUserProfiles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_profiles, :liked_ingredient_ids,    :uuid, array: true, default: [], null: false
+    add_column :user_profiles, :liked_tag_ids,           :uuid, array: true, default: [], null: false
+    add_column :user_profiles, :disliked_ingredient_ids, :uuid, array: true, default: [], null: false
+    add_column :user_profiles, :disliked_tag_ids,        :uuid, array: true, default: [], null: false
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_031000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_13_002000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -359,6 +359,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_031000) do
     t.uuid "avoid_ingredient_ids", default: [], null: false, array: true
     t.uuid "avoid_tag_ids", default: [], null: false, array: true
     t.datetime "created_at", null: false
+    t.uuid "disliked_ingredient_ids", default: [], null: false, array: true
+    t.uuid "disliked_tag_ids", default: [], null: false, array: true
+    t.uuid "liked_ingredient_ids", default: [], null: false, array: true
+    t.uuid "liked_tag_ids", default: [], null: false, array: true
     t.uuid "prefer_tag_ids", default: [], null: false, array: true
     t.uuid "primary_dietary_profile_id"
     t.string "strictness", default: "balanced", null: false

--- a/apps/api/spec/integration/api/v1/profile_spec.rb
+++ b/apps/api/spec/integration/api/v1/profile_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe "profile", type: :request do
           avoid_ingredient_ids: { type: :array, items: { type: :string, format: :uuid } },
           avoid_tag_ids:        { type: :array, items: { type: :string, format: :uuid } },
           prefer_tag_ids:       { type: :array, items: { type: :string, format: :uuid } },
+          liked_ingredient_ids:    { type: :array, items: { type: :string, format: :uuid } },
+          liked_tag_ids:           { type: :array, items: { type: :string, format: :uuid } },
+          disliked_ingredient_ids: { type: :array, items: { type: :string, format: :uuid } },
+          disliked_tag_ids:        { type: :array, items: { type: :string, format: :uuid } },
           strictness:           { type: :string, enum: %w[relaxed balanced strict] },
           dietary_profile_slug: { type: :string }
         }

--- a/apps/api/spec/requests/api/v1/profile_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_spec.rb
@@ -144,5 +144,83 @@ RSpec.describe "GET/PATCH /api/v1/profile", type: :request do
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    # Phase 8.1 — taste signals. Soft preferences that rank Top Picks;
+    # they never hide items (that's the avoid arrays' job). The
+    # validations exist because "loved AND hated" silently cancels in
+    # scoring, and a deleted/typo'd UUID would be an invisible no-op
+    # in the user's picks forever.
+    describe "taste signals (Phase 8.1)" do
+      let(:basil)     { create(:ingredient, slug: "herb-basil") }
+      let(:spicy_tag) { create(:tag, slug: "flavor-spicy") }
+
+      it "GET includes the four taste arrays (empty by default)" do
+        get "/api/v1/profile", headers: headers
+
+        expect(response.parsed_body).to include(
+          "liked_ingredient_ids"    => [],
+          "liked_tag_ids"           => [],
+          "disliked_ingredient_ids" => [],
+          "disliked_tag_ids"        => []
+        )
+      end
+
+      it "round-trips all four taste arrays" do
+        patch "/api/v1/profile",
+              params: {
+                liked_ingredient_ids:    [basil.id],
+                liked_tag_ids:           [spicy_tag.id],
+                disliked_ingredient_ids: [cheese.id],
+                disliked_tag_ids:        [fried_tag.id]
+              }.to_json,
+              headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["liked_ingredient_ids"]).to    contain_exactly(basil.id)
+        expect(body["liked_tag_ids"]).to           contain_exactly(spicy_tag.id)
+        expect(body["disliked_ingredient_ids"]).to contain_exactly(cheese.id)
+        expect(body["disliked_tag_ids"]).to        contain_exactly(fried_tag.id)
+
+        profile = user.reload.profile
+        expect(profile.liked_ingredient_ids).to contain_exactly(basil.id)
+        expect(profile.disliked_tag_ids).to     contain_exactly(fried_tag.id)
+      end
+
+      it "422s when an id appears in both liked and disliked" do
+        patch "/api/v1/profile",
+              params: {
+                liked_ingredient_ids:    [basil.id],
+                disliked_ingredient_ids: [basil.id]
+              }.to_json,
+              headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to have_key("liked_ingredient_ids")
+      end
+
+      it "422s on an unknown ingredient or tag UUID" do
+        patch "/api/v1/profile",
+              params: { liked_tag_ids: [SecureRandom.uuid] }.to_json,
+              headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to have_key("liked_tag_ids")
+      end
+
+      it "accepts an id that also sits in an avoid list (filter wins; scoring ignores it)" do
+        patch "/api/v1/profile",
+              params: {
+                avoid_ingredient_ids: [basil.id],
+                liked_ingredient_ids: [basil.id]
+              }.to_json,
+              headers: headers
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["avoid_ingredient_ids"]).to contain_exactly(basil.id)
+        expect(body["liked_ingredient_ids"]).to contain_exactly(basil.id)
+      end
+    end
   end
 end

--- a/apps/api/spec/swagger_helper.rb
+++ b/apps/api/spec/swagger_helper.rb
@@ -74,11 +74,20 @@ RSpec.configure do |config|
           },
           ProfilePayload: {
             type: :object,
-            required: %w[avoid_ingredient_ids avoid_tag_ids prefer_tag_ids strictness primary_dietary_profile],
+            required: %w[avoid_ingredient_ids avoid_tag_ids prefer_tag_ids
+                         liked_ingredient_ids liked_tag_ids
+                         disliked_ingredient_ids disliked_tag_ids
+                         strictness primary_dietary_profile],
             properties: {
               avoid_ingredient_ids: { type: :array, items: { type: :string, format: :uuid } },
               avoid_tag_ids:        { type: :array, items: { type: :string, format: :uuid } },
               prefer_tag_ids:       { type: :array, items: { type: :string, format: :uuid } },
+              # Phase 8.1 — taste signals: soft preferences that rank
+              # Top Picks. Never hide items (avoid arrays do that).
+              liked_ingredient_ids:    { type: :array, items: { type: :string, format: :uuid } },
+              liked_tag_ids:           { type: :array, items: { type: :string, format: :uuid } },
+              disliked_ingredient_ids: { type: :array, items: { type: :string, format: :uuid } },
+              disliked_tag_ids:        { type: :array, items: { type: :string, format: :uuid } },
               strictness:           { type: :string, enum: %w[relaxed balanced strict] },
               primary_dietary_profile: {
                 type: :object, nullable: true,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -325,6 +325,34 @@
                       "format": "uuid"
                     }
                   },
+                  "liked_ingredient_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "liked_tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "disliked_ingredient_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "disliked_tag_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
                   "strictness": {
                     "type": "string",
                     "enum": [
@@ -657,6 +685,10 @@
           "avoid_ingredient_ids",
           "avoid_tag_ids",
           "prefer_tag_ids",
+          "liked_ingredient_ids",
+          "liked_tag_ids",
+          "disliked_ingredient_ids",
+          "disliked_tag_ids",
           "strictness",
           "primary_dietary_profile"
         ],
@@ -676,6 +708,34 @@
             }
           },
           "prefer_tag_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "liked_ingredient_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "liked_tag_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "disliked_ingredient_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "disliked_tag_ids": {
             "type": "array",
             "items": {
               "type": "string",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,7 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 8.1 — taste signal schema + profile API** (`docs/plans/phase-8.md`)
-6. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)**
+1. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)** (`docs/plans/phase-8.md`)
 7. **Phase 8.3 — Top Picks UI (web)**
 8. **Phase 8.4 — Top Picks UI (mobile)**
 9. **Phase 8.5 — taste onboarding step (web + mobile)**
@@ -104,7 +103,8 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 6.6 — mobile community scan entrypoint (#305) — **Phase 6 feature-complete: anyone-can-scan on both surfaces**
 - ✅ Phase 7.1 — real expo-camera capture via ref (#306)
 - ✅ Phase 7.2 — real mobile home screen: search + scan CTA; near-me deferred pending expo-location (#307)
-- ✅ Phase 7.3 — scan-to-menu flow stitched: search-miss → prefilled create → capture → stage progress → verify → deep-link to own filtered menu; re-scan entry on the menu screen (this PR) — **Phase 7 feature-complete (device camera pass still pending a human phone test)**
+- ✅ Phase 7.3 — scan-to-menu flow stitched: search-miss → prefilled create → capture → stage progress → verify → deep-link to own filtered menu; re-scan entry on the menu screen (#308) — **Phase 7 feature-complete (device camera pass still pending a human phone test)**
+- ✅ Phase 8.1 — taste signal schema + profile API: 4 liked/disliked uuid[] columns, disjoint + existence validations, rswag + codegen (this PR)
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,25 @@ without spelunking GitHub.
 
 ---
 
+2026-06-13 00:35 — tick #142. **Phase 8.1 shipped — taste signal
+schema + profile API.** #308 (7.3) auto-merged on green. This PR:
+- Migration: liked/disliked_ingredient_ids + liked/disliked_tag_ids
+  uuid[] (default {}) on user_profiles; no GIN (read-side only).
+- UserProfile validations: liked∩disliked = 422 ("loved AND hated"
+  silently cancels in scoring — fail loud), unknown UUIDs = 422.
+  Avoid-overlap is deliberately ALLOWED (filter wins; scoring
+  ignores it in 8.2). NOTE: the plan said "same validation pattern
+  as the avoid arrays" but the avoid arrays have NO existence
+  validation — taste arrays are stricter than avoid; flagged in the
+  PR rather than silently matching the looser precedent.
+- GET/PATCH /api/v1/profile round-trips the four arrays (wholesale
+  replacement, same as avoid). rswag schema + body params updated,
+  openapi-export + api-types codegen in-PR.
+- +5 request specs (defaults, round-trip, both-lists 422, unknown
+  UUID 422, avoid-overlap OK). rspec 445/445; brakeman clean; JS
+  typecheck/lint/test green.
+Next: Phase 8.2 taste scoring engine (SQL + filter-engine, one PR).
+
 2026-06-12 22:55 — tick #141. **Phase 7.3 shipped — scan-to-menu flow
 stitched end-to-end. PHASE 7 FEATURE-COMPLETE.** #307 (7.2)
 auto-merged on green. This PR (all mobile):

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -258,6 +258,10 @@ export interface paths {
                         avoid_ingredient_ids?: string[];
                         avoid_tag_ids?: string[];
                         prefer_tag_ids?: string[];
+                        liked_ingredient_ids?: string[];
+                        liked_tag_ids?: string[];
+                        disliked_ingredient_ids?: string[];
+                        disliked_tag_ids?: string[];
                         /** @enum {string} */
                         strictness?: "relaxed" | "balanced" | "strict";
                         dietary_profile_slug?: string;
@@ -427,6 +431,10 @@ export interface components {
             avoid_ingredient_ids: string[];
             avoid_tag_ids: string[];
             prefer_tag_ids: string[];
+            liked_ingredient_ids: string[];
+            liked_tag_ids: string[];
+            disliked_ingredient_ids: string[];
+            disliked_tag_ids: string[];
             /** @enum {string} */
             strictness: "relaxed" | "balanced" | "strict";
             primary_dietary_profile: {


### PR DESCRIPTION
## What

Phase 8.1 (`docs/plans/phase-8.md`) — first leg of the "most likely to enjoy" taste ranking. **Design principle: safety filters, taste ranks.** The four new arrays are soft signals that will reorder and highlight (Phase 8.2+); they never hide an item — that stays the avoid arrays' job.

- **Migration**: `liked_ingredient_ids`, `liked_tag_ids`, `disliked_ingredient_ids`, `disliked_tag_ids` — `uuid[]`, default `{}`, not null, on `user_profiles`. No GIN (read-side only, per plan).
- **Validations** (`UserProfile`):
  - liked ∩ disliked → 422. "Loved AND hated" would silently cancel in scoring; fail loud instead.
  - unknown ingredient/tag UUID → 422. A typo'd id would be an invisible no-op in the user's picks forever.
  - an id that also sits in an **avoid** list is allowed — filter wins, scoring ignores it (8.2 enforces that).
- **API**: `GET/PATCH /api/v1/profile` round-trips all four arrays with the existing wholesale-replacement semantics.
- **Contract chain**: rswag `ProfilePayload` + PATCH body updated → `bin/openapi-export` → api-types codegen, all in this PR (`codegen:check` should be green).

## Plan deviation (flagged, not hidden)

The subplan says the taste arrays use "the same validation pattern as the avoid arrays (UUIDs must exist)" — but the shipped avoid arrays have **no** existence validation at all. I implemented the stricter behavior the plan clearly intends for the *taste* arrays and left the avoid arrays untouched (changing shipped validation behavior is out of scope and could break existing clients). If we want existence checks on avoid arrays too, that's a separate decision.

## Tests

- +5 request specs: GET defaults, four-array round-trip, both-lists 422, unknown-UUID 422, avoid-overlap accepted
- Full suite **445 examples, 0 failures**; brakeman 0 warnings; `pnpm typecheck` / `lint` / `test` green (codegen output compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)