### PR TITLE
build: full Docker local-dev stack (API + worker + Postgres)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,14 +82,20 @@ pnpm web <script>          # alias for: pnpm --filter @biteworthy/web ...
 pnpm mobile <script>       # alias for: pnpm --filter @biteworthy/mobile ...
 ```
 
-The API has its own toolchain — run from `apps/api/`:
+The fastest path is the containerized stack — `docker compose up` (from the
+repo root) boots the API on `:3000`, the Solid Queue worker, and Postgres,
+with `apps/api` bind-mounted for hot reload. `docker compose up -d postgres`
+still starts Postgres alone if you'd rather run the API natively. See
+`docs/local-dev.md` for the full guide.
+
+The API has its own toolchain — run from `apps/api/` (native path):
 
 ```bash
 docker compose up -d postgres           # (from repo root) local Postgres 16, localhost-only, trust auth
 bundle install
-bin/rails db:create db:schema:load db:seed
+bin/rails db:prepare                    # create + load schema + seed (idempotent)
 bin/rails s -p 3000                     # API on :3000 (web is on :3001)
-bin/jobs                                # Solid Queue worker (or boot inline: SOLID_QUEUE_IN_PUMA=true bin/rails s)
+bin/rails solid_queue:start             # Solid Queue worker (or boot inline: SOLID_QUEUE_IN_PUMA=true bin/rails s)
 bundle exec rspec                       # full test suite
 bundle exec rspec spec/requests/foo_spec.rb     # one file
 bundle exec rspec spec/requests/foo_spec.rb:42  # one example by line
@@ -97,6 +103,9 @@ bundle exec rubocop --parallel
 bundle exec brakeman --no-pager --quiet --format plain
 bin/openapi-export                      # regenerate docs/openapi.json from the rswag specs
 ```
+
+Inside the containerized stack the same commands run via
+`docker compose exec api …` (e.g. `docker compose exec api bundle exec rspec`).
 
 Per-app test runners (use these for narrow runs instead of `pnpm test`):
 

--- a/README.md
+++ b/README.md
@@ -28,21 +28,42 @@ biteworthy/
 
 ## Quickstart
 
-Requires Ruby 3.3+, Node 22+, pnpm 10+, Docker (or a local Postgres 16+).
+Requires Docker, plus Node 22+ and pnpm 10+ for web/mobile (and Ruby 3.3+
+only if you run the API natively).
+
+### Option A — containerized API (recommended)
+
+The API, its Solid Queue worker, and Postgres run in Docker; web and
+mobile run natively. One command brings the server side up:
+
+```bash
+cp apps/api/.env.example apps/api/.env   # optional — only ingestion needs a key
+docker compose up                        # API :3000 + worker + Postgres
+                                         # first boot installs gems, creates + seeds the DB
+
+pnpm install
+pnpm dev                                 # web :3001 + mobile, via Turborepo
+```
+
+Edits to `apps/api` hot-reload (source is bind-mounted). `docker compose
+down` stops it; add `-v` to also drop the database volume.
+
+### Option B — everything native
 
 ```bash
 pnpm install
-docker compose up -d postgres    # local Postgres 16 for the API
-pnpm dev                         # boots web + mobile concurrently via Turborepo
+docker compose up -d postgres    # just Postgres 16 in a container
+pnpm dev                         # web + mobile
 
-# The Rails API is not part of the pnpm workspace — boot it separately:
-cd apps/api
+cd apps/api                      # the API is not in the pnpm workspace
 bundle install
-bin/rails db:create db:schema:load db:seed
+bin/rails db:prepare             # create + load schema + seed
 bin/rails s -p 3000              # web dev server is on :3001
+bin/rails solid_queue:start      # background-job worker, in a second terminal
 ```
 
-Each app also has its own README under `apps/<name>/`.
+See [`docs/local-dev.md`](docs/local-dev.md) for the full local-development
+guide. Each app also has its own README under `apps/<name>/`.
 
 ## Status
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -25,6 +25,42 @@ ENV RAILS_ENV="production" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development:test"
 
+# --- dev stage (local development — see /compose.yaml) -----------------------
+# NOT part of the production build (that's the final unnamed stage below).
+# Overrides the base's production ENV: RAILS_ENV=development, dev + test
+# gems included, no deployment lockdown. At runtime compose.yaml bind-
+# mounts the source over /rails and mounts a named `bundle` volume over
+# BUNDLE_PATH (seeded from the gems baked in here), so a Gemfile change
+# self-heals via `bundle check || bundle install` on boot instead of a
+# rebuild. Runs as root so writes into the bind-mounted tmp/ and log/
+# don't trip host-ownership issues.
+FROM base AS dev
+
+ENV RAILS_ENV="development" \
+    BUNDLE_DEPLOYMENT="" \
+    BUNDLE_WITHOUT=""
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+        build-essential \
+        git \
+        libpq-dev \
+        libyaml-dev \
+        pkg-config \
+        curl \
+        libvips42 \
+        imagemagick \
+        postgresql-client && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bake the current lockfile's gems into the image; the named volume in
+# compose seeds from this on first run.
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+EXPOSE 3000
+CMD ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+
 # --- build stage -------------------------------------------------------------
 FROM base AS build
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,13 +1,46 @@
-# Local-dev Postgres for the Rails API.
+# Local-dev stack for the Rails API.
 #
-# Web / mobile / API run natively; only the database is containerized.
-# Usage:
-#   docker compose up -d postgres
-#   cd apps/api && bin/rails db:create db:schema:load db:seed
+# Two ways to use this:
+#
+#   1. Full containerized stack (API + worker + Postgres):
+#        cp apps/api/.env.example apps/api/.env   # optional — see notes
+#        docker compose up
+#      → API on http://localhost:3000, Solid Queue worker, Postgres.
+#      Source is bind-mounted, so edits hot-reload (Rails dev reloader).
+#      First boot installs gems + runs db:prepare (creates + seeds).
+#
+#   2. Postgres only (run web/mobile/API natively, as before):
+#        docker compose up -d postgres
+#        cd apps/api && bin/rails db:prepare && bin/rails s -p 3000
+#
+# Mobile (Expo) always runs natively — it needs simulator/device access
+# that doesn't containerize cleanly. Web can run natively (`pnpm dev`,
+# port 3001) against the containerized API on :3000.
 #
 # Auth: POSTGRES_HOST_AUTH_METHOD=trust matches database.yml defaults
-# (host=localhost, user=postgres, password=""). Safe because the port
-# is bound to localhost only. Dev use only.
+# (user=postgres, password=""). Safe because the port is bound to
+# localhost only. Dev use only.
+
+# Shared config for the API + worker — same image, same mounts, same DB.
+x-api-base: &api-base
+  build:
+    context: ./apps/api
+    target: dev
+  environment:
+    DATABASE_HOST: postgres
+    RAILS_ENV: development
+  env_file:
+    # Optional: holds ANTHROPIC_API_KEY etc. The stack boots without it;
+    # only the ingestion pipeline needs the key. `cp .env.example .env`.
+    - path: ./apps/api/.env
+      required: false
+  volumes:
+    - ./apps/api:/rails
+    - bundle:/usr/local/bundle
+  depends_on:
+    postgres:
+      condition: service_healthy
+  restart: unless-stopped
 
 services:
   postgres:
@@ -26,5 +59,42 @@ services:
       retries: 10
     restart: unless-stopped
 
+  # Rails API (Puma). Clears any stale server pid, self-heals gems if the
+  # Gemfile changed since the last build, prepares the dev databases
+  # (create + load schema + seed on first run), then boots on 0.0.0.0.
+  api:
+    <<: *api-base
+    container_name: biteworthy-api
+    command: >
+      bash -c "rm -f tmp/pids/server.pid &&
+               (bundle check || bundle install) &&
+               ./bin/rails db:prepare &&
+               ./bin/rails server -b 0.0.0.0 -p 3000"
+    ports:
+      - '127.0.0.1:3000:3000'
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -fsS http://localhost:3000/up || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      # Generous: covers first-boot bundle install + db:prepare.
+      start_period: 90s
+
+  # Solid Queue worker (background jobs — the ingestion pipeline). Waits
+  # for the API to be healthy so db:prepare has loaded the queue schema
+  # before this starts polling. Same command the Kamal `worker` role runs.
+  worker:
+    <<: *api-base
+    container_name: biteworthy-worker
+    command: >
+      bash -c "(bundle check || bundle install) &&
+               ./bin/rails solid_queue:start"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+
 volumes:
   pgdata:
+  bundle:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,157 @@
+# Local development
+
+How to run BiteWorthy on your machine. Two supported paths: a
+**containerized** server side (recommended) or **everything native**.
+
+- **API** (Rails 8) — containerized or native.
+- **Web** (Next.js, port `3001`) — native (`pnpm dev`). Talks to the API
+  on `:3000`.
+- **Mobile** (Expo) — always native. Expo needs simulator/device access
+  and a Metro bundler that don't containerize cleanly.
+
+The data model and the apps are described in [`README.md`](../README.md),
+[`schema.md`](schema.md), and each app's own `README`. This file is just
+the run book.
+
+## Prerequisites
+
+| Tool | Version | Needed for |
+|---|---|---|
+| Docker (Desktop or Engine) | recent | Postgres, and the containerized API |
+| Node | 22+ | web + mobile |
+| pnpm | 10+ | web + mobile (`corepack enable` or `npm i -g pnpm`) |
+| Ruby | 3.3.6 | only if running the API **natively** |
+
+`.nvmrc` and `.ruby-version` pin the exact versions.
+
+## Option A — containerized API (recommended)
+
+The API, its Solid Queue worker, and Postgres run in Docker; web and
+mobile run natively.
+
+```bash
+cp apps/api/.env.example apps/api/.env   # optional — see "Environment" below
+docker compose up                        # API :3000 + worker + Postgres
+
+pnpm install
+pnpm dev                                 # web :3001 + mobile, via Turborepo
+```
+
+What `docker compose up` does:
+
+- **`postgres`** — Postgres 16, bound to `127.0.0.1:5432`, trust auth,
+  data persisted in the `pgdata` named volume.
+- **`api`** — builds the `dev` stage of `apps/api/Dockerfile`, then on
+  every boot clears any stale Puma pid, runs `bundle check || bundle
+  install` (self-heals after a Gemfile change), runs `bin/rails
+  db:prepare` (creates + loads schema + **seeds on first run**), and
+  boots Puma on `0.0.0.0:3000`. Health-checked at `/up`.
+- **`worker`** — same image, runs `bin/rails solid_queue:start`. Waits
+  for `api` to be healthy so the queue schema exists before it polls.
+
+`apps/api` is bind-mounted into the container, so code edits hot-reload
+via Rails' dev reloader — no rebuild needed. Gems live in a named
+`bundle` volume (seeded from the image), so they persist across restarts.
+
+First boot pulls the Ruby image, installs gems, and seeds the DB — a few
+minutes. Later boots are seconds.
+
+### Everyday commands
+
+```bash
+docker compose up -d                 # start in the background
+docker compose logs -f api           # tail API logs (or: worker, postgres)
+docker compose ps                    # what's running + health
+
+docker compose exec api bash                         # shell in the API container
+docker compose exec api bin/rails console            # Rails console
+docker compose exec api bundle exec rspec            # run the test suite
+docker compose exec api bin/rails db:migrate         # run a new migration
+docker compose exec api bin/openapi-export           # regenerate docs/openapi.json
+
+docker compose down                  # stop (keeps the DB volume)
+docker compose down -v               # stop AND drop pgdata + bundle volumes (full reset)
+docker compose up -d --build         # rebuild after a Gemfile / Dockerfile change
+```
+
+> Rebuild the image (`--build`) when you change the `Gemfile`/`Dockerfile`.
+> A plain restart self-heals gems via `bundle check`, but rebuilding bakes
+> them into the image so the next clean boot is fast.
+
+## Option B — everything native
+
+Run only Postgres in a container; everything else on the host.
+
+```bash
+pnpm install
+docker compose up -d postgres        # just Postgres 16
+
+cd apps/api                          # the API is NOT in the pnpm workspace
+bundle install
+bin/rails db:prepare                 # create + load schema + seed (idempotent)
+bin/rails s -p 3000                  # API on :3000
+bin/rails solid_queue:start          # background-job worker, second terminal
+```
+
+Then `pnpm dev` from the repo root for web + mobile.
+
+Postgres needs the `ltree`, `pg_trgm`, `pgcrypto`, and `citext`
+extensions. The migrations enable them, but the role needs `CREATE
+EXTENSION` rights the first time (the containerized `postgres` superuser
+has them already).
+
+## Environment
+
+`apps/api/.env` (gitignored) holds local secrets; `apps/api/.env.example`
+is the canonical, commented template. The stack **boots without it** —
+every value has a dev default or fallback.
+
+You only need a value to exercise the feature it gates:
+
+| Variable | Needed for |
+|---|---|
+| `ANTHROPIC_API_KEY` | the AI menu-ingestion pipeline (`docs/ingestion.md`) |
+| `GOOGLE_OAUTH_*`, `APPLE_OAUTH_*` | real social sign-in flows |
+| `ADMIN_USERNAME` / `ADMIN_PASSWORD` | the Avo admin at `/admin` (defaults `admin`/`admin`) |
+
+In the container, `DATABASE_HOST` is set to the `postgres` service name by
+`compose.yaml`, so you don't set it in `.env`.
+
+## How the apps connect
+
+- **Web → API**: the web app calls `NEXT_PUBLIC_API_BASE` (default
+  `http://localhost:3000`). The containerized API publishes `:3000` on the
+  host, so the default works whether the API is containerized or native.
+- **Mobile → API**: set `EXPO_PUBLIC_API_BASE`. On a simulator
+  `http://localhost:3000` works; on a physical device use your machine's
+  LAN IP (e.g. `http://192.168.x.y:3000`).
+
+## Ports
+
+| Port | Service |
+|---|---|
+| `3000` | Rails API (Puma) |
+| `3001` | Next.js web dev server |
+| `5432` | Postgres (bound to `127.0.0.1`) |
+| `8081` | Expo / Metro bundler (when mobile is running) |
+
+## Troubleshooting
+
+- **`bind: address already in use` on 3000/5432** — something is already
+  on that port (a native Rails/Postgres, or a previous stack). Stop it, or
+  `docker compose down`. The API binds `5432`/`3000` to `127.0.0.1` only.
+- **`A server is already running` (stale pid)** — the `api` command clears
+  `tmp/pids/server.pid` on boot, but if you crashed mid-run, `docker
+  compose restart api` re-runs it.
+- **Changed the `Gemfile` and the container can't find a gem** — restart
+  (`bundle check` reinstalls) or `docker compose up -d --build` to bake it
+  in.
+- **Want a clean database** — `docker compose down -v` drops the `pgdata`
+  volume; the next `up` recreates and reseeds. Or, without a full reset:
+  `docker compose exec api bin/rails db:reset`.
+- **Migrations from a teammate's branch** — `docker compose exec api
+  bin/rails db:migrate` (or just restart `api`; `db:prepare` runs pending
+  migrations on boot).
+- **Tests** — run inside the container so they hit the right Postgres:
+  `docker compose exec api bundle exec rspec`. CI runs the same suite
+  against its own Postgres service (`.github/workflows/ci-api.yml`).


### PR DESCRIPTION
## Full Docker local-dev stack

`docker compose up` now boots the entire server side — **Rails API** (`:3000`), the **Solid Queue worker**, and **Postgres** — with `apps/api` bind-mounted for hot reload. Web/mobile stay native (Expo needs simulator/device access that doesn't containerize cleanly). The documented `docker compose up -d postgres` still works for the all-native path.

### Changes
- **`apps/api/Dockerfile`** — new `dev` stage: reuses `base`, resets to `RAILS_ENV=development` with dev+test gems and `libvips`/`imagemagick`/`postgresql-client`. **Production stages untouched.**
- **`compose.yaml`** — `api` + `worker` services off a shared YAML anchor. `api` clears any stale pid, self-heals gems (`bundle check || bundle install`), runs `db:prepare` (create + load schema + **seed on first run**), boots on `0.0.0.0`, health-checked at `/up`. `worker` runs `solid_queue:start` once the API is healthy (so the queue schema exists). `DATABASE_HOST=postgres`; gems persist in a named `bundle` volume; `apps/api/.env` loaded with `required: false`.
- **`docs/local-dev.md`** (new) — full run book: both paths, environment, ports, everyday `docker compose exec` commands, troubleshooting. README + CLAUDE.md now point at it, and I fixed stale references along the way (`bin/jobs` → `solid_queue:start`, `db:create db:schema:load db:seed` → `db:prepare`).

### Verification — please read
`docker compose config` validates and the anchors resolve correctly (`api` target=`dev`, `DATABASE_HOST=postgres`, worker waits on api health). **The image build + boot could not be exercised in the sandbox this was authored in** — it has no Docker Hub egress, so `ruby:3.3.6-slim` and the BuildKit frontend can't be pulled (`postgres:16` only works because it was already cached). **Please run `docker compose up` on a networked machine to confirm end-to-end** before relying on it.

No CI impact: `ci-api.yml` boots its own Postgres and runs rspec natively, not via this compose stack — so the required checks don't exercise (or gate on) these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)