### PR TITLE
feat(api): taste onboarding foundations — tags endpoint + reducer (Phase 8.5a)

### DIFF
--- a/apps/api/app/controllers/api/v1/tags_controller.rb
+++ b/apps/api/app/controllers/api/v1/tags_controller.rb
@@ -1,0 +1,43 @@
+module Api
+  module V1
+    # GET /api/v1/tags?families=cuisine,flavor&limit=50
+    #
+    # Phase 8.5 — the taste-onboarding "What do you love?" step pulls
+    # cuisine + flavor chips from here. The route existed since
+    # Phase 0 with no controller (hitting it 500'd) — same latent gap
+    # the restaurants index had (Phase 7.2).
+    #
+    # `families` filters to a comma-separated subset of Tag::FAMILIES
+    # (unknown names are ignored; an all-unknown filter returns []).
+    # Public — onboarding runs before signup.
+    class TagsController < BaseController
+      skip_before_action :authenticate_user!, only: [:index]
+
+      MAX_LIMIT     = 200
+      DEFAULT_LIMIT = 100
+
+      def index
+        limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
+        scope = Tag.order(:family, :name).limit(limit)
+
+        if params[:families].present?
+          families = params[:families].to_s.split(",").map(&:strip) & Tag::FAMILIES
+          scope = scope.where(family: families)
+        end
+
+        render json: { tags: scope.map { |t| serialize(t) } }
+      end
+
+      private
+
+      def serialize(t)
+        {
+          id:     t.id,
+          slug:   t.slug,
+          name:   t.name,
+          family: t.family
+        }
+      end
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/tags_spec.rb
+++ b/apps/api/spec/requests/api/v1/tags_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+# Phase 8.5 — tags index backing the taste-onboarding chip picker.
+# The route existed since Phase 0 with no controller action.
+RSpec.describe "GET /api/v1/tags", type: :request do
+  let!(:spicy)   { create(:tag, slug: "flavor-spicy",  name: "Spicy",   family: "flavor") }
+  let!(:thai)    { create(:tag, slug: "cuisine-thai",  name: "Thai",    family: "cuisine") }
+  let!(:vegan)   { create(:tag, slug: "diet-vegan",    name: "Vegan",   family: "diet") }
+
+  it "is public and returns id/slug/name/family per tag" do
+    get "/api/v1/tags"
+
+    expect(response).to have_http_status(:ok)
+    row = response.parsed_body["tags"].find { |t| t["slug"] == "flavor-spicy" }
+    expect(row).to eq(
+      "id" => spicy.id, "slug" => "flavor-spicy", "name" => "Spicy", "family" => "flavor"
+    )
+  end
+
+  it "filters to a comma-separated subset of families" do
+    get "/api/v1/tags", params: { families: "cuisine,flavor" }
+
+    slugs = response.parsed_body["tags"].pluck("slug")
+    expect(slugs).to contain_exactly("flavor-spicy", "cuisine-thai")
+  end
+
+  it "ignores unknown family names (whitelist, not error)" do
+    get "/api/v1/tags", params: { families: "cuisine,'); DROP TABLE tags;--" }
+
+    slugs = response.parsed_body["tags"].pluck("slug")
+    expect(slugs).to contain_exactly("cuisine-thai")
+  end
+
+  it "caps limit at 200" do
+    get "/api/v1/tags", params: { limit: 99_999 }
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["tags"].length).to be <= 200
+  end
+end

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 8.5 — taste onboarding step (web + mobile)** (`docs/plans/phase-8.md`)
+1. **Phase 8.5b — taste onboarding UI (web + mobile)** (`docs/plans/phase-8.md`) — foundations shipped in 8.5a: GET /api/v1/tags (?families=), reducer CYCLE_TASTE_TAG/INGREDIENT cycle, toProfilePayload taste arrays, toTastePayload (standalone "Improve my picks" save that can't wipe avoid lists). Remaining: the "What do you love?" step UI on both surfaces (chips from ?families=cuisine,flavor + optional ingredient search, skippable, step between strictness and review), ?step=taste standalone entry + an "Improve my picks" link, optional `taste_signal_count` prop on profile_set.
 15. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
 16. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
@@ -104,7 +104,8 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 8.1 — taste signal schema + profile API: 4 liked/disliked uuid[] columns, disjoint + existence validations, rswag + codegen (#309)
 - ✅ Phase 8.2 — taste scoring engine: SQL TasteScoring + TS scoreItem/topPicks, shared parity fixture both suites assert to 4dp, taste_score/taste_reasons on the items endpoint (#310)
 - ✅ Phase 8.3 — Top Picks UI (web): server-score-driven row + "because you like…" lines + Why-these explainer; anonymous unchanged (#311)
-- ✅ Phase 8.4 — Top Picks UI (mobile); selector + reason-line moved into filter-engine so web/mobile share one implementation (this PR)
+- ✅ Phase 8.4 — Top Picks UI (mobile); selector + reason-line moved into filter-engine so web/mobile share one implementation (#312)
+- ✅ Phase 8.5a — taste onboarding foundations: tags endpoint (Phase-0 route had no action), reducer taste cycle + payload helpers (this PR)
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,24 @@ without spelunking GitHub.
 
 ---
 
+2026-06-13 03:15 — tick #146. **Phase 8.5a shipped — taste onboarding
+foundations** (session wrapping on user request; 8.5b = the UI half,
+queued at the top of Next-up with a full handoff note).
+- GET /api/v1/tags implemented — third Phase-0 route that existed
+  with no controller (after restaurants index). Public,
+  ?families=cuisine,flavor whitelist filter, limit cap 200. +4 specs
+  (incl. injection-shaped family names ignored). rspec 465/465.
+- onboarding-reducer: 4 taste arrays in DraftProfile,
+  CYCLE_TASTE_TAG / CYCLE_TASTE_INGREDIENT (neutral → liked →
+  disliked → neutral, one tap target covers both polarities),
+  toProfilePayload now carries the four arrays (empty when step
+  skipped), NEW toTastePayload for the standalone "Improve my picks"
+  save — taste-fields-only PATCH so it can NEVER wipe the avoid
+  lists (wholesale-replace footgun, caught in design). +3 specs,
+  filter-engine 171/171; web/mobile suites untouched and green.
+Next: Phase 8.5b taste onboarding UI (web + mobile) — see Next-up
+for the precise remaining scope.
+
 2026-06-13 02:40 — tick #145. **Phase 8.4 shipped — Top Picks UI
 (mobile).** #311 (8.3) auto-merged on green. This PR:
 - filter-engine: topPicksFromScores + tasteReasonLine + TasteReason/

--- a/packages/filter-engine/src/index.ts
+++ b/packages/filter-engine/src/index.ts
@@ -278,10 +278,13 @@ export function applyOverrides<T extends FilteredItem>(
 export {
   initialDraft,
   onboardingReducer,
+  tasteStateOf,
   toProfilePayload,
+  toTastePayload,
   type DietaryPreset,
   type DraftProfile,
   type OnboardingAction,
+  type TasteState,
 } from './onboarding-reducer';
 
 // ─── Taste scoring (Phase 8.2) ─────────────────────────────────────

--- a/packages/filter-engine/src/onboarding-reducer.test.ts
+++ b/packages/filter-engine/src/onboarding-reducer.test.ts
@@ -3,6 +3,7 @@ import {
   initialDraft,
   onboardingReducer,
   toProfilePayload,
+  toTastePayload,
   type DietaryPreset,
   type DraftProfile,
 } from './onboarding-reducer';
@@ -49,6 +50,7 @@ describe('onboardingReducer', () => {
 
     it('preserves other state', () => {
       const seeded: DraftProfile = {
+        ...initialDraft,
         selectedPresetSlugs: [],
         manualIngredientIds: ['ing-cilantro'],
         strictness: 'strict',
@@ -118,6 +120,7 @@ describe('onboardingReducer', () => {
   describe('RESET', () => {
     it('returns the initial draft', () => {
       const seeded: DraftProfile = {
+        ...initialDraft,
         selectedPresetSlugs: ['vegan'],
         manualIngredientIds: ['ing-x'],
         strictness: 'strict',
@@ -137,11 +140,17 @@ describe('toProfilePayload', () => {
       avoid_tag_ids: [],
       prefer_tag_ids: [],
       strictness: 'balanced',
+      // Phase 8.5 — skipping the taste step leaves all four empty.
+      liked_tag_ids: [],
+      disliked_tag_ids: [],
+      liked_ingredient_ids: [],
+      disliked_ingredient_ids: [],
     });
   });
 
   it('unions a single preset onto manual ingredients', () => {
     const draft: DraftProfile = {
+      ...initialDraft,
       selectedPresetSlugs: ['vegan'],
       manualIngredientIds: ['ing-cilantro'],
       strictness: 'balanced',
@@ -155,6 +164,7 @@ describe('toProfilePayload', () => {
 
   it('dedupes ids that appear in multiple selected presets', () => {
     const draft: DraftProfile = {
+      ...initialDraft,
       selectedPresetSlugs: ['vegan', 'dairy-free'],
       manualIngredientIds: [],
       strictness: 'balanced',
@@ -166,6 +176,7 @@ describe('toProfilePayload', () => {
 
   it('combines presets, manual ingredients, and the strictness toggle', () => {
     const draft: DraftProfile = {
+      ...initialDraft,
       selectedPresetSlugs: ['vegan', 'tree-nut-allergy'],
       manualIngredientIds: ['ing-cilantro'],
       strictness: 'strict',
@@ -183,6 +194,7 @@ describe('toProfilePayload', () => {
 
   it('ignores selected slugs missing from the catalog (stale draft)', () => {
     const draft: DraftProfile = {
+      ...initialDraft,
       selectedPresetSlugs: ['ghost-preset', 'vegan'],
       manualIngredientIds: [],
       strictness: 'balanced',
@@ -191,5 +203,53 @@ describe('toProfilePayload', () => {
     expect(payload.avoid_ingredient_ids.sort()).toEqual(
       ['ing-dairy', 'ing-egg', 'ing-meat'].sort(),
     );
+  });
+});
+
+// Phase 8.5 — taste chips cycle neutral → liked → disliked → neutral
+// so one tap target covers both polarities; standalone saves use
+// toTastePayload so they can never wipe the avoid lists.
+describe('taste signals (Phase 8.5)', () => {
+  it('CYCLE_TASTE_TAG walks neutral → liked → disliked → neutral', () => {
+    const a = onboardingReducer(initialDraft, { type: 'CYCLE_TASTE_TAG', tagId: 't1' });
+    expect(a.likedTagIds).toEqual(['t1']);
+    expect(a.dislikedTagIds).toEqual([]);
+
+    const b = onboardingReducer(a, { type: 'CYCLE_TASTE_TAG', tagId: 't1' });
+    expect(b.likedTagIds).toEqual([]);
+    expect(b.dislikedTagIds).toEqual(['t1']);
+
+    const c = onboardingReducer(b, { type: 'CYCLE_TASTE_TAG', tagId: 't1' });
+    expect(c.likedTagIds).toEqual([]);
+    expect(c.dislikedTagIds).toEqual([]);
+  });
+
+  it('CYCLE_TASTE_INGREDIENT cycles independently of tags', () => {
+    const a = onboardingReducer(initialDraft, {
+      type: 'CYCLE_TASTE_INGREDIENT',
+      ingredientId: 'i1',
+    });
+    expect(a.likedIngredientIds).toEqual(['i1']);
+    expect(a.likedTagIds).toEqual([]);
+  });
+
+  it('toProfilePayload carries the four arrays; toTastePayload carries ONLY them', () => {
+    let draft = onboardingReducer(initialDraft, { type: 'CYCLE_TASTE_TAG', tagId: 't1' });
+    draft = onboardingReducer(draft, { type: 'CYCLE_TASTE_TAG', tagId: 't2' });
+    draft = onboardingReducer(draft, { type: 'CYCLE_TASTE_TAG', tagId: 't2' }); // → disliked
+
+    const full = toProfilePayload(draft, []);
+    expect(full.liked_tag_ids).toEqual(['t1']);
+    expect(full.disliked_tag_ids).toEqual(['t2']);
+
+    const standalone = toTastePayload(draft);
+    expect(standalone).toEqual({
+      liked_tag_ids: ['t1'],
+      disliked_tag_ids: ['t2'],
+      liked_ingredient_ids: [],
+      disliked_ingredient_ids: [],
+    });
+    // No avoid keys — a standalone PATCH cannot wipe the safety filter.
+    expect(Object.keys(standalone)).not.toContain('avoid_ingredient_ids');
   });
 });

--- a/packages/filter-engine/src/onboarding-reducer.ts
+++ b/packages/filter-engine/src/onboarding-reducer.ts
@@ -1,7 +1,8 @@
 /**
  * Phase 3.2 + 3.8 — pure reducer for the onboarding draft profile.
+ * Phase 8.5 — taste step ("What do you love?") joins the flow.
  *
- * Drives the 4-step onboarding flow on both mobile (Phase 3.2) and
+ * Drives the onboarding flow on both mobile (Phase 3.2) and
  * web (Phase 3.8). The reducer is pure so the spec verifies every
  * transition without mounting React, and the eventual
  * `PATCH /api/v1/profile` payload is the `toProfilePayload(state)`
@@ -11,6 +12,12 @@
  * preset's avoid_*_ids onto whatever's already in the draft. The
  * union+dedupe is what `toProfilePayload` does — the reducer just
  * remembers which slugs the user tapped on.
+ *
+ * Taste signals are SOFT (Phase 8 design principle: safety filters,
+ * taste ranks). Each chip cycles neutral → liked → disliked →
+ * neutral so one tap target covers both polarities. Skipping the
+ * step leaves all four arrays empty — taste is optional, safety is
+ * not.
  */
 import type { Strictness } from './index';
 
@@ -30,20 +37,59 @@ export interface DraftProfile {
   manualIngredientIds: string[];
   /** Strictness toggle. */
   strictness: Strictness;
+  /** Phase 8.5 — taste signals (rank, never hide). */
+  likedTagIds: string[];
+  dislikedTagIds: string[];
+  likedIngredientIds: string[];
+  dislikedIngredientIds: string[];
 }
 
 export const initialDraft: DraftProfile = {
   selectedPresetSlugs: [],
   manualIngredientIds: [],
   strictness: 'balanced',
+  likedTagIds: [],
+  dislikedTagIds: [],
+  likedIngredientIds: [],
+  dislikedIngredientIds: [],
 };
+
+export type TasteState = 'neutral' | 'liked' | 'disliked';
 
 export type OnboardingAction =
   | { type: 'TOGGLE_PRESET'; slug: string }
   | { type: 'ADD_MANUAL_INGREDIENT'; ingredientId: string }
   | { type: 'REMOVE_MANUAL_INGREDIENT'; ingredientId: string }
   | { type: 'SET_STRICTNESS'; strictness: Strictness }
+  | { type: 'CYCLE_TASTE_TAG'; tagId: string }
+  | { type: 'CYCLE_TASTE_INGREDIENT'; ingredientId: string }
   | { type: 'RESET' };
+
+export function tasteStateOf(
+  id: string,
+  liked: string[],
+  disliked: string[],
+): TasteState {
+  if (liked.includes(id)) return 'liked';
+  if (disliked.includes(id)) return 'disliked';
+  return 'neutral';
+}
+
+/** neutral → liked → disliked → neutral. */
+function cycle(
+  id: string,
+  liked: string[],
+  disliked: string[],
+): { liked: string[]; disliked: string[] } {
+  switch (tasteStateOf(id, liked, disliked)) {
+    case 'neutral':
+      return { liked: [...liked, id], disliked };
+    case 'liked':
+      return { liked: liked.filter((x) => x !== id), disliked: [...disliked, id] };
+    case 'disliked':
+      return { liked, disliked: disliked.filter((x) => x !== id) };
+  }
+}
 
 export function onboardingReducer(state: DraftProfile, action: OnboardingAction): DraftProfile {
   switch (action.type) {
@@ -70,6 +116,18 @@ export function onboardingReducer(state: DraftProfile, action: OnboardingAction)
       };
     case 'SET_STRICTNESS':
       return { ...state, strictness: action.strictness };
+    case 'CYCLE_TASTE_TAG': {
+      const next = cycle(action.tagId, state.likedTagIds, state.dislikedTagIds);
+      return { ...state, likedTagIds: next.liked, dislikedTagIds: next.disliked };
+    }
+    case 'CYCLE_TASTE_INGREDIENT': {
+      const next = cycle(
+        action.ingredientId,
+        state.likedIngredientIds,
+        state.dislikedIngredientIds,
+      );
+      return { ...state, likedIngredientIds: next.liked, dislikedIngredientIds: next.disliked };
+    }
     case 'RESET':
       return initialDraft;
   }
@@ -79,7 +137,8 @@ export function onboardingReducer(state: DraftProfile, action: OnboardingAction)
  * Compose the final avoid lists for `PATCH /api/v1/profile`. Unions
  * the manual ingredient picks with every selected preset's
  * avoid_ingredient_ids, dedupes, returns the wholesale-replacement
- * payload the endpoint expects (per Phase 1.3 semantics).
+ * payload the endpoint expects (per Phase 1.3 semantics). Phase 8.5
+ * adds the four taste arrays — empty when the step was skipped.
  */
 export function toProfilePayload(
   state: DraftProfile,
@@ -89,6 +148,10 @@ export function toProfilePayload(
   avoid_tag_ids: string[];
   prefer_tag_ids: string[];
   strictness: Strictness;
+  liked_tag_ids: string[];
+  disliked_tag_ids: string[];
+  liked_ingredient_ids: string[];
+  disliked_ingredient_ids: string[];
 } {
   const selected = presetCatalog.filter((p) => state.selectedPresetSlugs.includes(p.slug));
 
@@ -105,5 +168,29 @@ export function toProfilePayload(
     avoid_tag_ids:        Array.from(tagIds),
     prefer_tag_ids:       [],
     strictness:           state.strictness,
+    liked_tag_ids:           state.likedTagIds,
+    disliked_tag_ids:        state.dislikedTagIds,
+    liked_ingredient_ids:    state.likedIngredientIds,
+    disliked_ingredient_ids: state.dislikedIngredientIds,
+  };
+}
+
+/**
+ * Phase 8.5 standalone mode ("Improve my picks"): PATCH ONLY the
+ * four taste fields. The profile endpoint replaces arrays wholesale,
+ * so a standalone save that included the (empty) draft avoid lists
+ * would WIPE the user's existing safety filter — this payload can't.
+ */
+export function toTastePayload(state: DraftProfile): {
+  liked_tag_ids: string[];
+  disliked_tag_ids: string[];
+  liked_ingredient_ids: string[];
+  disliked_ingredient_ids: string[];
+} {
+  return {
+    liked_tag_ids:           state.likedTagIds,
+    disliked_tag_ids:        state.dislikedTagIds,
+    liked_ingredient_ids:    state.likedIngredientIds,
+    disliked_ingredient_ids: state.dislikedIngredientIds,
   };
 }


### PR DESCRIPTION
## What

First half of Phase 8.5 (`docs/plans/phase-8.md`), scoped so the UI half lands cleanly as 8.5b (queued at the top of the roadmap Next-up with the full remaining scope).

- **`GET /api/v1/tags`** — the third Phase-0 route that existed with **no controller action** (after the restaurants index in #307). Public, `?families=cuisine,flavor` filters against a `Tag::FAMILIES` whitelist (unknown names ignored, not an error), limit capped at 200. This backs the "What do you love?" chip picker.
- **`onboarding-reducer`** (filter-engine): four taste arrays join `DraftProfile`; `CYCLE_TASTE_TAG` / `CYCLE_TASTE_INGREDIENT` implement the subplan's chip cycle **neutral → liked → disliked → neutral** (one tap target covers both polarities); `toProfilePayload` now emits the four arrays — empty when the step is skipped (taste is optional, safety is not).
- **`toTastePayload`** — the standalone "Improve my picks" save sends ONLY the four taste fields. The profile endpoint replaces arrays wholesale, so a standalone save that included the (empty) draft avoid lists would **wipe the user's safety filter**; this payload shape makes that impossible by construction. Caught at design time, locked by a spec.

## Tests

- +4 rspec (**465/465**): public access + shape, family subset filter, injection-shaped family names ignored, limit cap
- +3 vitest (filter-engine **171/171**): full chip cycle, independent ingredient cycle, payload shapes (incl. asserting the standalone payload has no avoid keys)
- web 144 / mobile 118 / typecheck / lint green; brakeman 0 warnings

## 8.5b remaining (next session)

The "What do you love?" step UI on web + mobile (chips from `?families=cuisine,flavor` + optional ingredient search, skippable, between strictness and review), `?step=taste` standalone entry + "Improve my picks" link, optional `taste_signal_count` prop on `profile_set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)