### PR TITLE
refactor(api): shared pagination helpers on BaseController

### DIFF
--- a/apps/api/app/controllers/api/v1/base_controller.rb
+++ b/apps/api/app/controllers/api/v1/base_controller.rb
@@ -9,6 +9,10 @@ module Api
       rescue_from ActiveRecord::RecordInvalid,     with: :render_unprocessable
       rescue_from ActionController::ParameterMissing, with: :render_unprocessable
 
+      # Upper bound on pagination offset — deep pagination past this is
+      # almost always a scraper, and an unbounded offset is a cheap DoS.
+      MAX_OFFSET = 10_000
+
       private
 
       def render_not_found(error)
@@ -17,6 +21,17 @@ module Api
 
       def render_unprocessable(error)
         render json: { error: error.message }, status: :unprocessable_entity
+      end
+
+      # Shared pagination parsing for the index actions. Each controller
+      # passes its own bounds (they differ per resource); the offset cap
+      # is uniform across the API.
+      def page_limit(default:, max:)
+        (params[:limit].presence || default).to_i.clamp(1, max)
+      end
+
+      def page_offset
+        (params[:offset].presence || 0).to_i.clamp(0, MAX_OFFSET)
       end
     end
   end

--- a/apps/api/app/controllers/api/v1/ingredients_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingredients_controller.rb
@@ -18,7 +18,7 @@ module Api
       DEFAULT_LIMIT = 20
 
       def index
-        limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
+        limit = page_limit(default: DEFAULT_LIMIT, max: MAX_LIMIT)
         scope = Ingredient.order(:path).limit(limit)
 
         if params[:q].present?

--- a/apps/api/app/controllers/api/v1/profile_history_controller.rb
+++ b/apps/api/app/controllers/api/v1/profile_history_controller.rb
@@ -14,8 +14,8 @@ module Api
       MAX_LIMIT     = 100
 
       def index
-        limit  = (params[:limit].presence  || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
-        offset = (params[:offset].presence || 0).to_i.clamp(0, 10_000)
+        limit  = page_limit(default: DEFAULT_LIMIT, max: MAX_LIMIT)
+        offset = page_offset
 
         scope = current_user.restaurant_visits
                             .newest_first

--- a/apps/api/app/controllers/api/v1/reviews_controller.rb
+++ b/apps/api/app/controllers/api/v1/reviews_controller.rb
@@ -20,8 +20,8 @@ module Api
       MAX_LIMIT     = 100
 
       def index
-        limit  = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
-        offset = (params[:offset].presence || 0).to_i.clamp(0, 10_000)
+        limit  = page_limit(default: DEFAULT_LIMIT, max: MAX_LIMIT)
+        offset = page_offset
         # Phase 4.6 — public feed shows visible (non-hidden) reviews only.
         # Flagged reviews stay public until a moderator decides; only
         # hide! removes them from the feed.

--- a/apps/api/app/controllers/api/v1/tags_controller.rb
+++ b/apps/api/app/controllers/api/v1/tags_controller.rb
@@ -17,7 +17,7 @@ module Api
       DEFAULT_LIMIT = 100
 
       def index
-        limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)
+        limit = page_limit(default: DEFAULT_LIMIT, max: MAX_LIMIT)
         scope = Tag.order(:family, :name).limit(limit)
 
         if params[:families].present?


### PR DESCRIPTION
## DRY: pagination parsing in one place

The limit/offset clamp was copy-pasted across four `index` actions:
- `limit = (params[:limit].presence || DEFAULT_LIMIT).to_i.clamp(1, MAX_LIMIT)` — in `tags`, `ingredients`, `profile_history`, `reviews`
- `offset = (params[:offset].presence || 0).to_i.clamp(0, 10_000)` — in `profile_history` + `reviews`, with the cap as a bare magic number

Extracted **`page_limit(default:, max:)`** and **`page_offset`** onto `BaseController` — where the shared `rescue_from` handlers already live, so no new concern/pattern is introduced — and named the offset cap `MAX_OFFSET`. Each controller keeps its own `DEFAULT_LIMIT`/`MAX_LIMIT` (they legitimately differ per resource); only the parsing is shared.

**Behavior-identical.** Verified locally:
- The four affected request specs pass **30/30** — unchanged from the pre-refactor baseline.
- No new rubocop offenses (the 2 on `base_controller.rb` are pre-existing repo style).

Next slice of the `/loop` code-quality pass. CI runs the full rspec suite as the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)