### PR TITLE
feat(web): Top Picks row on the restaurant page (Phase 8.3)

### DIFF
--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -22,6 +22,7 @@ import {
   type RestaurantItemsResponse,
 } from '../../../lib/restaurants';
 import { ItemRow } from './ItemRow';
+import { TopPicksRow } from './TopPicksRow';
 import { useTracker } from '../../_PostHogProvider';
 
 /**
@@ -50,6 +51,9 @@ export function RestaurantClient({
 }) {
   const tracker = useTracker();
   const [filter, setFilter] = useState<FilterSummary>(initialItems.filter);
+  // Phase 8.3 — the raw (server-sorted) items feed the Top Picks row;
+  // the section state below still drives the main menu + overrides.
+  const [rawItems, setRawItems] = useState<RestaurantItem[]>(initialItems.items);
   const [sections, setSections] = useState<ItemSection<RestaurantItem>[]>(() =>
     groupItemsBySection(initialItems.items),
   );
@@ -94,6 +98,7 @@ export function RestaurantClient({
         .then((res) => {
           if (cancelled) return;
           setFilter(res.filter);
+          setRawItems(res.items);
           setSections(groupItemsBySection(res.items));
           setShownAnyway(new Set());
           const totalVisible = res.items.filter((it) => it.status === 'visible').length;
@@ -189,6 +194,8 @@ export function RestaurantClient({
           Could not refresh items — {error}
         </p>
       )}
+
+      <TopPicksRow items={rawItems} restaurantSlug={slug} />
 
       {overriddenSections.length === 0 && (
         <p className="mt-bw-6 text-center text-bw-base text-zinc-500">

--- a/apps/web/src/app/restaurants/[slug]/TopPicksRow.tsx
+++ b/apps/web/src/app/restaurants/[slug]/TopPicksRow.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState } from 'react';
+import type { RestaurantItem, TasteReason } from '../../../lib/restaurants';
+
+/**
+ * Phase 8.3 — "Top picks for you", rendered above the menu sections.
+ *
+ * Uses the SERVER's taste_score/taste_reasons (Phase 8.2) — the
+ * client never recomputes scores here, it just selects. Thresholds
+ * mirror filter-engine's topPicks: the 5 highest-scoring visible
+ * items with score > 0, and nothing at all below 3 positive items
+ * (don't fake enthusiasm). Anonymous and zero-signal users have
+ * taste_score = null on every item, so this renders nothing and the
+ * page is byte-identical to the pre-8.3 layout.
+ *
+ * Copy rule: taste ≠ safety. Nothing here may imply a low-scored
+ * item is unsafe — the picks are "more likely to enjoy", the rest of
+ * the menu is exactly as safe as the filter says.
+ */
+
+const TOP_PICKS_COUNT = 5;
+const MIN_POSITIVE_PICKS = 3;
+
+export function topPicksFromScores(items: RestaurantItem[]): RestaurantItem[] {
+  const positive = items.filter(
+    (i) => i.status === 'visible' && typeof i.taste_score === 'number' && i.taste_score > 0,
+  );
+  if (positive.length < MIN_POSITIVE_PICKS) return [];
+  return [...positive]
+    .sort(
+      (a, b) =>
+        b.taste_score! - a.taste_score! ||
+        b.popularity - a.popularity ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, TOP_PICKS_COUNT);
+}
+
+export function tasteReasonLine(reasons: TasteReason[] | undefined): string | null {
+  const names = (reasons ?? [])
+    .map((r) => (r.kind === 'liked_tag' ? r.tag_name : r.ingredient_name))
+    .filter((n): n is string => !!n);
+  if (names.length === 0) return null;
+  const list =
+    names.length === 1
+      ? names[0]
+      : `${names.slice(0, -1).join(', ')} & ${names[names.length - 1]}`;
+  return `Because you like ${list}`;
+}
+
+export function TopPicksRow({
+  items,
+  restaurantSlug,
+}: {
+  items: RestaurantItem[];
+  restaurantSlug: string;
+}) {
+  const [whyOpen, setWhyOpen] = useState(false);
+  const picks = topPicksFromScores(items);
+  if (picks.length === 0) return null;
+
+  return (
+    <section data-testid="top-picks" className="mt-bw-6">
+      <div className="flex items-baseline gap-bw-2">
+        <h2 className="text-bw-lg font-bold">Top picks for you</h2>
+        <button
+          type="button"
+          data-testid="why-these"
+          aria-expanded={whyOpen}
+          onClick={() => setWhyOpen((v) => !v)}
+          className="text-bw-xs font-semibold text-bite hover:text-bite-dark"
+        >
+          Why these?
+        </button>
+      </div>
+      {whyOpen && (
+        <p data-testid="why-these-explainer" className="mt-bw-1 text-bw-sm text-zinc-500">
+          Ranked from the tags and ingredients you said you love in your taste profile.
+          Everything below passed your dietary filter too — these are just the dishes
+          you&rsquo;re most likely to enjoy.
+        </p>
+      )}
+      <ul className="mt-bw-2 flex gap-bw-3 overflow-x-auto pb-bw-2">
+        {picks.map((item) => {
+          const reason = tasteReasonLine(item.taste_reasons);
+          return (
+            <li
+              key={item.id}
+              data-testid={`top-pick-${item.id}`}
+              className="w-44 shrink-0 rounded-bw-md border border-zinc-200 p-bw-2"
+            >
+              <a
+                href={`/restaurants/${encodeURIComponent(restaurantSlug)}/items/${encodeURIComponent(item.id)}`}
+                className="block"
+              >
+                {item.photo_url && (
+                  <img
+                    src={item.photo_url}
+                    alt={item.name}
+                    loading="lazy"
+                    className="mb-bw-2 h-28 w-full rounded-bw-md object-cover"
+                  />
+                )}
+                <p className="text-bw-sm font-semibold text-zinc-900">{item.name}</p>
+                {reason && (
+                  <p
+                    data-testid={`pick-reason-${item.id}`}
+                    className="mt-1 text-bw-xs text-bite-dark"
+                  >
+                    {reason}
+                  </p>
+                )}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/app/restaurants/[slug]/__tests__/TopPicksRow.test.tsx
+++ b/apps/web/src/app/restaurants/[slug]/__tests__/TopPicksRow.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { tasteReasonLine, TopPicksRow, topPicksFromScores } from '../TopPicksRow';
+import type { RestaurantItem } from '../../../../lib/restaurants';
+
+/**
+ * Phase 8.3 — Top Picks row. Renders only from server-provided
+ * taste_score/taste_reasons (Phase 8.2); anonymous payloads carry
+ * null scores, so the row must vanish entirely — that's the
+ * "anonymous unchanged" contract.
+ */
+
+const item = (overrides: Partial<RestaurantItem> & { id: string }): RestaurantItem => ({
+  restaurant_id: 'rest-1',
+  name: overrides.id,
+  description: '',
+  popularity: 0,
+  ingredient_ids: [],
+  tag_ids: [],
+  confidence: 'confirmed',
+  menu_section_id: null,
+  menu_section_name: null,
+  status: 'visible',
+  reasons: [],
+  photo_url: null,
+  ...overrides,
+});
+
+const scored = (id: string, taste_score: number, popularity = 0) =>
+  item({ id, taste_score, popularity });
+
+describe('topPicksFromScores', () => {
+  it('returns [] below 3 positive-score items (no fake enthusiasm)', () => {
+    expect(topPicksFromScores([scored('a', 2), scored('b', 1), scored('c', 0)])).toEqual([]);
+  });
+
+  it('returns [] when scores are null (anonymous / zero-signal payload)', () => {
+    const items = [item({ id: 'a' }), item({ id: 'b' }), item({ id: 'c' })];
+    expect(topPicksFromScores(items)).toEqual([]);
+  });
+
+  it('excludes hidden items even with positive scores', () => {
+    const items = [
+      scored('a', 3),
+      scored('b', 2),
+      { ...scored('hidden', 5), status: 'hidden' as const },
+      scored('c', 1),
+    ];
+    expect(topPicksFromScores(items).map((i) => i.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('caps at 5, sorted score desc → popularity desc → name asc', () => {
+    const items = [
+      scored('f', 1),
+      scored('e', 2),
+      scored('d', 3),
+      scored('tie-z', 4, 10),
+      scored('tie-a', 4, 10),
+      scored('best', 5),
+    ];
+    expect(topPicksFromScores(items).map((i) => i.id)).toEqual([
+      'best',
+      'tie-a',
+      'tie-z',
+      'd',
+      'e',
+    ]);
+  });
+});
+
+describe('tasteReasonLine', () => {
+  it('joins tag + ingredient names into the "because you like…" line', () => {
+    expect(
+      tasteReasonLine([
+        { kind: 'liked_tag', tag_id: 't1', tag_name: 'Spicy' },
+        { kind: 'liked_ingredient', ingredient_id: 'i1', ingredient_name: 'Basil' },
+      ]),
+    ).toBe('Because you like Spicy & Basil');
+  });
+
+  it('handles a single name and null names', () => {
+    expect(tasteReasonLine([{ kind: 'liked_tag', tag_id: 't1', tag_name: 'Spicy' }])).toBe(
+      'Because you like Spicy',
+    );
+    expect(tasteReasonLine([{ kind: 'liked_tag', tag_id: 't1', tag_name: null }])).toBeNull();
+    expect(tasteReasonLine(undefined)).toBeNull();
+  });
+});
+
+describe('TopPicksRow', () => {
+  const threePicks = [
+    {
+      ...scored('curry', 4),
+      name: 'Spicy Basil Curry',
+      taste_reasons: [
+        { kind: 'liked_tag' as const, tag_id: 't1', tag_name: 'Spicy' },
+        { kind: 'liked_ingredient' as const, ingredient_id: 'i1', ingredient_name: 'Basil' },
+      ],
+    },
+    { ...scored('pad', 2), name: 'Pad Thai' },
+    { ...scored('soup', 1), name: 'Tom Kha Soup' },
+  ];
+
+  it('renders the row with a reason line per pick at ≥3 positive scores', () => {
+    render(<TopPicksRow items={threePicks} restaurantSlug="ninis" />);
+
+    expect(screen.getByTestId('top-picks')).toBeInTheDocument();
+    expect(screen.getByText('Top picks for you')).toBeInTheDocument();
+    expect(screen.getByTestId('pick-reason-curry')).toHaveTextContent(
+      'Because you like Spicy & Basil',
+    );
+  });
+
+  it('renders nothing below the 3-pick threshold', () => {
+    render(<TopPicksRow items={threePicks.slice(0, 2)} restaurantSlug="ninis" />);
+    expect(screen.queryByTestId('top-picks')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for an anonymous payload (all scores null)', () => {
+    const anonymous = threePicks.map(({ taste_score: _score, taste_reasons: _r, ...rest }) => ({
+      ...rest,
+      taste_score: null,
+    }));
+    render(<TopPicksRow items={anonymous} restaurantSlug="ninis" />);
+    expect(screen.queryByTestId('top-picks')).not.toBeInTheDocument();
+  });
+
+  it('"Why these?" toggles the explainer (taste ≠ safety copy)', () => {
+    render(<TopPicksRow items={threePicks} restaurantSlug="ninis" />);
+
+    expect(screen.queryByTestId('why-these-explainer')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('why-these'));
+    expect(screen.getByTestId('why-these-explainer')).toHaveTextContent(
+      /passed your dietary filter/,
+    );
+  });
+
+  it('links each pick to its item page', () => {
+    render(<TopPicksRow items={threePicks} restaurantSlug="ninis" />);
+    const link = screen.getByTestId('top-pick-curry').querySelector('a');
+    expect(link).toHaveAttribute('href', '/restaurants/ninis/items/curry');
+  });
+});

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -60,7 +60,18 @@ export interface RestaurantItem extends FilterableItem {
    * 4.11.2 / for menu items with no inline photo.
    */
   photo_url: string | null;
+  /**
+   * Phase 8.2 — taste ranks, never hides. Null unless the signed-in
+   * caller's profile carries taste signals (Phase 8.1 arrays).
+   */
+  taste_score?: number | null;
+  /** Which liked tags/ingredients matched — the "because you like…" line. */
+  taste_reasons?: TasteReason[];
 }
+
+export type TasteReason =
+  | { kind: 'liked_tag'; tag_id: string; tag_name: string | null }
+  | { kind: 'liked_ingredient'; ingredient_id: string; ingredient_name: string | null };
 
 export interface FilterSummary {
   source: 'preset' | 'user_profile' | 'none';

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,7 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 8.3 — Top Picks UI (web)** (`docs/plans/phase-8.md`)
-8. **Phase 8.4 — Top Picks UI (mobile)**
+1. **Phase 8.4 — Top Picks UI (mobile)** (`docs/plans/phase-8.md`)
 9. **Phase 8.5 — taste onboarding step (web + mobile)**
 15. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
 16. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
@@ -104,7 +103,8 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 7.2 — real mobile home screen: search + scan CTA; near-me deferred pending expo-location (#307)
 - ✅ Phase 7.3 — scan-to-menu flow stitched: search-miss → prefilled create → capture → stage progress → verify → deep-link to own filtered menu; re-scan entry on the menu screen (#308) — **Phase 7 feature-complete (device camera pass still pending a human phone test)**
 - ✅ Phase 8.1 — taste signal schema + profile API: 4 liked/disliked uuid[] columns, disjoint + existence validations, rswag + codegen (#309)
-- ✅ Phase 8.2 — taste scoring engine: SQL TasteScoring + TS scoreItem/topPicks, shared parity fixture both suites assert to 4dp, taste_score/taste_reasons on the items endpoint (this PR)
+- ✅ Phase 8.2 — taste scoring engine: SQL TasteScoring + TS scoreItem/topPicks, shared parity fixture both suites assert to 4dp, taste_score/taste_reasons on the items endpoint (#310)
+- ✅ Phase 8.3 — Top Picks UI (web): server-score-driven row + "because you like…" lines + Why-these explainer; anonymous unchanged (this PR)
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,26 @@ without spelunking GitHub.
 
 ---
 
+2026-06-13 02:05 — tick #144. **Phase 8.3 shipped — Top Picks UI
+(web).** #310 (8.2) auto-merged on green. This PR (web-only):
+- New TopPicksRow above the menu sections: horizontal cards (photo,
+  name, "Because you like Spicy & Basil" line from taste_reasons),
+  "Why these?" explainer whose copy explicitly says everything below
+  passed the dietary filter (taste ≠ safety rule).
+- Selection uses the SERVER's Phase 8.2 scores — no client
+  recompute: top 5 visible score>0, nothing under 3 positive picks.
+  Anonymous/zero-signal payloads carry null scores → row absent,
+  page byte-identical to pre-8.3.
+- RestaurantClient keeps rawItems state alongside sections so picks
+  survive strictness refetches. taste_score/taste_reasons added to
+  the web RestaurantItem type.
+- Deviation noted: plan card lists "price" — the items endpoint has
+  no price field (prices live only on ingestion payloads), so cards
+  ship without it; surfaced rather than silently extending the API.
+- +11 vitest (web 144/144): thresholds, null-score anonymous, hidden
+  exclusion, sort ties, reason-line shapes, explainer toggle, links.
+Next: Phase 8.4 Top Picks UI (mobile).
+
 2026-06-13 01:30 — tick #143. **Phase 8.2 shipped — taste scoring
 engine, SQL + TS in one PR.** #309 (8.1) auto-merged on green.
 - New TasteScoring service: one sanitized SQL query per request


### PR DESCRIPTION
## What

Phase 8.3 (`docs/plans/phase-8.md`) — the web Top Picks surface for the Phase 8.2 scoring engine.

- **`TopPicksRow`** above the menu sections: horizontal scroll cards with photo, name, and a per-pick "Because you like Spicy & Basil" line built from `taste_reasons`. Each card links to the item page.
- **"Why these?"** toggle with an explainer whose copy enforces the taste ≠ safety rule: *"Everything below passed your dietary filter too — these are just the dishes you're most likely to enjoy."* Nothing implies a low-scored item is unsafe.
- **Selection is server-score-driven** — no client recompute. Thresholds mirror filter-engine's `topPicks`: the 5 highest-scoring *visible* items with `taste_score > 0`; nothing at all under 3 positive picks (don't fake enthusiasm).
- **Anonymous / zero-signal users unchanged**: their payloads carry `taste_score: null` on every item, the row renders nothing, and the page layout is identical to pre-8.3 (spec asserts it).
- `RestaurantClient` keeps the raw server-sorted items in state beside the derived sections so the row survives strictness-toggle refetches. `taste_score`/`taste_reasons` added to the web `RestaurantItem` type.

## Deviation from plan (surfaced)

The subplan's card spec lists "price" — the items endpoint has **no price field** (prices only exist on ingestion staging payloads, they were never materialized onto `items`). Cards ship without price rather than smuggling an API change into a UI PR. If we want prices on menus, that's its own schema task.

## Tests

+11 vitest (web **144/144**): threshold at 3, null-score anonymous payload, hidden-item exclusion despite positive score, 5-cap + score/popularity/name tie-breaks, reason-line single/multi/null-name shapes, explainer toggle, item-page links. `pnpm typecheck` + `lint` green. No API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)