### PR TITLE
refactor(web): single source of truth for API_BASE

### DIFF
--- a/apps/web/src/app/api/auth/[action]/route.ts
+++ b/apps/web/src/app/api/auth/[action]/route.ts
@@ -17,7 +17,7 @@ import { SESSION_COOKIE } from '../../../../lib/server-auth';
 import { getServerJwt } from '../../../../lib/server-auth';
 import { buildAuthCookieOptions } from '../../../../lib/cookie-options';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../lib/api-base';
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 const ACTIONS = new Set(['login', 'signup', 'logout']);

--- a/apps/web/src/app/api/ingestion_runs/[id]/items/[itemId]/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/items/[itemId]/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../../lib/api-base';
 
 export async function PATCH(
   request: NextRequest,

--- a/apps/web/src/app/api/ingestion_runs/[id]/items/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/items/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../lib/api-base';
 
 export async function GET(
   _request: NextRequest,

--- a/apps/web/src/app/api/ingestion_runs/[id]/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../lib/api-base';
 
 export async function GET(
   _request: NextRequest,

--- a/apps/web/src/app/api/ingestion_runs/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/route.ts
@@ -7,7 +7,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../lib/api-base';
 
 export async function POST(request: NextRequest) {
   const jwt = await getServerJwt();

--- a/apps/web/src/app/api/items/[id]/never_hide/route.ts
+++ b/apps/web/src/app/api/items/[id]/never_hide/route.ts
@@ -8,7 +8,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../lib/api-base';
 
 async function proxy(method: 'POST' | 'DELETE', id: string) {
   const jwt = await getServerJwt();

--- a/apps/web/src/app/api/items/[id]/reviews/route.ts
+++ b/apps/web/src/app/api/items/[id]/reviews/route.ts
@@ -8,7 +8,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../lib/api-base';
 
 export async function GET(
   request: NextRequest,

--- a/apps/web/src/app/api/items/[id]/suggestions/route.ts
+++ b/apps/web/src/app/api/items/[id]/suggestions/route.ts
@@ -7,7 +7,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../lib/api-base';
 
 export async function POST(
   request: NextRequest,

--- a/apps/web/src/app/api/profile/history/route.ts
+++ b/apps/web/src/app/api/profile/history/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../lib/api-base';
 
 export async function GET(request: NextRequest) {
   const jwt = await getServerJwt();

--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -6,7 +6,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../lib/api-base';
 
 export async function PATCH(request: NextRequest) {
   const jwt = await getServerJwt();

--- a/apps/web/src/app/api/restaurants/[slug]/claim/route.ts
+++ b/apps/web/src/app/api/restaurants/[slug]/claim/route.ts
@@ -10,7 +10,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../lib/api-base';
 
 export async function POST(
   request: NextRequest,

--- a/apps/web/src/app/api/restaurants/[slug]/claim/verify/route.ts
+++ b/apps/web/src/app/api/restaurants/[slug]/claim/verify/route.ts
@@ -4,7 +4,7 @@
  */
 import { NextResponse, type NextRequest } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../../lib/api-base';
 
 export async function GET(
   request: NextRequest,

--- a/apps/web/src/app/api/restaurants/[slug]/suggestions/route.ts
+++ b/apps/web/src/app/api/restaurants/[slug]/suggestions/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse } from 'next/server';
 import { getServerJwt } from '../../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../../lib/api-base';
 
 export async function GET(
   _request: Request,

--- a/apps/web/src/app/api/restaurants/route.ts
+++ b/apps/web/src/app/api/restaurants/route.ts
@@ -7,7 +7,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../lib/api-base';
 
 export async function POST(request: NextRequest) {
   const jwt = await getServerJwt();

--- a/apps/web/src/app/api/reviews/[id]/route.ts
+++ b/apps/web/src/app/api/reviews/[id]/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../lib/api-base';
 
 async function proxy(method: 'PATCH' | 'DELETE', id: string, request: NextRequest) {
   const jwt = await getServerJwt();

--- a/apps/web/src/app/api/suggestions/[id]/route.ts
+++ b/apps/web/src/app/api/suggestions/[id]/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getServerJwt } from '../../../../lib/server-auth';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../../lib/api-base';
 
 export async function PATCH(
   request: NextRequest,

--- a/apps/web/src/app/api/waitlist/route.ts
+++ b/apps/web/src/app/api/waitlist/route.ts
@@ -9,7 +9,7 @@
 
 import { NextResponse, type NextRequest } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../../../lib/api-base';
 
 interface SignupBody {
   email?: string;

--- a/apps/web/src/lib/api-base.ts
+++ b/apps/web/src/lib/api-base.ts
@@ -1,0 +1,12 @@
+/**
+ * The origin of the BiteWorthy Rails API.
+ *
+ * Single source of truth: every Next.js route handler (the `/api/*`
+ * proxy that injects the session cookie as a Bearer header) and every
+ * server-side fetch helper imports this instead of re-deriving it. The
+ * browser never sees it — these are all server-side reads.
+ *
+ * Defaults to the local API on :3000; production sets
+ * `NEXT_PUBLIC_API_BASE` to the deployed origin.
+ */
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -6,7 +6,7 @@
  * uses the global fetch.
  */
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from './api-base';
 
 export interface ApiOptions extends RequestInit {
   fetchImpl?: typeof fetch;

--- a/apps/web/src/lib/durango.ts
+++ b/apps/web/src/lib/durango.ts
@@ -16,7 +16,7 @@
  *     until the next deploy.
  */
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from './api-base';
 
 export const DURANGO_CITY_SLUG = 'durango';
 

--- a/apps/web/src/lib/reviews.ts
+++ b/apps/web/src/lib/reviews.ts
@@ -11,7 +11,7 @@
  */
 import { api, type ApiOptions } from './api';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from './api-base';
 
 export interface ReviewAuthor {
   id: string;


### PR DESCRIPTION
## DRY: one `API_BASE`, not 20 copies

`const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3000'` was copy-pasted verbatim into **20 files** — 17 `/api/*` route handlers (the proxy layer that injects the session cookie as a Bearer header) and 3 server-side fetch helpers (`api.ts`, `durango.ts`, `reviews.ts`).

Extracted to **`src/lib/api-base.ts`** as the single source of truth; every consumer now imports it. If the default origin ever changes, it changes in one place.

Pure structural dedupe — **zero behavior change** (the value is identical; these are all server-side reads, the browser never sees it). Relative imports match the repo convention (the `@/` alias is configured but unused elsewhere).

**Verified locally:** `pnpm --filter @biteworthy/web typecheck` + `lint` clean, **153/153** vitest pass.

First slice of the code-quality pass (`/loop`); more DRY/elegance PRs to follow per layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)