### PR TITLE
feat: taste onboarding UI on web + mobile (Phase 8.5b)

### DIFF
--- a/apps/mobile/__tests__/screens/onboarding.render.test.tsx
+++ b/apps/mobile/__tests__/screens/onboarding.render.test.tsx
@@ -20,12 +20,16 @@ jest.mock('expo-router', () => ({
 // Mock the onboarding API at the boundary so the screen renders
 // against deterministic preset + ingredient catalogs.
 const mockFetchDietaryProfiles = jest.fn();
+const mockFetchTags = jest.fn();
 const mockSearchIngredients = jest.fn();
 const mockSaveProfile = jest.fn();
+const mockSaveTaste = jest.fn();
 jest.mock('../../lib/api/onboarding', () => ({
   fetchDietaryProfiles: (...args: unknown[]) => mockFetchDietaryProfiles(...args),
+  fetchTags: (...args: unknown[]) => mockFetchTags(...args),
   searchIngredients: (...args: unknown[]) => mockSearchIngredients(...args),
   saveProfile: (...args: unknown[]) => mockSaveProfile(...args),
+  saveTaste: (...args: unknown[]) => mockSaveTaste(...args),
 }));
 
 // Mock auth so finalize doesn't try to hit the keychain.
@@ -68,12 +72,17 @@ const GF_PRESET = {
   avoid_tag_ids: [],
 };
 
+const THAI_TAG = { id: 'tag-thai', slug: 'cuisine-thai', name: 'Thai', family: 'cuisine' };
+
 beforeEach(() => {
   mockFetchDietaryProfiles.mockReset();
+  mockFetchTags.mockReset();
   mockSearchIngredients.mockReset();
   mockSaveProfile.mockReset();
+  mockSaveTaste.mockReset();
   mockReplace.mockReset();
   mockFetchDietaryProfiles.mockResolvedValue([VEGAN_PRESET, GF_PRESET]);
+  mockFetchTags.mockResolvedValue([THAI_TAG]);
   mockSearchIngredients.mockResolvedValue([]);
 });
 
@@ -82,7 +91,7 @@ describe('OnboardingScreen — Step 1: presets', () => {
     mockFetchDietaryProfiles.mockReturnValue(new Promise(() => {})); // never resolves
     render(<OnboardingScreen />);
 
-    expect(screen.getByText('Step 1 of 4')).toBeOnTheScreen();
+    expect(screen.getByText('Step 1 of 5')).toBeOnTheScreen();
     expect(screen.getByText("What can't you eat?")).toBeOnTheScreen();
     expect(screen.getByTestId('presets-loading')).toBeOnTheScreen();
   });
@@ -137,10 +146,10 @@ describe('OnboardingScreen — Step 3: strictness', () => {
     await screen.findByLabelText('preset-vegan'); // wait for step 1 to settle
 
     fireEvent.press(screen.getByLabelText('next-to-ingredients'));
-    expect(screen.getByText('Step 2 of 4')).toBeOnTheScreen();
+    expect(screen.getByText('Step 2 of 5')).toBeOnTheScreen();
 
     fireEvent.press(screen.getByLabelText('next-to-strictness'));
-    expect(screen.getByText('Step 3 of 4')).toBeOnTheScreen();
+    expect(screen.getByText('Step 3 of 5')).toBeOnTheScreen();
     expect(screen.getByText('How strict?')).toBeOnTheScreen();
 
     expect(screen.getByLabelText('strictness-relaxed')).toBeOnTheScreen();
@@ -164,16 +173,52 @@ describe('OnboardingScreen — Step 3: strictness', () => {
   });
 });
 
-describe('OnboardingScreen — Step 4: review', () => {
+describe('OnboardingScreen — Step 4: taste', () => {
+  it('renders the taste step between strictness and review, and is skippable', async () => {
+    render(<OnboardingScreen />);
+    await screen.findByLabelText('preset-vegan');
+
+    fireEvent.press(screen.getByLabelText('next-to-ingredients'));
+    fireEvent.press(screen.getByLabelText('next-to-strictness'));
+    fireEvent.press(screen.getByLabelText('next-to-taste'));
+
+    expect(screen.getByText('Step 4 of 5')).toBeOnTheScreen();
+    expect(screen.getByText('What do you love?')).toBeOnTheScreen();
+    // Tag chip from the mocked fetchTags resolves.
+    await screen.findByLabelText('taste-tag-cuisine-thai');
+
+    // Skip → review step (taste arrays stay empty).
+    fireEvent.press(screen.getByLabelText('skip-taste'));
+    expect(screen.getByText('Step 5 of 5')).toBeOnTheScreen();
+    expect(screen.getByText('Ready?')).toBeOnTheScreen();
+  });
+
+  it('cycles a tag chip to liked when tapped', async () => {
+    render(<OnboardingScreen />);
+    await screen.findByLabelText('preset-vegan');
+
+    fireEvent.press(screen.getByLabelText('next-to-ingredients'));
+    fireEvent.press(screen.getByLabelText('next-to-strictness'));
+    fireEvent.press(screen.getByLabelText('next-to-taste'));
+
+    const chip = await screen.findByLabelText('taste-tag-cuisine-thai');
+    fireEvent.press(chip);
+    // Liked chips prefix the name with a heart.
+    expect(screen.getByText('♥ Thai')).toBeOnTheScreen();
+  });
+});
+
+describe('OnboardingScreen — Step 5: review', () => {
   it('summarizes the empty draft on the review step', async () => {
     render(<OnboardingScreen />);
     await screen.findByLabelText('preset-vegan');
 
     fireEvent.press(screen.getByLabelText('next-to-ingredients'));
     fireEvent.press(screen.getByLabelText('next-to-strictness'));
+    fireEvent.press(screen.getByLabelText('next-to-taste'));
     fireEvent.press(screen.getByLabelText('next-to-done'));
 
-    expect(screen.getByText('Step 4 of 4')).toBeOnTheScreen();
+    expect(screen.getByText('Step 5 of 5')).toBeOnTheScreen();
     expect(screen.getByText('Ready?')).toBeOnTheScreen();
     // The summary string is split across multiple <Text> nodes for
     // bolding — assert via the bolded count nodes.
@@ -190,6 +235,7 @@ describe('OnboardingScreen — Step 4: review', () => {
 
     fireEvent.press(screen.getByLabelText('next-to-ingredients'));
     fireEvent.press(screen.getByLabelText('next-to-strictness'));
+    fireEvent.press(screen.getByLabelText('next-to-taste'));
     fireEvent.press(screen.getByLabelText('next-to-done'));
 
     // Singular when count = 1.
@@ -203,6 +249,7 @@ describe('OnboardingScreen — Step 4: review', () => {
 
     fireEvent.press(screen.getByLabelText('next-to-ingredients'));
     fireEvent.press(screen.getByLabelText('next-to-strictness'));
+    fireEvent.press(screen.getByLabelText('next-to-taste'));
     fireEvent.press(screen.getByLabelText('next-to-done'));
 
     await act(async () => {

--- a/apps/mobile/app/onboarding/index.tsx
+++ b/apps/mobile/app/onboarding/index.tsx
@@ -10,20 +10,25 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
   initialDraft,
   onboardingReducer,
+  tasteStateOf,
   toProfilePayload,
+  toTastePayload,
   type DietaryPreset,
   type Strictness,
 } from '@biteworthy/filter-engine';
 import {
   fetchDietaryProfiles,
+  fetchTags,
   saveProfile,
+  saveTaste,
   searchIngredients,
   type IngredientSearchResult,
+  type TasteTag,
 } from '../../lib/api/onboarding';
 import { getJwt } from '../../lib/auth';
 import { useTracker } from '../../lib/tracker-context';
@@ -34,23 +39,34 @@ import { useTracker } from '../../lib/tracker-context';
  *   1. Pick presets ("What can't you eat?")
  *   2. Add specific ingredients ("Anything else?")
  *   3. Set strictness ("How strict?")
- *   4. Done → PATCH /api/v1/profile, navigate to /.
+ *   4. Taste ("What do you love?") — Phase 8.5, skippable
+ *   5. Done → PATCH /api/v1/profile, navigate to /.
  *
  * Phase 4.1 dropped the paste-the-JWT field; auth comes from the
  * keychain-backed token stored by /login. A 401 means the session
  * expired — the user is bounced to /login?next=/onboarding.
+ *
+ * Phase 8.5 — `?step=taste` enters the taste step standalone ("Improve
+ * my picks"). That mode saves ONLY the taste arrays (toTastePayload),
+ * so refining picks can never wipe the avoid lists. Safety filters,
+ * taste ranks.
  */
-type Step = 'presets' | 'ingredients' | 'strictness' | 'done';
+type Step = 'presets' | 'ingredients' | 'strictness' | 'taste' | 'done';
 
 export default function OnboardingScreen() {
   const tracker = useTracker();
-  const [step, setStep] = useState<Step>('presets');
+  const params = useLocalSearchParams<{ step?: string }>();
+  const standalone = params.step === 'taste';
+  const [step, setStep] = useState<Step>(standalone ? 'taste' : 'presets');
   const [draft, dispatch] = useReducer(onboardingReducer, initialDraft);
   const [presets, setPresets] = useState<DietaryPreset[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<IngredientSearchResult[]>([]);
   const [searchedIngredients, setSearchedIngredients] = useState<Map<string, IngredientSearchResult>>(new Map());
+  const [tags, setTags] = useState<TasteTag[]>([]);
+  const [tasteQuery, setTasteQuery] = useState('');
+  const [tasteResults, setTasteResults] = useState<IngredientSearchResult[]>([]);
   const [saving, setSaving] = useState(false);
 
   // Load presets once.
@@ -61,7 +77,17 @@ export default function OnboardingScreen() {
       .finally(() => setLoadingPresets(false));
   }, []);
 
-  // Debounced ingredient search.
+  // Load taste tag chips once (cuisine + flavor families).
+  useEffect(() => {
+    fetchTags()
+      .then(setTags)
+      .catch(() => {
+        // Tags are optional — taste is skippable, so a load failure
+        // just leaves the chip grid empty.
+      });
+  }, []);
+
+  // Debounced ingredient search (avoid-list step).
   useEffect(() => {
     if (step !== 'ingredients') return;
     const handle = setTimeout(() => {
@@ -81,6 +107,28 @@ export default function OnboardingScreen() {
     return () => clearTimeout(handle);
   }, [searchQuery, step]);
 
+  // Debounced ingredient search (taste step — separate query).
+  useEffect(() => {
+    if (step !== 'taste' || tasteQuery.trim().length === 0) {
+      setTasteResults([]);
+      return;
+    }
+    const handle = setTimeout(() => {
+      searchIngredients(tasteQuery)
+        .then(setTasteResults)
+        .catch(() => {
+          // Non-fatal.
+        });
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [tasteQuery, step]);
+
+  const tasteSignalCount =
+    draft.likedTagIds.length +
+    draft.dislikedTagIds.length +
+    draft.likedIngredientIds.length +
+    draft.dislikedIngredientIds.length;
+
   const finalize = async () => {
     const jwt = await getJwt();
     if (!jwt) {
@@ -96,6 +144,7 @@ export default function OnboardingScreen() {
         avoid_ingredient_count: payload.avoid_ingredient_ids.length,
         avoid_tag_count: payload.avoid_tag_ids.length,
         strictness: payload.strictness,
+        taste_signal_count: tasteSignalCount,
       });
       Alert.alert('Profile saved', 'Your dietary filter is ready.');
       router.replace('/');
@@ -111,11 +160,36 @@ export default function OnboardingScreen() {
     }
   };
 
+  // Standalone "Improve my picks" save — taste arrays only, so it can
+  // never wipe the user's existing avoid lists (wholesale replace).
+  const finalizeTaste = async () => {
+    const jwt = await getJwt();
+    if (!jwt) {
+      router.replace('/login?next=%2Fonboarding%3Fstep%3Dtaste');
+      return;
+    }
+    try {
+      setSaving(true);
+      await saveTaste(toTastePayload(draft), jwt);
+      Alert.alert('Picks updated', 'Your Top Picks just got smarter.');
+      router.replace('/');
+    } catch (e) {
+      const message = (e as Error).message;
+      if (message.includes('401')) {
+        router.replace('/login?next=%2Fonboarding%3Fstep%3Dtaste');
+        return;
+      }
+      Alert.alert('Save failed', message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   // ── Step bodies ──────────────────────────────────────────────────────
   if (step === 'presets') {
     return (
       <View style={styles.container}>
-        <Text style={styles.eyebrow}>Step 1 of 4</Text>
+        <Text style={styles.eyebrow}>Step 1 of 5</Text>
         <Text style={styles.headline}>What can't you eat?</Text>
         <Text style={styles.body}>Tap any presets that apply. You can multi-select.</Text>
 
@@ -150,7 +224,7 @@ export default function OnboardingScreen() {
   if (step === 'ingredients') {
     return (
       <View style={styles.container}>
-        <Text style={styles.eyebrow}>Step 2 of 4</Text>
+        <Text style={styles.eyebrow}>Step 2 of 5</Text>
         <Text style={styles.headline}>Anything else?</Text>
         <Text style={styles.body}>Search for specific ingredients to avoid.</Text>
 
@@ -208,7 +282,7 @@ export default function OnboardingScreen() {
   if (step === 'strictness') {
     return (
       <View style={styles.container}>
-        <Text style={styles.eyebrow}>Step 3 of 4</Text>
+        <Text style={styles.eyebrow}>Step 3 of 5</Text>
         <Text style={styles.headline}>How strict?</Text>
         <Text style={styles.body}>
           Strict mode also hides items the AI hasn't fully confirmed. Pick balanced if unsure.
@@ -235,8 +309,115 @@ export default function OnboardingScreen() {
           );
         })}
 
-        <Pressable accessibilityLabel="next-to-done" onPress={() => setStep('done')} style={styles.primary}>
-          <Text style={styles.primaryText}>Review →</Text>
+        <Pressable accessibilityLabel="next-to-taste" onPress={() => setStep('taste')} style={styles.primary}>
+          <Text style={styles.primaryText}>Next →</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (step === 'taste') {
+    return (
+      <View style={styles.container}>
+        {standalone ? (
+          <>
+            <Text style={styles.eyebrow}>Improve your picks</Text>
+            <Text style={styles.headline}>What do you love?</Text>
+            <Text style={styles.body}>
+              Tap to love a cuisine or flavor; tap again to pass. This only ranks your menus —
+              it never hides anything your dietary filter allows.
+            </Text>
+          </>
+        ) : (
+          <>
+            <Text style={styles.eyebrow}>Step 4 of 5</Text>
+            <Text style={styles.headline}>What do you love?</Text>
+            <Text style={styles.body}>
+              Tap to love a cuisine or flavor; tap again to pass. Optional — this only ranks your
+              Top Picks, it never hides safe food.
+            </Text>
+          </>
+        )}
+
+        <View style={styles.chipGrid}>
+          {tags.map((t) => {
+            const state = tasteStateOf(t.id, draft.likedTagIds, draft.dislikedTagIds);
+            return (
+              <Pressable
+                key={t.id}
+                accessibilityLabel={`taste-tag-${t.slug}`}
+                onPress={() => dispatch({ type: 'CYCLE_TASTE_TAG', tagId: t.id })}
+                style={[
+                  styles.tasteChip,
+                  state === 'liked' && styles.tasteChipLiked,
+                  state === 'disliked' && styles.tasteChipDisliked,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.tasteChipText,
+                    state === 'disliked' && styles.tasteChipTextDisliked,
+                  ]}
+                >
+                  {state === 'liked' ? '♥ ' : state === 'disliked' ? '✕ ' : ''}
+                  {t.name}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <TextInput
+          accessibilityLabel="taste-ingredient-search"
+          placeholder="Search a favorite ingredient (e.g. 'basil')"
+          value={tasteQuery}
+          onChangeText={setTasteQuery}
+          style={styles.input}
+        />
+        <FlatList
+          data={tasteResults}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => {
+            const state = tasteStateOf(item.id, draft.likedIngredientIds, draft.dislikedIngredientIds);
+            return (
+              <Pressable
+                accessibilityLabel={`taste-ing-${item.slug}`}
+                onPress={() => dispatch({ type: 'CYCLE_TASTE_INGREDIENT', ingredientId: item.id })}
+                style={[styles.searchRow, state === 'liked' && styles.searchRowAdded]}
+              >
+                <Text style={[styles.searchName, { flex: 1 }]}>{item.name}</Text>
+                <Text style={[styles.addLabel, state === 'liked' && styles.addedLabel]}>
+                  {state === 'liked' ? '♥ love' : state === 'disliked' ? '✕ pass' : '+ love'}
+                </Text>
+              </Pressable>
+            );
+          }}
+          ListEmptyComponent={null}
+        />
+
+        <Text style={styles.muted}>{tasteSignalCount} taste signal(s) set</Text>
+
+        {standalone ? (
+          <Pressable
+            accessibilityLabel="save-taste"
+            onPress={finalizeTaste}
+            disabled={saving}
+            style={[styles.primary, saving && { opacity: 0.5 }]}
+          >
+            <Text style={styles.primaryText}>{saving ? 'Saving…' : 'Save picks'}</Text>
+          </Pressable>
+        ) : (
+          <Pressable accessibilityLabel="next-to-done" onPress={() => setStep('done')} style={styles.primary}>
+            <Text style={styles.primaryText}>Review →</Text>
+          </Pressable>
+        )}
+
+        <Pressable
+          accessibilityLabel="skip-taste"
+          onPress={() => (standalone ? router.replace('/') : setStep('done'))}
+          style={styles.skip}
+        >
+          <Text style={styles.skipText}>{standalone ? 'Cancel' : 'Skip for now'}</Text>
         </Pressable>
       </View>
     );
@@ -245,7 +426,7 @@ export default function OnboardingScreen() {
   // step === 'done'
   return (
     <View style={styles.container}>
-      <Text style={styles.eyebrow}>Step 4 of 4</Text>
+      <Text style={styles.eyebrow}>Step 5 of 5</Text>
       <Text style={styles.headline}>Ready?</Text>
 
       <Text style={styles.body}>
@@ -379,5 +560,39 @@ const styles = StyleSheet.create({
     color: colors.bg,
     fontWeight: '700',
     fontSize: fontSize.base,
+  },
+  skip: {
+    alignItems: 'center',
+    paddingVertical: space['3'],
+  },
+  skipText: {
+    color: colors.textMuted,
+    fontWeight: '600',
+    fontSize: fontSize.sm,
+  },
+  tasteChip: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bgAlt,
+    borderRadius: 999,
+    paddingHorizontal: space['3'],
+    paddingVertical: space['2'],
+  },
+  tasteChipLiked: {
+    borderColor: colors.ok,
+    backgroundColor: colors.biteLight,
+  },
+  tasteChipDisliked: {
+    borderColor: colors.bite,
+    backgroundColor: colors.biteLight,
+  },
+  tasteChipText: {
+    fontSize: fontSize.sm,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  tasteChipTextDisliked: {
+    color: colors.biteDark,
+    textDecorationLine: 'line-through',
   },
 });

--- a/apps/mobile/app/restaurants/_TopPicksRow.tsx
+++ b/apps/mobile/app/restaurants/_TopPicksRow.tsx
@@ -29,6 +29,13 @@ export function TopPicksRow({ items }: { items: RestaurantItem[] }) {
         <Pressable accessibilityLabel="why-these" onPress={() => setWhyOpen((v) => !v)}>
           <Text style={styles.whyLink}>Why these?</Text>
         </Pressable>
+        <Pressable
+          accessibilityLabel="improve-picks"
+          onPress={() => router.push('/onboarding?step=taste')}
+          style={styles.improveLink}
+        >
+          <Text style={styles.whyLink}>Improve my picks</Text>
+        </Pressable>
       </View>
       {whyOpen && (
         <Text style={styles.explainer} testID="why-these-explainer">
@@ -85,6 +92,9 @@ const styles = StyleSheet.create({
     color: colors.bite,
     fontSize: fontSize.xs,
     fontWeight: '600',
+  },
+  improveLink: {
+    marginLeft: 'auto',
   },
   explainer: {
     color: colors.textMuted,

--- a/apps/mobile/lib/api/onboarding.ts
+++ b/apps/mobile/lib/api/onboarding.ts
@@ -46,11 +46,47 @@ export async function searchIngredients(
   return json.ingredients;
 }
 
+/** A taste-onboarding chip. Mirrors GET /api/v1/tags rows. */
+export interface TasteTag {
+  id: string;
+  slug: string;
+  name: string;
+  family: string;
+}
+
+/**
+ * Phase 8.5 — tag chips for the "What do you love?" step. Narrows to
+ * the taste-relevant families; the server whitelists unknown names.
+ */
+export async function fetchTags(
+  families: string[] = ['cuisine', 'flavor'],
+  opts: FetchOptions = {},
+): Promise<TasteTag[]> {
+  const { fetchImpl = fetch } = opts;
+  const url = new URL(`${API_BASE}/api/v1/tags`);
+  if (families.length > 0) url.searchParams.set('families', families.join(','));
+  const res = await fetchImpl(url.toString());
+  if (!res.ok) throw new Error(`fetchTags failed: ${res.status}`);
+  const json = (await res.json()) as { tags: TasteTag[] };
+  return json.tags;
+}
+
 export interface SaveProfilePayload {
   avoid_ingredient_ids: string[];
   avoid_tag_ids: string[];
   prefer_tag_ids: string[];
   strictness: 'relaxed' | 'balanced' | 'strict';
+  liked_tag_ids?: string[];
+  disliked_tag_ids?: string[];
+  liked_ingredient_ids?: string[];
+  disliked_ingredient_ids?: string[];
+}
+
+export interface SaveTastePayload {
+  liked_tag_ids: string[];
+  disliked_tag_ids: string[];
+  liked_ingredient_ids: string[];
+  disliked_ingredient_ids: string[];
 }
 
 export async function saveProfile(
@@ -75,5 +111,36 @@ export async function saveProfile(
       // ignore
     }
     throw new Error(`saveProfile failed: ${res.status} ${JSON.stringify(body)}`);
+  }
+}
+
+/**
+ * Phase 8.5 standalone "Improve my picks": PATCH ONLY the four taste
+ * arrays. The endpoint replaces arrays wholesale, so a save carrying
+ * the (empty) avoid lists would wipe the user's safety filter — this
+ * payload omits them entirely.
+ */
+export async function saveTaste(
+  payload: SaveTastePayload,
+  jwt: string,
+  opts: FetchOptions = {},
+): Promise<void> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/profile`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new Error(`saveTaste failed: ${res.status} ${JSON.stringify(body)}`);
   }
 }

--- a/apps/web/src/app/onboarding/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/__tests__/page.test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Phase 8.5 — web taste-onboarding step.
+ *
+ * The pure cycle (neutral → liked → disliked → neutral) is covered in
+ * the filter-engine reducer spec, and the saveTaste/fetchTags wire
+ * shapes in `lib/__tests__/onboarding.test.ts`. This file targets the
+ * React page: that the taste chips render + cycle, that standalone
+ * `?step=taste` saves ONLY the taste arrays (toTastePayload, can't
+ * wipe avoid lists), and that the full flow's taste step is skippable.
+ */
+
+const mockReplace = vi.fn();
+const mockGet = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+const mockFetchDietaryProfiles = vi.fn();
+const mockFetchTags = vi.fn();
+const mockSearchIngredients = vi.fn();
+const mockSaveProfile = vi.fn();
+const mockSaveTaste = vi.fn();
+vi.mock('../../../lib/onboarding', () => ({
+  fetchDietaryProfiles: (...a: unknown[]) => mockFetchDietaryProfiles(...a),
+  fetchTags: (...a: unknown[]) => mockFetchTags(...a),
+  searchIngredients: (...a: unknown[]) => mockSearchIngredients(...a),
+  saveProfile: (...a: unknown[]) => mockSaveProfile(...a),
+  saveTaste: (...a: unknown[]) => mockSaveTaste(...a),
+}));
+
+vi.mock('../../_PostHogProvider', () => ({
+  useTracker: () => ({ track: vi.fn() }),
+}));
+
+import OnboardingPage from '../page';
+
+const THAI = { id: 'tag-thai', slug: 'cuisine-thai', name: 'Thai', family: 'cuisine' };
+
+beforeEach(() => {
+  mockReplace.mockReset();
+  mockGet.mockReset();
+  mockFetchDietaryProfiles.mockReset().mockResolvedValue([]);
+  mockFetchTags.mockReset().mockResolvedValue([THAI]);
+  mockSearchIngredients.mockReset().mockResolvedValue([]);
+  mockSaveProfile.mockReset().mockResolvedValue(undefined);
+  mockSaveTaste.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+describe('OnboardingPage — taste step (standalone "Improve my picks")', () => {
+  beforeEach(() => mockGet.mockReturnValue('taste'));
+
+  it('opens directly on the taste step with the standalone framing', async () => {
+    render(<OnboardingPage />);
+    expect(await screen.findByText('What do you love?')).toBeInTheDocument();
+    expect(screen.getByText('Improve your picks')).toBeInTheDocument();
+    // No "Step X of 5" eyebrow in standalone mode.
+    expect(screen.queryByText(/Step \d of 5/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('save-taste')).toBeInTheDocument();
+  });
+
+  it('cycles a tag chip neutral → liked on tap and saves only taste arrays', async () => {
+    render(<OnboardingPage />);
+    const chip = await screen.findByTestId('taste-tag-cuisine-thai');
+    expect(chip).toHaveAttribute('data-state', 'neutral');
+
+    fireEvent.click(chip);
+    expect(screen.getByTestId('taste-tag-cuisine-thai')).toHaveAttribute('data-state', 'liked');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('save-taste'));
+    });
+
+    await waitFor(() => expect(mockSaveTaste).toHaveBeenCalledTimes(1));
+    expect(mockSaveTaste.mock.calls[0]![0]).toEqual({
+      liked_tag_ids: ['tag-thai'],
+      disliked_tag_ids: [],
+      liked_ingredient_ids: [],
+      disliked_ingredient_ids: [],
+    });
+    // The footgun guard: a taste save must NOT touch the avoid lists.
+    expect(mockSaveProfile).not.toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+
+  it('Cancel leaves without saving', async () => {
+    render(<OnboardingPage />);
+    await screen.findByTestId('skip-taste');
+    fireEvent.click(screen.getByTestId('skip-taste'));
+    expect(mockSaveTaste).not.toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+});
+
+describe('OnboardingPage — taste step in the full flow', () => {
+  beforeEach(() => mockGet.mockReturnValue(null));
+
+  it('sits at step 4 of 5 between strictness and review, and is skippable', async () => {
+    render(<OnboardingPage />);
+    // presets (1) → ingredients (2) → strictness (3) → taste (4)
+    fireEvent.click(await screen.findByTestId('next-to-ingredients'));
+    fireEvent.click(screen.getByTestId('next-to-strictness'));
+    fireEvent.click(screen.getByTestId('next-to-taste'));
+
+    expect(screen.getByText('Step 4 of 5')).toBeInTheDocument();
+    expect(screen.getByText('What do you love?')).toBeInTheDocument();
+
+    // Skip for now → review step (taste arrays stay empty).
+    fireEvent.click(screen.getByTestId('skip-taste'));
+    expect(screen.getByText('Step 5 of 5')).toBeInTheDocument();
+    expect(screen.getByText('Ready?')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,19 +1,25 @@
 'use client';
 
-import { useEffect, useReducer, useState, type FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { Suspense, useEffect, useReducer, useState, type FormEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   initialDraft,
   onboardingReducer,
+  tasteStateOf,
   toProfilePayload,
+  toTastePayload,
   type DietaryPreset,
   type Strictness,
+  type TasteState,
 } from '@biteworthy/filter-engine';
 import {
   fetchDietaryProfiles,
+  fetchTags,
   saveProfile,
+  saveTaste,
   searchIngredients,
   type IngredientSearchResult,
+  type TasteTag,
 } from '../../lib/onboarding';
 import { useTracker } from '../_PostHogProvider';
 
@@ -23,14 +29,20 @@ import { useTracker } from '../_PostHogProvider';
  *   1. Pick presets ("What can't you eat?")
  *   2. Add specific ingredients ("Anything else?")
  *   3. Set strictness ("How strict?")
- *   4. Done → PATCH /api/profile (Next proxy reads the bw_session
+ *   4. Taste ("What do you love?") — Phase 8.5, skippable
+ *   5. Done → PATCH /api/profile (Next proxy reads the bw_session
  *      cookie + forwards to Rails), navigate home.
  *
  * Phase 4.1 dropped the paste-the-JWT input; if the request comes
  * back 401, the user is bounced to /login?next=/onboarding so they
  * can sign in and resume.
+ *
+ * Phase 8.5 — `?step=taste` enters the taste step standalone ("Improve
+ * my picks"). That mode saves ONLY the taste arrays (toTastePayload),
+ * so refining picks can never wipe the avoid lists. Taste is soft:
+ * safety filters, taste ranks.
  */
-type Step = 'presets' | 'ingredients' | 'strictness' | 'done';
+type Step = 'presets' | 'ingredients' | 'strictness' | 'taste' | 'done';
 
 const STRICTNESSES: Strictness[] = ['relaxed', 'balanced', 'strict'];
 const STRICTNESS_BLURB: Record<Strictness, string> = {
@@ -40,16 +52,31 @@ const STRICTNESS_BLURB: Record<Strictness, string> = {
 };
 
 export default function OnboardingPage() {
+  // useSearchParams (in OnboardingFlow) needs a Suspense boundary or
+  // Next 15's prod build bails the whole page out of static rendering.
+  return (
+    <Suspense>
+      <OnboardingFlow />
+    </Suspense>
+  );
+}
+
+function OnboardingFlow() {
   const router = useRouter();
   const tracker = useTracker();
+  const searchParams = useSearchParams();
+  const standalone = searchParams.get('step') === 'taste';
 
-  const [step, setStep] = useState<Step>('presets');
+  const [step, setStep] = useState<Step>(standalone ? 'taste' : 'presets');
   const [draft, dispatch] = useReducer(onboardingReducer, initialDraft);
   const [presets, setPresets] = useState<DietaryPreset[]>([]);
   const [presetsError, setPresetsError] = useState<string | null>(null);
   const [loadingPresets, setLoadingPresets] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<IngredientSearchResult[]>([]);
+  const [tags, setTags] = useState<TasteTag[]>([]);
+  const [tasteQuery, setTasteQuery] = useState('');
+  const [tasteResults, setTasteResults] = useState<IngredientSearchResult[]>([]);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -60,7 +87,17 @@ export default function OnboardingPage() {
       .finally(() => setLoadingPresets(false));
   }, []);
 
-  // Debounced ingredient search.
+  // Load taste tag chips once (cuisine + flavor families).
+  useEffect(() => {
+    fetchTags()
+      .then(setTags)
+      .catch(() => {
+        // Tags are optional — taste is skippable, so a load failure
+        // just leaves the chip grid empty.
+      });
+  }, []);
+
+  // Debounced ingredient search (avoid-list step).
   useEffect(() => {
     if (step !== 'ingredients') return;
     const handle = setTimeout(() => {
@@ -72,6 +109,29 @@ export default function OnboardingPage() {
     }, 250);
     return () => clearTimeout(handle);
   }, [searchQuery, step]);
+
+  // Debounced ingredient search (taste step — separate query so the
+  // two searches don't bleed into each other).
+  useEffect(() => {
+    if (step !== 'taste' || tasteQuery.trim().length === 0) {
+      setTasteResults([]);
+      return;
+    }
+    const handle = setTimeout(() => {
+      searchIngredients(tasteQuery)
+        .then(setTasteResults)
+        .catch(() => {
+          // Non-fatal.
+        });
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [tasteQuery, step]);
+
+  const tasteSignalCount =
+    draft.likedTagIds.length +
+    draft.dislikedTagIds.length +
+    draft.likedIngredientIds.length +
+    draft.dislikedIngredientIds.length;
 
   const finalize = async (e: FormEvent) => {
     e.preventDefault();
@@ -85,6 +145,7 @@ export default function OnboardingPage() {
         avoid_ingredient_count: payload.avoid_ingredient_ids.length,
         avoid_tag_count: payload.avoid_tag_ids.length,
         strictness: payload.strictness,
+        taste_signal_count: tasteSignalCount,
       });
       router.replace('/');
     } catch (err) {
@@ -93,6 +154,27 @@ export default function OnboardingPage() {
       // — bounce to login and come back here to finish.
       if (message.includes('401')) {
         router.replace(`/login?next=${encodeURIComponent('/onboarding')}`);
+        return;
+      }
+      setSaveError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Standalone "Improve my picks" save — taste arrays only, so it can
+  // never wipe the user's existing avoid lists (wholesale-replace
+  // semantics on the endpoint).
+  const finalizeTaste = async () => {
+    try {
+      setSaving(true);
+      setSaveError(null);
+      await saveTaste(toTastePayload(draft));
+      router.replace('/');
+    } catch (err) {
+      const message = (err as Error).message;
+      if (message.includes('401')) {
+        router.replace(`/login?next=${encodeURIComponent('/onboarding?step=taste')}`);
         return;
       }
       setSaveError(message);
@@ -134,7 +216,31 @@ export default function OnboardingPage() {
         <StrictnessStep
           active={draft.strictness}
           onPick={(s) => dispatch({ type: 'SET_STRICTNESS', strictness: s })}
+          onNext={() => setStep('taste')}
+        />
+      )}
+
+      {step === 'taste' && (
+        <TasteStep
+          standalone={standalone}
+          tags={tags}
+          likedTagIds={draft.likedTagIds}
+          dislikedTagIds={draft.dislikedTagIds}
+          onCycleTag={(tagId) => dispatch({ type: 'CYCLE_TASTE_TAG', tagId })}
+          query={tasteQuery}
+          results={tasteResults}
+          likedIngredientIds={draft.likedIngredientIds}
+          dislikedIngredientIds={draft.dislikedIngredientIds}
+          onQueryChange={setTasteQuery}
+          onCycleIngredient={(ingredientId) =>
+            dispatch({ type: 'CYCLE_TASTE_INGREDIENT', ingredientId })
+          }
+          signalCount={tasteSignalCount}
+          saving={saving}
+          error={saveError}
           onNext={() => setStep('done')}
+          onSave={finalizeTaste}
+          onSkip={() => (standalone ? router.replace('/') : setStep('done'))}
         />
       )}
 
@@ -166,7 +272,7 @@ function StepHeader({
   return (
     <>
       <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">
-        Step {step} of 4
+        Step {step} of 5
       </p>
       <h1 className="mt-bw-2 text-bw-2xl font-bold">{title}</h1>
       <p className="mt-bw-2 text-bw-base text-zinc-700">{body}</p>
@@ -371,7 +477,192 @@ function StrictnessStep({
           );
         })}
       </div>
-      <NextButton label="Review →" onClick={onNext} testId="next-to-done" />
+      <NextButton label="Next →" onClick={onNext} testId="next-to-taste" />
+    </>
+  );
+}
+
+// ─── Phase 8.5 — taste step ("What do you love?") ─────────────────
+
+function TasteChip({
+  label,
+  state,
+  onClick,
+  testId,
+}: {
+  label: string;
+  state: TasteState;
+  onClick: () => void;
+  testId: string;
+}) {
+  const tone =
+    state === 'liked'
+      ? 'border-ok bg-bite-light text-ok'
+      : state === 'disliked'
+        ? 'border-bite bg-bite-light text-bite-dark line-through'
+        : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300';
+  const prefix = state === 'liked' ? '♥ ' : state === 'disliked' ? '✕ ' : '';
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      data-state={state}
+      aria-pressed={state !== 'neutral'}
+      onClick={onClick}
+      className={['rounded-full border px-bw-3 py-bw-2 text-bw-sm font-semibold transition', tone].join(
+        ' ',
+      )}
+    >
+      {prefix}
+      {label}
+    </button>
+  );
+}
+
+function TasteStep({
+  standalone,
+  tags,
+  likedTagIds,
+  dislikedTagIds,
+  onCycleTag,
+  query,
+  results,
+  likedIngredientIds,
+  dislikedIngredientIds,
+  onQueryChange,
+  onCycleIngredient,
+  signalCount,
+  saving,
+  error,
+  onNext,
+  onSave,
+  onSkip,
+}: {
+  standalone: boolean;
+  tags: TasteTag[];
+  likedTagIds: string[];
+  dislikedTagIds: string[];
+  onCycleTag: (tagId: string) => void;
+  query: string;
+  results: IngredientSearchResult[];
+  likedIngredientIds: string[];
+  dislikedIngredientIds: string[];
+  onQueryChange: (q: string) => void;
+  onCycleIngredient: (ingredientId: string) => void;
+  signalCount: number;
+  saving: boolean;
+  error: string | null;
+  onNext: () => void;
+  onSave: () => void;
+  onSkip: () => void;
+}) {
+  return (
+    <>
+      {standalone ? (
+        <>
+          <p className="text-bite text-bw-sm font-semibold uppercase tracking-wider">
+            Improve your picks
+          </p>
+          <h1 className="mt-bw-2 text-bw-2xl font-bold">What do you love?</h1>
+          <p className="mt-bw-2 text-bw-base text-zinc-700">
+            Tap to love a cuisine or flavor; tap again to pass. This only ranks your menus —
+            it never hides anything your dietary filter allows.
+          </p>
+        </>
+      ) : (
+        <StepHeader
+          step={4}
+          title="What do you love?"
+          body="Tap to love a cuisine or flavor; tap again to pass. Optional — this only ranks your Top Picks, it never hides safe food."
+        />
+      )}
+
+      {tags.length > 0 && (
+        <div className="mt-bw-4 flex flex-wrap gap-bw-2" data-testid="taste-tags">
+          {tags.map((t) => (
+            <TasteChip
+              key={t.id}
+              label={t.name}
+              state={tasteStateOf(t.id, likedTagIds, dislikedTagIds)}
+              onClick={() => onCycleTag(t.id)}
+              testId={`taste-tag-${t.slug}`}
+            />
+          ))}
+        </div>
+      )}
+
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="Search a favorite ingredient (e.g. 'basil')"
+        aria-label="taste-ingredient-search"
+        className="mt-bw-4 w-full rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+      />
+      <ul className="mt-bw-2 divide-y divide-zinc-100">
+        {results.map((r) => {
+          const state = tasteStateOf(r.id, likedIngredientIds, dislikedIngredientIds);
+          return (
+            <li key={r.id}>
+              <button
+                type="button"
+                onClick={() => onCycleIngredient(r.id)}
+                data-testid={`taste-ing-${r.slug}`}
+                data-state={state}
+                className="flex w-full items-center justify-between py-bw-3 text-left"
+              >
+                <span className="text-bw-base text-zinc-900">{r.name}</span>
+                <span
+                  className={[
+                    'font-semibold',
+                    state === 'liked'
+                      ? 'text-ok'
+                      : state === 'disliked'
+                        ? 'text-bite'
+                        : 'text-zinc-400',
+                  ].join(' ')}
+                >
+                  {state === 'liked' ? '♥ love' : state === 'disliked' ? '✕ pass' : '+ love'}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="mt-bw-3 text-bw-sm text-zinc-500">{signalCount} taste signal(s) set</p>
+
+      {error && (
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          {error}
+        </p>
+      )}
+
+      {standalone ? (
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          data-testid="save-taste"
+          className={[
+            'mt-bw-6 w-full rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
+            saving ? 'opacity-60' : 'hover:bg-bite-dark',
+          ].join(' ')}
+        >
+          {saving ? 'Saving…' : 'Save picks'}
+        </button>
+      ) : (
+        <NextButton label="Review →" onClick={onNext} testId="next-to-done" />
+      )}
+
+      <button
+        type="button"
+        onClick={onSkip}
+        data-testid="skip-taste"
+        className="mt-bw-3 w-full text-bw-sm font-semibold text-zinc-500 hover:text-zinc-700"
+      >
+        {standalone ? 'Cancel' : 'Skip for now'}
+      </button>
     </>
   );
 }
@@ -393,7 +684,7 @@ function ReviewStep({
 }) {
   return (
     <form onSubmit={onSubmit}>
-      <StepHeader step={4} title="Ready?" body="Saving will replace any existing avoid lists on your profile." />
+      <StepHeader step={5} title="Ready?" body="Saving will replace any existing avoid lists on your profile." />
 
       <p className="mt-bw-4 text-bw-base text-zinc-700">
         Avoiding{' '}

--- a/apps/web/src/app/restaurants/[slug]/TopPicksRow.tsx
+++ b/apps/web/src/app/restaurants/[slug]/TopPicksRow.tsx
@@ -46,6 +46,13 @@ export function TopPicksRow({
         >
           Why these?
         </button>
+        <a
+          href="/onboarding?step=taste"
+          data-testid="improve-picks"
+          className="ml-auto text-bw-xs font-semibold text-bite hover:text-bite-dark"
+        >
+          Improve my picks
+        </a>
       </div>
       {whyOpen && (
         <p data-testid="why-these-explainer" className="mt-bw-1 text-bw-sm text-zinc-500">

--- a/apps/web/src/app/restaurants/[slug]/__tests__/TopPicksRow.test.tsx
+++ b/apps/web/src/app/restaurants/[slug]/__tests__/TopPicksRow.test.tsx
@@ -140,4 +140,9 @@ describe('TopPicksRow', () => {
     const link = screen.getByTestId('top-pick-curry').querySelector('a');
     expect(link).toHaveAttribute('href', '/restaurants/ninis/items/curry');
   });
+
+  it('offers an "Improve my picks" link into the standalone taste step', () => {
+    render(<TopPicksRow items={threePicks} restaurantSlug="ninis" />);
+    expect(screen.getByTestId('improve-picks')).toHaveAttribute('href', '/onboarding?step=taste');
+  });
 });

--- a/apps/web/src/lib/__tests__/onboarding.test.ts
+++ b/apps/web/src/lib/__tests__/onboarding.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   fetchDietaryProfiles,
+  fetchTags,
   saveProfile,
+  saveTaste,
   searchIngredients,
   type SaveProfilePayload,
+  type SaveTastePayload,
 } from '../onboarding';
 
 type FetchArgs = Parameters<typeof fetch>;
@@ -67,6 +70,50 @@ describe('searchIngredients', () => {
     });
     const out = await searchIngredients('cilantro', { fetchImpl });
     expect(out[0]!.name).toBe('Cilantro');
+  });
+});
+
+describe('fetchTags', () => {
+  it('GETs /api/v1/tags with the default cuisine,flavor families', async () => {
+    const fetchImpl = fakeFetch(200, { tags: [] });
+    await fetchTags(undefined, { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    expect(url).toContain('/api/v1/tags');
+    expect(url).toContain('families=cuisine%2Cflavor');
+  });
+
+  it('unwraps the tags array', async () => {
+    const fetchImpl = fakeFetch(200, {
+      tags: [{ id: 't1', slug: 'cuisine-thai', name: 'Thai', family: 'cuisine' }],
+    });
+    const out = await fetchTags(['cuisine'], { fetchImpl });
+    expect(out[0]!.name).toBe('Thai');
+  });
+});
+
+describe('saveTaste', () => {
+  const payload: SaveTastePayload = {
+    liked_tag_ids: ['tag-thai'],
+    disliked_tag_ids: [],
+    liked_ingredient_ids: [],
+    disliked_ingredient_ids: [],
+  };
+
+  it('PATCHes /api/profile with ONLY the taste arrays (no avoid lists)', async () => {
+    const fetchImpl = fakeFetch(200, {});
+    await saveTaste(payload, { fetchImpl });
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual(payload);
+    // The footgun this guards against: a wholesale-replace PATCH must
+    // not carry avoid_* keys, or it would wipe the safety filter.
+    expect(body).not.toHaveProperty('avoid_ingredient_ids');
+    expect(body).not.toHaveProperty('avoid_tag_ids');
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'Not signed in' });
+    await expect(saveTaste(payload, { fetchImpl })).rejects.toThrow(/401/);
   });
 });
 

--- a/apps/web/src/lib/onboarding.ts
+++ b/apps/web/src/lib/onboarding.ts
@@ -18,16 +18,56 @@ export interface IngredientSearchResult {
   allergen: boolean;
 }
 
+/**
+ * Phase 8.5 — taste signals ride on the same PATCH /api/profile as
+ * the avoid lists, so they're optional on the full-onboarding
+ * payload. The standalone "Improve my picks" save uses
+ * `SaveTastePayload` (taste-only) so it can't wipe avoid lists.
+ */
 export interface SaveProfilePayload {
   avoid_ingredient_ids: string[];
   avoid_tag_ids: string[];
   prefer_tag_ids: string[];
   strictness: 'relaxed' | 'balanced' | 'strict';
+  liked_tag_ids?: string[];
+  disliked_tag_ids?: string[];
+  liked_ingredient_ids?: string[];
+  disliked_ingredient_ids?: string[];
+}
+
+export interface SaveTastePayload {
+  liked_tag_ids: string[];
+  disliked_tag_ids: string[];
+  liked_ingredient_ids: string[];
+  disliked_ingredient_ids: string[];
+}
+
+/** A taste-onboarding chip. Mirrors GET /api/v1/tags rows. */
+export interface TasteTag {
+  id: string;
+  slug: string;
+  name: string;
+  family: string;
 }
 
 export async function fetchDietaryProfiles(opts: ApiOptions = {}): Promise<DietaryPreset[]> {
   const json = await api<{ dietary_profiles: DietaryPreset[] }>('/dietary_profiles', opts);
   return json.dietary_profiles;
+}
+
+/**
+ * Phase 8.5 — tag chips for the "What do you love?" step. `families`
+ * narrows to the taste-relevant families (cuisine, flavor); the
+ * server whitelists unknown names away.
+ */
+export async function fetchTags(
+  families: string[] = ['cuisine', 'flavor'],
+  opts: ApiOptions = {},
+): Promise<TasteTag[]> {
+  const params = new URLSearchParams();
+  if (families.length > 0) params.set('families', families.join(','));
+  const json = await api<{ tags: TasteTag[] }>(`/tags?${params.toString()}`, opts);
+  return json.tags;
 }
 
 export async function searchIngredients(
@@ -72,5 +112,33 @@ export async function saveProfile(
       // ignore
     }
     throw new Error(`saveProfile failed: ${res.status} ${JSON.stringify(body)}`);
+  }
+}
+
+/**
+ * Phase 8.5 standalone "Improve my picks": PATCH ONLY the four taste
+ * arrays. The profile endpoint replaces arrays wholesale, so a save
+ * that carried the (empty) avoid lists would wipe the user's safety
+ * filter — this payload omits them entirely.
+ */
+export async function saveTaste(
+  payload: SaveTastePayload,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<void> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/profile', {
+    method: 'PATCH',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore
+    }
+    throw new Error(`saveTaste failed: ${res.status} ${JSON.stringify(body)}`);
   }
 }

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -33,6 +33,7 @@ Fired when the user finishes the 6-tap onboarding (Phase 3.2 / 3.8) OR updates t
 | `avoid_ingredient_count` | `number` | Final count after onboarding. |
 | `avoid_tag_count` | `number` | Final count after onboarding. |
 | `strictness` | `"relaxed" \| "balanced" \| "strict"` | The Phase 3.5 toggle value. |
+| `taste_signal_count` | `number?` | Phase 8.5 — liked + disliked tags + ingredients set in the "What do you love?" step. Optional; absent when the step was skipped or for pre-8.5 callers. |
 
 ### `menu_filtered`
 Fired when the user lands on a filtered restaurant page and the items endpoint returns. Once per page render, not per item.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,9 +22,8 @@ at the bottom until credentials drop.
 
 Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemRow + Phase 4.11.4 photo snapshot landed in #192. Phase 3.2 onboarding-screen backfill landed in this PR — Phases 3.4 (HiddenReasonChip) and 3.5 (StrictnessToggle) are already covered by `restaurant-screen.render.test.tsx` (#191), and the Phase 3.3 helpers (FilterBadge, SectionBlock) are simple enough to wait for a real bug to motivate them. **No remaining loop-shippable test-infra followups.**
 
-1. **Phase 8.5b — taste onboarding UI (web + mobile)** (`docs/plans/phase-8.md`) — foundations shipped in 8.5a: GET /api/v1/tags (?families=), reducer CYCLE_TASTE_TAG/INGREDIENT cycle, toProfilePayload taste arrays, toTastePayload (standalone "Improve my picks" save that can't wipe avoid lists). Remaining: the "What do you love?" step UI on both surfaces (chips from ?families=cuisine,flavor + optional ingredient search, skippable, step between strictness and review), ?step=taste standalone entry + an "Improve my picks" link, optional `taste_signal_count` prop on profile_set.
-15. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
-16. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
+1. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
+2. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
 ### Done
 
@@ -105,7 +104,8 @@ Test-infra wiring shipped both sides (web in #189, mobile in #191). Mobile ItemR
 - ✅ Phase 8.2 — taste scoring engine: SQL TasteScoring + TS scoreItem/topPicks, shared parity fixture both suites assert to 4dp, taste_score/taste_reasons on the items endpoint (#310)
 - ✅ Phase 8.3 — Top Picks UI (web): server-score-driven row + "because you like…" lines + Why-these explainer; anonymous unchanged (#311)
 - ✅ Phase 8.4 — Top Picks UI (mobile); selector + reason-line moved into filter-engine so web/mobile share one implementation (#312)
-- ✅ Phase 8.5a — taste onboarding foundations: tags endpoint (Phase-0 route had no action), reducer taste cycle + payload helpers (this PR)
+- ✅ Phase 8.5a — taste onboarding foundations: tags endpoint (Phase-0 route had no action), reducer taste cycle + payload helpers (#313)
+- ✅ Phase 8.5b — taste onboarding UI (web + mobile): "What do you love?" step (cuisine/flavor chips + optional ingredient search, skippable) between strictness and review; ?step=taste standalone "Improve my picks" save (taste-only, can't wipe avoid lists); taste_signal_count on profile_set (this PR) — **Phase 8 feature-complete: safety filters, taste ranks, end to end**
 
 **🎉 Phase 5 loop work is complete.** Every loop-shippable launch piece is on master. The remaining queue is entirely human-credential-gated; see `docs/launch-readiness.md` for the linear path from "code complete" to "real users on a Friday night."
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -13,6 +13,32 @@ without spelunking GitHub.
 
 ---
 
+2026-06-13 05:30 — tick #147. **Phase 8.5b shipped — taste onboarding
+UI (web + mobile). Phase 8 feature-complete.** JS-only PR (no apps/api
+changes → ci-api/rspec/brakeman/openapi untouched).
+- New "What do you love?" step between strictness and review on both
+  surfaces (now 5 steps): cuisine/flavor tag chips from
+  GET /api/v1/tags?families=cuisine,flavor that cycle neutral → liked
+  → disliked → neutral on tap, plus an optional favorite-ingredient
+  search. Skippable — taste is soft, safety is not.
+- Standalone "Improve my picks": `?step=taste` (web useSearchParams,
+  mobile useLocalSearchParams) opens the step alone and saves via the
+  taste-only saveTaste/toTastePayload, so refining picks can NEVER
+  wipe the avoid lists. Web page wrapped in <Suspense> (Next 15
+  useSearchParams prod-build requirement). Entry link added to the
+  TopPicksRow header on both surfaces.
+- Contract: optional taste_signal_count on profile_set (analytics
+  EventPropsMap + docs/analytics.md, both updated same PR; no rename).
+  fetchTags + saveTaste + SaveTastePayload added to both onboarding
+  libs; SaveProfilePayload extended with the 4 optional taste arrays.
+- Tests: web 153 (+9: fetchTags/saveTaste lib shapes + taste-step page
+  render incl. standalone-save footgun guard + improve-picks link),
+  mobile 120 (+2: taste step in the of-5 flow + chip cycle); existing
+  of-4 flow assertions migrated to of-5. typecheck/lint green across
+  the workspace.
+Next: Phase 8 done — remaining queue is human-credential-gated launch
+wiring (see docs/launch-readiness.md).
+
 2026-06-13 03:15 — tick #146. **Phase 8.5a shipped — taste onboarding
 foundations** (session wrapping on user request; 8.5b = the UI half,
 queued at the top of Next-up with a full handoff note).

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -76,6 +76,12 @@ export interface EventPropsMap {
     avoid_ingredient_count: number;
     avoid_tag_count: number;
     strictness: 'relaxed' | 'balanced' | 'strict';
+    /**
+     * Phase 8.5 — total taste signals set during onboarding (liked +
+     * disliked tags + ingredients). Optional: pre-8.5 callers and the
+     * standalone "Improve my picks" save omit it.
+     */
+    taste_signal_count?: number;
   };
   menu_filtered: {
     restaurant_slug: string;


### PR DESCRIPTION
## Phase 8.5b — taste onboarding UI (web + mobile)

Completes Phase 8.5 — 8.5a (#313) shipped the backend + shared foundations; this PR adds the UI on both surfaces and closes **Phase 8** (taste ranking). Design principle held throughout: **safety filters, taste ranks** — taste signals only reorder/highlight, they never hide food.

### What's new
- **"What do you love?" step** between strictness and review (onboarding is now 5 steps on both web + mobile): tap cuisine/flavor **tag chips** (from `GET /api/v1/tags?families=cuisine,flavor`) that cycle **neutral → liked → disliked → neutral** on a single tap target, plus an **optional favorite-ingredient search**. The step is **skippable** — taste is optional, safety is not.
- **Standalone "Improve my picks"**: `?step=taste` opens the taste step on its own and saves via the **taste-only** `saveTaste` / `toTastePayload`. Because the profile endpoint replaces arrays wholesale, a standalone save that carried the (empty) avoid lists would wipe the user's safety filter — this path omits them entirely. A guard test asserts the payload carries no `avoid_*` keys.
- **Entry link**: an "Improve my picks" link added to the `TopPicksRow` header on web + mobile → `/onboarding?step=taste`.
- Web onboarding page wrapped in `<Suspense>` (Next 15's `useSearchParams` static-build requirement).

### Contract
- Optional `taste_signal_count` on `profile_set` — added to both `packages/analytics` `EventPropsMap` **and** `docs/analytics.md` in the same PR. **No event rename** (renames break funnels); optional-field-only.
- `fetchTags` + `saveTaste` + `SaveTastePayload` added to both onboarding libs; `SaveProfilePayload` extended with the 4 optional taste arrays.

### Tests
- **web 153** (+9): `fetchTags`/`saveTaste` wire shapes, taste-step page render incl. standalone-save footgun guard, the improve-picks link.
- **mobile 120** (+2): taste step in the of-5 flow + chip cycle. Existing of-4 flow assertions migrated to of-5.
- `pnpm typecheck` + `pnpm lint` green across the workspace.

### Scope note
JS-only — **no `apps/api/` changes**, so `ci-api`, rspec, brakeman, and `docs/openapi.json` are untouched (the tags endpoint shipped in 8.5a). Formatting matches the surrounding hand-formatted style; this repo's source already predates prettier enforcement (eslint is the gate and passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)