### PR TITLE
feat(api): taste scoring engine — SQL + filter-engine parity (Phase 8.2)

### DIFF
--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -33,7 +33,20 @@ module Api
         labels        = build_label_lookup(items, filter)
         override_ids  = current_user_override_item_ids(items)
         review_counts = review_counts_for(items)
-        rendered      = items.map { |item| serialize_item(item, filter, labels, override_ids, review_counts) }
+
+        # Phase 8.2 — taste ranks, safety filters. Scores only exist
+        # when the signed-in user's profile carries taste signals;
+        # everyone else gets the legacy payload + sort untouched.
+        taste        = build_taste_signals(filter)
+        scores       = taste&.any? ? TasteScoring.scores_for(restaurant_id: restaurant.id, signals: taste) : nil
+        taste_labels = build_taste_label_lookup(scores)
+
+        rendered = items.map do |item|
+          serialize_item(item, filter, labels, override_ids, review_counts, scores, taste_labels)
+        end
+        if scores
+          rendered.sort_by! { |i| [-(i[:taste_score] || 0.0), -i[:popularity], i[:name]] }
+        end
 
         # Phase 4.8 — record an authenticated user's visit to this
         # restaurant for the History tab. Best-effort, async, never
@@ -105,6 +118,51 @@ module Api
         UserProfile::STRICTNESS.include?(params[:strictness]) ? params[:strictness] : nil
       end
 
+      # Phase 8.2 — taste signals come ONLY from the signed-in user's
+      # saved profile (presets and share tokens carry no taste). Ids
+      # that also sit in an avoid list are subtracted here — filter
+      # wins; an avoided id never scores (Phase 8.1 contract).
+      def build_taste_signals(filter)
+        return nil unless filter.source == "user_profile"
+
+        p = current_user.profile
+        TasteScoring::Signals.new(
+          liked_ingredient_ids:    p.liked_ingredient_ids    - filter.avoid_ingredient_ids,
+          liked_tag_ids:           p.liked_tag_ids           - filter.avoid_tag_ids,
+          disliked_ingredient_ids: p.disliked_ingredient_ids - filter.avoid_ingredient_ids,
+          disliked_tag_ids:        p.disliked_tag_ids        - filter.avoid_tag_ids
+        )
+      end
+
+      # Names for the matched liked ids so taste_reasons renders the
+      # "because you like…" line without a second roundtrip. Same
+      # shape as build_label_lookup, scoped to taste matches.
+      def build_taste_label_lookup(scores)
+        return { ingredients: {}, tags: {} } if scores.nil?
+
+        tag_ids = scores.values.flat_map { |s| s[:matched_liked_tag_ids] }.uniq
+        ing_ids = scores.values.flat_map { |s| s[:matched_liked_ingredient_ids] }.uniq
+
+        {
+          ingredients: Ingredient.where(id: ing_ids).pluck(:id, :name).to_h,
+          tags:        Tag.where(id: tag_ids).pluck(:id, :name).to_h
+        }
+      end
+
+      # Tags first, then ingredients, both in the SQL's sorted-uuid
+      # order — the TS mirror emits the same order so parity holds.
+      def taste_reasons_for(score_row, taste_labels)
+        return [] if score_row.nil?
+
+        score_row[:matched_liked_tag_ids].map do |tag_id|
+          { kind: "liked_tag", tag_id: tag_id, tag_name: taste_labels[:tags][tag_id] }
+        end +
+          score_row[:matched_liked_ingredient_ids].map do |ing_id|
+            { kind: "liked_ingredient", ingredient_id: ing_id,
+              ingredient_name: taste_labels[:ingredients][ing_id] }
+          end
+      end
+
       # Compute reasons WHY an item would be hidden under this filter.
       # An empty reasons array means the item passes the filter. Each
       # reason is enriched with display strings (`*_name`, `*_family`)
@@ -160,9 +218,11 @@ module Api
 
       # Try to keep this stable — mobile + web bind to these keys via
       # generated TS types; Phase 1.6's openapi.json should match.
-      def serialize_item(item, filter, labels, override_ids = Set.new, review_counts = {})
-        reasons = hide_reasons(item, filter, labels)
-        section = item.menu_section
+      def serialize_item(item, filter, labels, override_ids = Set.new, review_counts = {},
+                         scores = nil, taste_labels = nil)
+        reasons   = hide_reasons(item, filter, labels)
+        section   = item.menu_section
+        score_row = scores&.fetch(item.id, nil)
         {
           id:                  item.id,
           restaurant_id:       item.restaurant_id,
@@ -178,7 +238,12 @@ module Api
           reasons:             reasons,
           overridden_by_user:  override_ids.include?(item.id),
           reviews_count:       review_counts.fetch(item.id, 0),
-          photo_url:           photo_url_for(item)
+          photo_url:           photo_url_for(item),
+          # Phase 8.2 — null/[] whenever the caller has no taste
+          # signals. Score never hides; the client only reorders and
+          # highlights with it.
+          taste_score:         score_row&.fetch(:score),
+          taste_reasons:       taste_reasons_for(score_row, taste_labels)
         }
       end
 

--- a/apps/api/app/services/taste_scoring.rb
+++ b/apps/api/app/services/taste_scoring.rb
@@ -1,0 +1,125 @@
+# Phase 8.2 — the taste scoring engine (SQL side).
+#
+# score(item) =
+#     2.0 * |item.tag_ids ∩ liked_tag_ids|
+#   + 1.0 * |item.ingredient_ids ∩ liked_ingredient_ids|
+#   - 2.0 * |item.tag_ids ∩ disliked_tag_ids|
+#   - 1.0 * |item.ingredient_ids ∩ disliked_ingredient_ids|
+#   + 0.5 * (popularity / max_popularity_at_restaurant)
+#   + 0.5 * (avg_visible_rating - 3) / 2          (0 when unreviewed)
+#
+# Safety filters, taste ranks: scores reorder and highlight, they
+# never hide. The TS mirror is `scoreItem` in
+# `packages/filter-engine/src/taste.ts` — the two implementations
+# share the fixture at `packages/filter-engine/fixtures/
+# taste-parity.json`, and BOTH must change together (repo rule).
+#
+# Callers pass Signals that have already had the avoid lists
+# subtracted (filter wins; an avoided id never scores) — see
+# ItemsController#build_taste_signals.
+class TasteScoring
+  WEIGHTS = {
+    liked_tag:           2.0,
+    liked_ingredient:    1.0,
+    disliked_tag:        2.0, # subtracted
+    disliked_ingredient: 1.0, # subtracted
+    popularity:          0.5,
+    rating:              0.5
+  }.freeze
+
+  Signals = Struct.new(
+    :liked_ingredient_ids, :liked_tag_ids,
+    :disliked_ingredient_ids, :disliked_tag_ids,
+    keyword_init: true
+  ) do
+    def any?
+      [liked_ingredient_ids, liked_tag_ids,
+       disliked_ingredient_ids, disliked_tag_ids].any?(&:present?)
+    end
+  end
+
+  # Every value reaches the SQL through a sanitize_sql_array
+  # placeholder — weights included, so the score expression and the
+  # WEIGHTS constant cannot drift apart.
+  SCORES_SQL = <<~SQL.freeze
+    SELECT scored.id,
+           (? * cardinality(scored.matched_liked_tag_ids)
+          + ? * cardinality(scored.matched_liked_ingredient_ids)
+          - ? * scored.disliked_tag_count
+          - ? * scored.disliked_ingredient_count
+          + ? * COALESCE(scored.popularity::float8 / NULLIF(scored.max_popularity, 0), 0)
+          + ? * COALESCE((scored.avg_rating - 3) / 2.0, 0)) AS score,
+           scored.matched_liked_tag_ids,
+           scored.matched_liked_ingredient_ids
+    FROM (
+      SELECT items.id,
+             items.popularity,
+             MAX(items.popularity) OVER () AS max_popularity,
+             (SELECT COALESCE(array_agg(t ORDER BY t), '{}')
+                FROM unnest(items.tag_ids) AS t
+               WHERE t = ANY(CAST(? AS uuid[])))    AS matched_liked_tag_ids,
+             (SELECT COALESCE(array_agg(i ORDER BY i), '{}')
+                FROM unnest(items.ingredient_ids) AS i
+               WHERE i = ANY(CAST(? AS uuid[])))    AS matched_liked_ingredient_ids,
+             (SELECT COUNT(*)
+                FROM unnest(items.tag_ids) AS t
+               WHERE t = ANY(CAST(? AS uuid[])))    AS disliked_tag_count,
+             (SELECT COUNT(*)
+                FROM unnest(items.ingredient_ids) AS i
+               WHERE i = ANY(CAST(? AS uuid[])))    AS disliked_ingredient_count,
+             ratings.avg_rating
+      FROM items
+      LEFT JOIN (
+        SELECT reviews.item_id, AVG(reviews.rating)::float8 AS avg_rating
+        FROM reviews
+        WHERE reviews.hidden_at IS NULL
+        GROUP BY reviews.item_id
+      ) ratings ON ratings.item_id = items.id
+      WHERE items.restaurant_id = ?
+        AND items.status = 'published'
+    ) scored
+  SQL
+
+  # Returns { item_id => { score: Float,
+  #                        matched_liked_tag_ids: [...],
+  #                        matched_liked_ingredient_ids: [...] } }
+  # for every published item at the restaurant. One query; the
+  # matched arrays feed the "because you like…" line client-side.
+  def self.scores_for(restaurant_id:, signals:)
+    sql = ActiveRecord::Base.sanitize_sql_array([
+      SCORES_SQL,
+      WEIGHTS[:liked_tag], WEIGHTS[:liked_ingredient],
+      WEIGHTS[:disliked_tag], WEIGHTS[:disliked_ingredient],
+      WEIGHTS[:popularity], WEIGHTS[:rating],
+      pg_uuid_array(signals.liked_tag_ids),
+      pg_uuid_array(signals.liked_ingredient_ids),
+      pg_uuid_array(signals.disliked_tag_ids),
+      pg_uuid_array(signals.disliked_ingredient_ids),
+      restaurant_id
+    ])
+
+    ActiveRecord::Base.connection.select_all(sql).rows.to_h do |id, score, tags, ings|
+      [id, {
+        score:                        score.to_f,
+        matched_liked_tag_ids:        parse_uuid_array(tags),
+        matched_liked_ingredient_ids: parse_uuid_array(ings)
+      }]
+    end
+  end
+
+  # "{a,b}" — the PG array-literal string form CAST(? AS uuid[])
+  # accepts. Inputs are validated UUIDs (Phase 8.1) and the whole
+  # string goes through a sanitized placeholder regardless.
+  def self.pg_uuid_array(ids)
+    "{#{Array(ids).join(',')}}"
+  end
+  private_class_method :pg_uuid_array
+
+  # select_all returns uuid[] as the wire string "{a,b}". UUIDs never
+  # contain commas/braces, so a plain split is exact.
+  def self.parse_uuid_array(value)
+    return value if value.is_a?(Array)
+    value.to_s.delete("{}").split(",").reject(&:empty?)
+  end
+  private_class_method :parse_uuid_array
+end

--- a/apps/api/spec/integration/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/integration/api/v1/restaurants/items_spec.rb
@@ -57,6 +57,24 @@ RSpec.describe "restaurants/items", type: :request do
                              confidence:    { type: :string, enum: %w[confirmed suggested inferred] }
                            }
                          }
+                       },
+                       # Phase 8.2 — taste ranks, never hides. Null /
+                       # empty unless the signed-in caller's profile
+                       # carries taste signals.
+                       taste_score: { type: :number, nullable: true },
+                       taste_reasons: {
+                         type: :array,
+                         items: {
+                           type: :object,
+                           required: %w[kind],
+                           properties: {
+                             kind:            { type: :string, enum: %w[liked_tag liked_ingredient] },
+                             tag_id:          { type: :string, format: :uuid },
+                             tag_name:        { type: :string, nullable: true },
+                             ingredient_id:   { type: :string, format: :uuid },
+                             ingredient_name: { type: :string, nullable: true }
+                           }
+                         }
                        }
                      }
                    }

--- a/apps/api/spec/requests/api/v1/restaurants/items_taste_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/items_taste_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+# Phase 8.2 — taste ranking on the items endpoint. Safety filters,
+# taste ranks: scores reorder and annotate, they never hide. The
+# scoring math itself is locked by the SQL ↔ TS parity fixture
+# (spec/services/taste_scoring_spec.rb); this spec locks the HTTP
+# behavior — when scores appear, how items sort, and that every
+# legacy caller sees an unchanged payload.
+RSpec.describe "GET /api/v1/restaurants/:id/items (taste ranking)", type: :request do
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:user)       { create(:user, :confirmed) }
+  let(:headers)    { auth_headers_for(user) }
+
+  let(:spicy_tag) { create(:tag, slug: "flavor-spicy", name: "Spicy") }
+  let(:basil)     { create(:ingredient, slug: "herb-basil", name: "Basil") }
+
+  # Popularity order is curry < noodles, so legacy sort leads with
+  # noodles — a taste profile that likes spice must flip them.
+  let!(:plain_noodles) do
+    create(:item, :published, :confirmed,
+           restaurant: restaurant, name: "Plain Noodles", popularity: 90)
+  end
+  let!(:spicy_curry) do
+    create(:item, :published, :confirmed,
+           restaurant: restaurant, name: "Spicy Basil Curry", popularity: 10,
+           ingredients: [basil], tag_list: [spicy_tag])
+  end
+
+  describe "anonymous callers" do
+    it "gets null taste_score, empty taste_reasons, legacy popularity sort" do
+      get "/api/v1/restaurants/#{restaurant.id}/items"
+
+      body = response.parsed_body
+      expect(body["items"].pluck("name")).to eq(["Plain Noodles", "Spicy Basil Curry"])
+      expect(body["items"].pluck("taste_score").uniq).to eq([nil])
+      expect(body["items"].pluck("taste_reasons").flatten).to be_empty
+    end
+  end
+
+  describe "signed-in user with no taste signals (zero-signal no-op)" do
+    it "behaves exactly like the legacy payload" do
+      get "/api/v1/restaurants/#{restaurant.id}/items", headers: headers
+
+      body = response.parsed_body
+      expect(body["items"].pluck("name")).to eq(["Plain Noodles", "Spicy Basil Curry"])
+      expect(body["items"].pluck("taste_score").uniq).to eq([nil])
+    end
+  end
+
+  describe "signed-in user with taste signals" do
+    before do
+      user.profile.update!(liked_tag_ids: [spicy_tag.id], liked_ingredient_ids: [basil.id])
+    end
+
+    it "scores every item and re-sorts by taste_score desc" do
+      get "/api/v1/restaurants/#{restaurant.id}/items", headers: headers
+
+      body = response.parsed_body
+      expect(body["items"].pluck("name")).to eq(["Spicy Basil Curry", "Plain Noodles"])
+
+      curry = body["items"].first
+      # 2.0 (spicy tag) + 1.0 (basil) + 0.5 * (10/90) popularity term.
+      expect(curry["taste_score"]).to be_within(0.00005).of(3.0 + 0.5 * (10.0 / 90))
+      expect(curry["taste_reasons"]).to eq([
+        { "kind" => "liked_tag", "tag_id" => spicy_tag.id, "tag_name" => "Spicy" },
+        { "kind" => "liked_ingredient", "ingredient_id" => basil.id, "ingredient_name" => "Basil" }
+      ])
+
+      noodles = body["items"].last
+      expect(noodles["taste_score"]).to be_within(0.00005).of(0.5) # max popularity only
+      expect(noodles["taste_reasons"]).to eq([])
+    end
+
+    it "never hides an item via taste — low scores stay visible" do
+      user.profile.update!(disliked_tag_ids: [spicy_tag.id], liked_tag_ids: [], liked_ingredient_ids: [])
+
+      get "/api/v1/restaurants/#{restaurant.id}/items", headers: headers
+
+      curry = response.parsed_body["items"].find { |i| i["name"] == "Spicy Basil Curry" }
+      expect(curry["taste_score"]).to be < 0
+      expect(curry["status"]).to eq("visible")
+      expect(curry["reasons"]).to be_empty
+    end
+
+    it "ignores an id that also sits in an avoid list (filter wins)" do
+      user.profile.update!(avoid_tag_ids: [spicy_tag.id])
+
+      get "/api/v1/restaurants/#{restaurant.id}/items", headers: headers
+
+      curry = response.parsed_body["items"].find { |i| i["name"] == "Spicy Basil Curry" }
+      expect(curry["status"]).to eq("hidden") # the avoid still filters
+      # The liked tag scored nothing and is not cited as a reason-to-like;
+      # only the basil like survives.
+      expect(curry["taste_reasons"].pluck("kind")).to eq(["liked_ingredient"])
+      expect(curry["taste_score"]).to be_within(0.00005).of(1.0 + 0.5 * (10.0 / 90))
+    end
+
+    it "turns taste off when the caller picks a preset (?profile=)" do
+      preset = create(:dietary_profile, slug: "vegan")
+
+      get "/api/v1/restaurants/#{restaurant.id}/items",
+          params: { profile: preset.slug }, headers: headers
+
+      body = response.parsed_body
+      expect(body["filter"]["source"]).to eq("preset")
+      expect(body["items"].pluck("taste_score").uniq).to eq([nil])
+    end
+  end
+end

--- a/apps/api/spec/services/taste_scoring_spec.rb
+++ b/apps/api/spec/services/taste_scoring_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+# Phase 8.2 — SQL half of the SQL ↔ TS scoring parity contract.
+#
+# Loads the SAME fixture the filter-engine vitest suite asserts
+# against (packages/filter-engine/fixtures/taste-parity.json),
+# materializes its items in Postgres (real join rows so the
+# denormalized arrays sync; real reviews so AVG(rating) is the real
+# aggregate), and asserts TasteScoring's SQL produces the fixture's
+# expected scores to 4 decimal places. If either implementation
+# drifts, its half of this contract fails.
+RSpec.describe TasteScoring do
+  fixture_path = Rails.root.join("../../packages/filter-engine/fixtures/taste-parity.json")
+  fixture      = JSON.parse(File.read(fixture_path))
+
+  let(:restaurant) { create(:restaurant, :published) }
+
+  let!(:taxonomy) do
+    fixture["tags"].each do |id, name|
+      create(:tag, id: id, name: name, slug: name.parameterize)
+    end
+    fixture["ingredients"].each do |id, name|
+      create(:ingredient, id: id, name: name, slug: name.parameterize)
+    end
+  end
+
+  let!(:items) do
+    fixture["items"].map do |row|
+      item = create(:item, :published,
+                    id:         row["id"],
+                    restaurant: restaurant,
+                    name:       row["name"],
+                    popularity: row["popularity"],
+                    ingredients: Ingredient.where(id: row["ingredient_ids"]),
+                    tag_list:    Tag.where(id: row["tag_ids"]))
+      row["review_ratings"].each { |rating| create(:review, item: item, rating: rating) }
+      item
+    end
+  end
+
+  fixture["profiles"].each do |profile|
+    context "profile: #{profile['key']}" do
+      let(:signals) do
+        described_class::Signals.new(
+          liked_ingredient_ids:    profile["liked_ingredient_ids"]    - profile["avoid_ingredient_ids"],
+          liked_tag_ids:           profile["liked_tag_ids"]           - profile["avoid_tag_ids"],
+          disliked_ingredient_ids: profile["disliked_ingredient_ids"] - profile["avoid_ingredient_ids"],
+          disliked_tag_ids:        profile["disliked_tag_ids"]        - profile["avoid_tag_ids"]
+        )
+      end
+
+      fixture["items"].each do |row|
+        expected = row["expected"][profile["key"]]
+        next if expected.nil?
+
+        it "scores \"#{row['name']}\" = #{expected['score']}" do
+          scores = described_class.scores_for(restaurant_id: restaurant.id, signals: signals)
+          result = scores.fetch(row["id"])
+
+          expect(result[:score]).to be_within(0.00005).of(expected["score"])
+          expect(result[:matched_liked_tag_ids]).to        eq(expected["matched_liked_tag_ids"])
+          expect(result[:matched_liked_ingredient_ids]).to eq(expected["matched_liked_ingredient_ids"])
+        end
+      end
+    end
+  end
+
+  describe "scoping" do
+    it "scores only published items at the given restaurant" do
+      create(:item, restaurant: restaurant, name: "Draft Special", popularity: 999) # status: draft
+      other = create(:restaurant, :published)
+      create(:item, :published, restaurant: other, name: "Elsewhere", popularity: 1)
+
+      scores = described_class.scores_for(
+        restaurant_id: restaurant.id,
+        signals:       described_class::Signals.new(
+          liked_ingredient_ids: [], liked_tag_ids: [fixture["tags"].keys.first],
+          disliked_ingredient_ids: [], disliked_tag_ids: []
+        )
+      )
+      expect(scores.keys).to match_array(items.map(&:id))
+    end
+
+    it "ignores hidden reviews in the rating term" do
+      plate = items.find { |i| i.name == "Cheese Plate" } # unreviewed in fixture
+      create(:review, item: plate, rating: 5, hidden_at: Time.current)
+
+      scores = described_class.scores_for(
+        restaurant_id: restaurant.id,
+        signals:       described_class::Signals.new(
+          liked_ingredient_ids: [], liked_tag_ids: [fixture["tags"].keys.first],
+          disliked_ingredient_ids: [], disliked_tag_ids: []
+        )
+      )
+      # Still no rating term: 0.5 * (50/100) only.
+      expect(scores.fetch(plate.id)[:score]).to be_within(0.00005).of(0.25)
+    end
+  end
+end

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -572,6 +572,44 @@
                                 }
                               }
                             }
+                          },
+                          "taste_score": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "taste_reasons": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "kind"
+                              ],
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "liked_tag",
+                                    "liked_ingredient"
+                                  ]
+                                },
+                                "tag_id": {
+                                  "type": "string",
+                                  "format": "uuid"
+                                },
+                                "tag_name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "ingredient_id": {
+                                  "type": "string",
+                                  "format": "uuid"
+                                },
+                                "ingredient_name": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              }
+                            }
                           }
                         }
                       }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,7 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 8.2 — taste scoring engine (SQL + filter-engine parity, one PR)** (`docs/plans/phase-8.md`)
-7. **Phase 8.3 — Top Picks UI (web)**
+1. **Phase 8.3 — Top Picks UI (web)** (`docs/plans/phase-8.md`)
 8. **Phase 8.4 — Top Picks UI (mobile)**
 9. **Phase 8.5 — taste onboarding step (web + mobile)**
 15. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
@@ -104,7 +103,8 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 7.1 — real expo-camera capture via ref (#306)
 - ✅ Phase 7.2 — real mobile home screen: search + scan CTA; near-me deferred pending expo-location (#307)
 - ✅ Phase 7.3 — scan-to-menu flow stitched: search-miss → prefilled create → capture → stage progress → verify → deep-link to own filtered menu; re-scan entry on the menu screen (#308) — **Phase 7 feature-complete (device camera pass still pending a human phone test)**
-- ✅ Phase 8.1 — taste signal schema + profile API: 4 liked/disliked uuid[] columns, disjoint + existence validations, rswag + codegen (this PR)
+- ✅ Phase 8.1 — taste signal schema + profile API: 4 liked/disliked uuid[] columns, disjoint + existence validations, rswag + codegen (#309)
+- ✅ Phase 8.2 — taste scoring engine: SQL TasteScoring + TS scoreItem/topPicks, shared parity fixture both suites assert to 4dp, taste_score/taste_reasons on the items endpoint (this PR)
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,29 @@ without spelunking GitHub.
 
 ---
 
+2026-06-13 01:30 — tick #143. **Phase 8.2 shipped — taste scoring
+engine, SQL + TS in one PR.** #309 (8.1) auto-merged on green.
+- New TasteScoring service: one sanitized SQL query per request
+  (unnest/array_agg intersections, MAX(popularity) window,
+  AVG(visible reviews) join); weights live in WEIGHTS and reach the
+  SQL through placeholders so the constant and the expression can't
+  drift. Brakeman-clean (first draft interpolated quoted values —
+  flagged it; rewrote with sanitize_sql_array).
+- Items endpoint: taste_score + taste_reasons ("because you like…"
+  ids + names) per item; sort flips to score DESC, popularity DESC,
+  name ASC only when the signed-in caller's profile has signals
+  (presets/tokens/anonymous = untouched legacy payload, score null).
+  Taste never hides: negative-score items stay visible. Avoid-listed
+  ids subtracted from signals before scoring (filter wins).
+- filter-engine: scoreItem/topPicks/hasTasteSignals + TASTE_WEIGHTS.
+  topPicks: top-5 visible score>0, none under 3 picks; hidden items
+  still normalize popularity (matches the SQL window).
+- Parity contract: shared fixture (4 items × 2 profiles incl.
+  avoid-overlap) asserted to 4dp by BOTH vitest and rspec.
+- +21 vitest (139 total), +16 rspec (461 total: 10 parity/scoping +
+  6 endpoint). rswag items schema + openapi-export + codegen in-PR.
+Next: Phase 8.3 Top Picks UI (web).
+
 2026-06-13 00:35 — tick #142. **Phase 8.1 shipped — taste signal
 schema + profile API.** #308 (7.3) auto-merged on green. This PR:
 - Migration: liked/disliked_ingredient_ids + liked/disliked_tag_ids

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -381,6 +381,17 @@ export interface paths {
                                     /** @enum {string} */
                                     confidence?: "confirmed" | "suggested" | "inferred";
                                 }[];
+                                taste_score?: number | null;
+                                taste_reasons?: {
+                                    /** @enum {string} */
+                                    kind: "liked_tag" | "liked_ingredient";
+                                    /** Format: uuid */
+                                    tag_id?: string;
+                                    tag_name?: string | null;
+                                    /** Format: uuid */
+                                    ingredient_id?: string;
+                                    ingredient_name?: string | null;
+                                }[];
                             }[];
                         };
                     };

--- a/packages/filter-engine/fixtures/taste-parity.json
+++ b/packages/filter-engine/fixtures/taste-parity.json
@@ -1,0 +1,124 @@
+{
+  "$comment": "Phase 8.2 shared parity fixture. Consumed by BOTH packages/filter-engine/src/taste-parity.test.ts (TS scoreItem) and apps/api/spec/services/taste_scoring_spec.rb (SQL TasteScoring) — each asserts its computed scores match `expected` to 4 decimal places, so the two implementations cannot drift apart silently. review_ratings drives the rating term: TS averages the array; the rspec creates one visible review per entry. max popularity at this restaurant is 100 (Spicy Basil Curry). Profile avoid lists are subtracted from taste signals BEFORE scoring (filter wins) — the avoid-overlap profile proves a liked-but-avoided ingredient contributes nothing and never appears in matched ids.",
+  "profiles": [
+    {
+      "key": "taster",
+      "liked_tag_ids": ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01"],
+      "liked_ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01"],
+      "disliked_tag_ids": ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa02"],
+      "disliked_ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb02"],
+      "avoid_ingredient_ids": [],
+      "avoid_tag_ids": []
+    },
+    {
+      "key": "avoid-overlap",
+      "liked_tag_ids": [],
+      "liked_ingredient_ids": [
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb03",
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01"
+      ],
+      "disliked_tag_ids": [],
+      "disliked_ingredient_ids": [],
+      "avoid_ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb03"],
+      "avoid_tag_ids": []
+    }
+  ],
+  "tags": {
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01": "Spicy",
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa02": "Fried",
+    "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa03": "Vegan"
+  },
+  "ingredients": {
+    "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01": "Basil",
+    "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb02": "Pork",
+    "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb03": "Cheese"
+  },
+  "items": [
+    {
+      "id": "11111111-1111-4111-8111-111111111111",
+      "name": "Spicy Basil Curry",
+      "popularity": 100,
+      "tag_ids": ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01"],
+      "ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01"],
+      "review_ratings": [5],
+      "expected": {
+        "taster": {
+          "score": 4.0,
+          "matched_liked_tag_ids": ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01"],
+          "matched_liked_ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01"]
+        },
+        "avoid-overlap": {
+          "score": 2.0,
+          "matched_liked_tag_ids": [],
+          "matched_liked_ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01"]
+        }
+      }
+    },
+    {
+      "id": "22222222-2222-4222-8222-222222222222",
+      "name": "Fried Pork Belly",
+      "popularity": 80,
+      "tag_ids": ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa02"],
+      "ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb02"],
+      "review_ratings": [4, 5],
+      "expected": {
+        "taster": {
+          "score": -2.225,
+          "matched_liked_tag_ids": [],
+          "matched_liked_ingredient_ids": []
+        },
+        "avoid-overlap": {
+          "score": 0.775,
+          "matched_liked_tag_ids": [],
+          "matched_liked_ingredient_ids": []
+        }
+      }
+    },
+    {
+      "id": "33333333-3333-4333-8333-333333333333",
+      "name": "Cheese Plate",
+      "popularity": 50,
+      "tag_ids": [],
+      "ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb03"],
+      "review_ratings": [],
+      "expected": {
+        "taster": {
+          "score": 0.25,
+          "matched_liked_tag_ids": [],
+          "matched_liked_ingredient_ids": []
+        },
+        "avoid-overlap": {
+          "score": 0.25,
+          "matched_liked_tag_ids": [],
+          "matched_liked_ingredient_ids": []
+        }
+      }
+    },
+    {
+      "id": "44444444-4444-4444-8444-444444444444",
+      "name": "Garden Veg Bowl",
+      "popularity": 20,
+      "tag_ids": [
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa03",
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01"
+      ],
+      "ingredient_ids": [
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01",
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb03"
+      ],
+      "review_ratings": [3],
+      "expected": {
+        "taster": {
+          "score": 3.1,
+          "matched_liked_tag_ids": ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01"],
+          "matched_liked_ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01"]
+        },
+        "avoid-overlap": {
+          "score": 1.1,
+          "matched_liked_tag_ids": [],
+          "matched_liked_ingredient_ids": ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbb01"]
+        }
+      }
+    }
+  ]
+}

--- a/packages/filter-engine/src/index.ts
+++ b/packages/filter-engine/src/index.ts
@@ -284,6 +284,18 @@ export {
   type OnboardingAction,
 } from './onboarding-reducer';
 
+// ─── Taste scoring (Phase 8.2) ─────────────────────────────────────
+
+export {
+  hasTasteSignals,
+  scoreItem,
+  topPicks,
+  TASTE_WEIGHTS,
+  type ScorableItem,
+  type TasteProfile,
+  type TasteScore,
+} from './taste';
+
 // ─── Shareable profile tokens (Phase 3.9) ──────────────────────────
 
 export {

--- a/packages/filter-engine/src/taste-parity.test.ts
+++ b/packages/filter-engine/src/taste-parity.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Phase 8.2 — TS half of the SQL ↔ TS scoring parity contract.
+ *
+ * The fixture at ../fixtures/taste-parity.json is ALSO loaded by
+ * `apps/api/spec/services/taste_scoring_spec.rb`, which inserts the
+ * same items into Postgres and asserts the SQL scores match the same
+ * `expected` values to 4 decimal places. If either implementation
+ * drifts, its half of this contract fails.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { scoreItem, type TasteProfile } from './taste';
+
+interface FixtureItem {
+  id: string;
+  name: string;
+  popularity: number;
+  tag_ids: string[];
+  ingredient_ids: string[];
+  review_ratings: number[];
+  expected: Record<
+    string,
+    { score: number; matched_liked_tag_ids: string[]; matched_liked_ingredient_ids: string[] }
+  >;
+}
+
+interface Fixture {
+  profiles: Array<TasteProfile & { key: string }>;
+  items: FixtureItem[];
+}
+
+const fixture: Fixture = JSON.parse(
+  readFileSync(new URL('../fixtures/taste-parity.json', import.meta.url), 'utf8'),
+);
+
+const maxPopularity = Math.max(...fixture.items.map((i) => i.popularity));
+
+const avgRating = (ratings: number[]): number | null =>
+  ratings.length === 0 ? null : ratings.reduce((a, b) => a + b, 0) / ratings.length;
+
+describe('SQL ↔ TS taste-scoring parity (shared fixture)', () => {
+  for (const profile of fixture.profiles) {
+    describe(`profile: ${profile.key}`, () => {
+      for (const fixtureItem of fixture.items) {
+        const expected = fixtureItem.expected[profile.key];
+        if (!expected) continue;
+
+        it(`scores "${fixtureItem.name}" = ${expected.score}`, () => {
+          const result = scoreItem(
+            {
+              id: fixtureItem.id,
+              name: fixtureItem.name,
+              popularity: fixtureItem.popularity,
+              tag_ids: fixtureItem.tag_ids,
+              ingredient_ids: fixtureItem.ingredient_ids,
+              avg_rating: avgRating(fixtureItem.review_ratings),
+            },
+            profile,
+            { maxPopularity },
+          );
+
+          expect(result.score).toBeCloseTo(expected.score, 4);
+          expect(result.matched_liked_tag_ids).toEqual(expected.matched_liked_tag_ids);
+          expect(result.matched_liked_ingredient_ids).toEqual(
+            expected.matched_liked_ingredient_ids,
+          );
+        });
+      }
+    });
+  }
+});

--- a/packages/filter-engine/src/taste.test.ts
+++ b/packages/filter-engine/src/taste.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Phase 8.2 — taste scoring unit tests. The cross-implementation
+ * fixture lives in taste-parity.test.ts; these lock the behaviors the
+ * subplan calls out by name: zero-signal no-op, dislike outweighs
+ * popularity, unreviewed items get no rating term, and the Top Picks
+ * thresholds ("don't fake enthusiasm").
+ */
+import { describe, expect, it } from 'vitest';
+import { hasTasteSignals, scoreItem, topPicks, type ScorableItem, type TasteProfile } from './taste';
+
+const emptyProfile: TasteProfile = {
+  liked_ingredient_ids: [],
+  liked_tag_ids: [],
+  disliked_ingredient_ids: [],
+  disliked_tag_ids: [],
+};
+
+const item = (overrides: Partial<ScorableItem> & { id: string }): ScorableItem => ({
+  name: overrides.id,
+  popularity: 0,
+  ingredient_ids: [],
+  tag_ids: [],
+  ...overrides,
+});
+
+describe('hasTasteSignals', () => {
+  it('is false for empty arrays (zero-signal no-op)', () => {
+    expect(hasTasteSignals(emptyProfile)).toBe(false);
+  });
+
+  it('is false when every signal is cancelled by an avoid list (filter wins)', () => {
+    expect(
+      hasTasteSignals({
+        ...emptyProfile,
+        liked_ingredient_ids: ['ing-cheese'],
+        avoid_ingredient_ids: ['ing-cheese'],
+      }),
+    ).toBe(false);
+  });
+
+  it('is true with any surviving signal', () => {
+    expect(hasTasteSignals({ ...emptyProfile, liked_tag_ids: ['tag-spicy'] })).toBe(true);
+  });
+});
+
+describe('scoreItem', () => {
+  it('a dislike (-2 per tag) outweighs maximum popularity (+0.5)', () => {
+    const profile = { ...emptyProfile, disliked_tag_ids: ['tag-fried'] };
+    const popular = item({ id: 'i1', tag_ids: ['tag-fried'], popularity: 100 });
+
+    const { score } = scoreItem(popular, profile, { maxPopularity: 100 });
+    expect(score).toBe(-2 + 0.5);
+  });
+
+  it('unreviewed items get no rating term (not a penalty)', () => {
+    const unreviewed = item({ id: 'i1', popularity: 50 });
+    const reviewedBad = item({ id: 'i2', popularity: 50, avg_rating: 1 });
+
+    const unreviewedScore = scoreItem(unreviewed, emptyProfile, { maxPopularity: 100 }).score;
+    const badScore = scoreItem(reviewedBad, emptyProfile, { maxPopularity: 100 }).score;
+
+    expect(unreviewedScore).toBe(0.25); // popularity term only
+    expect(badScore).toBe(0.25 + 0.5 * ((1 - 3) / 2)); // 1-star drags below
+    expect(unreviewedScore).toBeGreaterThan(badScore);
+  });
+
+  it('an avoided id neither scores nor appears in matched ids', () => {
+    const profile: TasteProfile = {
+      ...emptyProfile,
+      liked_ingredient_ids: ['ing-cheese', 'ing-basil'],
+      avoid_ingredient_ids: ['ing-cheese'],
+    };
+    const dish = item({ id: 'i1', ingredient_ids: ['ing-cheese', 'ing-basil'] });
+
+    const result = scoreItem(dish, profile, { maxPopularity: 0 });
+    expect(result.score).toBe(1); // basil only
+    expect(result.matched_liked_ingredient_ids).toEqual(['ing-basil']);
+  });
+
+  it('guards the popularity term when the restaurant max is 0', () => {
+    const dish = item({ id: 'i1', popularity: 0 });
+    expect(scoreItem(dish, emptyProfile, { maxPopularity: 0 }).score).toBe(0);
+  });
+});
+
+describe('topPicks', () => {
+  const likesSpice = { ...emptyProfile, liked_tag_ids: ['tag-spicy'] };
+  const spicy = (id: string, popularity: number) =>
+    item({ id, tag_ids: ['tag-spicy'], popularity });
+
+  it('returns [] with no taste signals even when items would score > 0', () => {
+    const items = [spicy('a', 10), spicy('b', 20), spicy('c', 30)];
+    expect(topPicks(items, emptyProfile)).toEqual([]);
+  });
+
+  it('returns [] below 3 positive-score items (no fake enthusiasm)', () => {
+    expect(topPicks([spicy('a', 10), spicy('b', 20)], likesSpice)).toEqual([]);
+  });
+
+  it('caps at n, excludes hidden items, sorts score desc → popularity desc → name asc', () => {
+    const items = [
+      { ...spicy('hidden-best', 100), status: 'hidden' as const },
+      spicy('low-pop', 10),
+      spicy('high-pop', 90),
+      // Same score as high-pop is impossible here (popularity term differs),
+      // so tie-break via two no-signal-match items with equal everything but name.
+      spicy('mid-pop', 50),
+      item({ id: 'no-match', popularity: 100 }),
+    ];
+
+    const picks = topPicks(items, likesSpice, 3);
+    expect(picks.map((p) => p.id)).toEqual(['high-pop', 'mid-pop', 'low-pop']);
+    // hidden-best held max popularity (100) — it normalizes the term
+    // but can never itself be a pick.
+    expect(picks[0]!.taste_score).toBe(2 + 0.5 * (90 / 100));
+  });
+
+  it('excludes zero/negative scores entirely', () => {
+    const items = [
+      spicy('a', 10),
+      spicy('b', 20),
+      spicy('c', 30),
+      item({ id: 'meh', popularity: 0 }), // score 0 → not a pick
+    ];
+    const picks = topPicks(items, likesSpice, 5);
+    expect(picks.map((p) => p.id)).not.toContain('meh');
+    expect(picks).toHaveLength(3);
+  });
+});

--- a/packages/filter-engine/src/taste.ts
+++ b/packages/filter-engine/src/taste.ts
@@ -1,0 +1,152 @@
+/**
+ * Phase 8.2 — the taste scoring engine (TS side).
+ *
+ * Mirrors `apps/api/app/services/taste_scoring.rb` EXACTLY — both
+ * implementations assert against the shared fixture at
+ * `fixtures/taste-parity.json`, and the repo rule is they change in
+ * the same PR or not at all.
+ *
+ * Design principle: **safety filters, taste ranks.** Scores reorder
+ * and highlight the items the filter already allowed; they never
+ * hide anything. If a change here is about to hide an item, stop.
+ */
+
+import type { ItemStatus } from './index';
+
+/** One place per implementation — the Ruby twin is TasteScoring::WEIGHTS. */
+export const TASTE_WEIGHTS = {
+  liked_tag: 2.0,
+  liked_ingredient: 1.0,
+  disliked_tag: 2.0, // subtracted
+  disliked_ingredient: 1.0, // subtracted
+  popularity: 0.5,
+  rating: 0.5,
+} as const;
+
+/**
+ * The four Phase 8.1 profile arrays, plus the avoid lists so scoring
+ * can honor "filter wins": an id present in an avoid list is
+ * subtracted from the taste signals before any intersection — it
+ * neither scores nor shows up in matched ids.
+ */
+export interface TasteProfile {
+  liked_ingredient_ids: string[];
+  liked_tag_ids: string[];
+  disliked_ingredient_ids: string[];
+  disliked_tag_ids: string[];
+  avoid_ingredient_ids?: string[];
+  avoid_tag_ids?: string[];
+}
+
+/** Minimum item shape scoring needs. `avg_rating` is the visible-review
+ * average (null/omitted when unreviewed — the rating term is then 0). */
+export interface ScorableItem {
+  id: string;
+  name?: string;
+  popularity: number;
+  ingredient_ids: string[];
+  tag_ids: string[];
+  avg_rating?: number | null;
+}
+
+export interface TasteScore {
+  score: number;
+  /** Sorted ascending — same ORDER BY the SQL emits. */
+  matched_liked_tag_ids: string[];
+  matched_liked_ingredient_ids: string[];
+}
+
+export function hasTasteSignals(profile: TasteProfile): boolean {
+  const effective = effectiveSignals(profile);
+  return (
+    effective.likedTags.size > 0 ||
+    effective.likedIngredients.size > 0 ||
+    effective.dislikedTags.size > 0 ||
+    effective.dislikedIngredients.size > 0
+  );
+}
+
+function effectiveSignals(profile: TasteProfile) {
+  const avoidIngredients = new Set(profile.avoid_ingredient_ids ?? []);
+  const avoidTags = new Set(profile.avoid_tag_ids ?? []);
+  const minus = (ids: string[], avoid: Set<string>) => new Set(ids.filter((id) => !avoid.has(id)));
+  return {
+    likedTags: minus(profile.liked_tag_ids, avoidTags),
+    likedIngredients: minus(profile.liked_ingredient_ids, avoidIngredients),
+    dislikedTags: minus(profile.disliked_tag_ids, avoidTags),
+    dislikedIngredients: minus(profile.disliked_ingredient_ids, avoidIngredients),
+  };
+}
+
+/**
+ * Score one item. `maxPopularity` must be the max popularity across
+ * ALL published items at the restaurant (visible and hidden) — the
+ * SQL computes it as a window over the whole restaurant; pass the
+ * same scope or parity breaks. `topPicks` handles this for you.
+ */
+export function scoreItem(
+  item: ScorableItem,
+  profile: TasteProfile,
+  opts: { maxPopularity: number },
+): TasteScore {
+  const { likedTags, likedIngredients, dislikedTags, dislikedIngredients } =
+    effectiveSignals(profile);
+
+  const matchedLikedTagIds = item.tag_ids.filter((t) => likedTags.has(t)).sort();
+  const matchedLikedIngredientIds = item.ingredient_ids
+    .filter((i) => likedIngredients.has(i))
+    .sort();
+  const dislikedTagCount = item.tag_ids.filter((t) => dislikedTags.has(t)).length;
+  const dislikedIngredientCount = item.ingredient_ids.filter((i) =>
+    dislikedIngredients.has(i),
+  ).length;
+
+  const popularityTerm =
+    opts.maxPopularity > 0 ? item.popularity / opts.maxPopularity : 0;
+  const ratingTerm = item.avg_rating == null ? 0 : (item.avg_rating - 3) / 2;
+
+  const score =
+    TASTE_WEIGHTS.liked_tag * matchedLikedTagIds.length +
+    TASTE_WEIGHTS.liked_ingredient * matchedLikedIngredientIds.length -
+    TASTE_WEIGHTS.disliked_tag * dislikedTagCount -
+    TASTE_WEIGHTS.disliked_ingredient * dislikedIngredientCount +
+    TASTE_WEIGHTS.popularity * popularityTerm +
+    TASTE_WEIGHTS.rating * ratingTerm;
+
+  return {
+    score,
+    matched_liked_tag_ids: matchedLikedTagIds,
+    matched_liked_ingredient_ids: matchedLikedIngredientIds,
+  };
+}
+
+/**
+ * Top Picks = the n highest-scoring VISIBLE items with score > 0.
+ * Fewer than 3 positive-score items → empty array (don't fake
+ * enthusiasm). `items` should be every published item at the
+ * restaurant — hidden items don't qualify as picks but they DO count
+ * toward max popularity, matching the SQL window.
+ */
+export function topPicks<T extends ScorableItem & { status?: ItemStatus }>(
+  items: T[],
+  profile: TasteProfile,
+  n = 5,
+): Array<T & { taste_score: number }> {
+  if (!hasTasteSignals(profile)) return [];
+
+  const maxPopularity = items.reduce((max, i) => Math.max(max, i.popularity), 0);
+  const positive = items
+    .filter((i) => i.status !== 'hidden')
+    .map((i) => ({ ...i, taste_score: scoreItem(i, profile, { maxPopularity }).score }))
+    .filter((i) => i.taste_score > 0);
+
+  if (positive.length < 3) return [];
+
+  positive.sort(
+    (a, b) =>
+      b.taste_score - a.taste_score ||
+      b.popularity - a.popularity ||
+      (a.name ?? '').localeCompare(b.name ?? ''),
+  );
+  return positive.slice(0, n);
+}


### PR DESCRIPTION
## What

Phase 8.2 (`docs/plans/phase-8.md`) — both halves of the v1 scoring model in one PR, per the repo rule that the SQL and the TS filter-engine change together.

```
score = 2.0*|tags∩liked| + 1.0*|ings∩liked| − 2.0*|tags∩disliked| − 1.0*|ings∩disliked|
      + 0.5*(popularity / max_at_restaurant) + 0.5*(avg_visible_rating − 3)/2   (0 unreviewed)
```

**Design principle held throughout: safety filters, taste ranks.** Scores reorder and annotate; a negative score never hides an item (there's a spec asserting exactly that).

### API
- **`TasteScoring`** service — one query per request: `unnest`/`array_agg` intersections (no `intarray`-style operators exist for `uuid[]`), `MAX(popularity) OVER ()` for normalization, `AVG(rating)` over visible reviews. Weights, signal arrays, and restaurant id all reach the SQL through `sanitize_sql_array` placeholders — brakeman 0 warnings (the first draft interpolated quoted values; brakeman flagged it, rewritten properly).
- **Items endpoint**: `taste_score: number|null` + `taste_reasons[]` (matched liked tag/ingredient ids enriched with names for the "because you like…" line). Sort flips to `score DESC, popularity DESC, name ASC` **only** when the signed-in caller's saved profile carries taste signals. Anonymous, preset (`?profile=`), and share-token callers get the byte-identical legacy payload. Avoid-listed ids are subtracted from signals before scoring (Phase 8.1's "filter wins" contract).

### filter-engine
- `scoreItem` / `topPicks` / `hasTasteSignals` + `TASTE_WEIGHTS` mirroring the SQL exactly. `topPicks`: top-5 *visible* items with score > 0, empty below 3 positive picks ("don't fake enthusiasm"); hidden items still feed the popularity max, matching the SQL window.

### Parity contract
`packages/filter-engine/fixtures/taste-parity.json` — 4 items × 2 profiles (including the avoid-overlap case proving a liked-but-avoided id contributes nothing and never appears in matched ids). **Both** suites load the same file: vitest asserts the TS scores, rspec materializes the items in Postgres (real join rows, real reviews) and asserts the SQL scores — each to 4 decimal places. Either implementation drifting fails its half.

### Contract chain
rswag items schema (+`taste_score`, +`taste_reasons`) → `bin/openapi-export` → api-types codegen, all in-PR.

## Tests

- +21 vitest (filter-engine **139/139**): parity fixture, zero-signal no-op, dislike-outweighs-popularity, unreviewed-no-rating-term, topPicks thresholds/sorting/hidden-exclusion
- +16 rspec (**461/461**): 10 parity + scoping (published-only, hidden reviews ignored), 6 endpoint (anonymous unchanged, zero-signal no-op, score+sort+reasons, never-hides, avoid-overlap, preset-disables-taste)
- brakeman 0 warnings; `pnpm typecheck`/`lint`/`test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)