### PR TITLE
refactor(api): hoist photo_url_for + public_host to BaseController

### DIFF
--- a/apps/api/app/controllers/api/v1/base_controller.rb
+++ b/apps/api/app/controllers/api/v1/base_controller.rb
@@ -33,6 +33,22 @@ module Api
       def page_offset
         (params[:offset].presence || 0).to_i.clamp(0, MAX_OFFSET)
       end
+
+      # The origin absolute URLs should resolve from. Production sets
+      # PUBLIC_HOST (clients fetch from a different origin than the API);
+      # dev / CI fall back to the incoming request's base URL.
+      def public_host
+        ENV["PUBLIC_HOST"].presence || request.base_url
+      end
+
+      # Signed ActiveStorage blob URL for a record's attached `photo`,
+      # or nil when none is attached. Shared by the item / review / user
+      # serializers — built via the route helpers directly so it doesn't
+      # depend on Devise's URL helpers being mixed into the controller.
+      def photo_url_for(record)
+        return nil unless record.photo.attached?
+        Rails.application.routes.url_helpers.rails_blob_url(record.photo, host: public_host)
+      end
     end
   end
 end

--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -247,16 +247,6 @@ module Api
         }
       end
 
-      # Phase 4.11.3 — same shape as ReviewsController#photo_url_for.
-      # Returns the signed blob URL, falling back to the request's base
-      # URL when PUBLIC_HOST isn't set (dev / CI). Production deploys
-      # set PUBLIC_HOST so URLs work for clients on a different origin.
-      def photo_url_for(item)
-        return nil unless item.photo.attached?
-        host = ENV["PUBLIC_HOST"].presence || request.base_url
-        Rails.application.routes.url_helpers.rails_blob_url(item.photo, host: host)
-      end
-
       # Phase 4.4 — bulk-load review counts for the items in the
       # response. One grouped query, joined client-side so the
       # restaurant page can render an "X reviews" badge per item

--- a/apps/api/app/controllers/api/v1/restaurant_claims_controller.rb
+++ b/apps/api/app/controllers/api/v1/restaurant_claims_controller.rb
@@ -65,8 +65,7 @@ module Api
       # Build the URL the email recipient clicks. The web app at
       # PUBLIC_HOST handles /restaurants/<slug>/claim?t=<token>.
       def build_verify_url(restaurant, token)
-        host = ENV["PUBLIC_HOST"].presence || request.base_url
-        "#{host.chomp('/')}/restaurants/#{restaurant.slug}/claim?t=#{token}"
+        "#{public_host.chomp('/')}/restaurants/#{restaurant.slug}/claim?t=#{token}"
       end
     end
   end

--- a/apps/api/app/controllers/api/v1/reviews_controller.rb
+++ b/apps/api/app/controllers/api/v1/reviews_controller.rb
@@ -107,17 +107,6 @@ module Api
           updated_at:   review.updated_at
         }
       end
-
-      # Build the signed blob URL without depending on Devise's URL
-      # helpers being mixed into the controller. Falls back to the
-      # incoming request's base URL when PUBLIC_HOST isn't set (dev /
-      # CI). Production deploys should set PUBLIC_HOST so URLs work
-      # for clients fetching from a different origin.
-      def photo_url_for(review)
-        return nil unless review.photo.attached?
-        host = ENV["PUBLIC_HOST"].presence || request.base_url
-        Rails.application.routes.url_helpers.rails_blob_url(review.photo, host: host)
-      end
     end
   end
 end

--- a/apps/api/app/controllers/api/v1/users_controller.rb
+++ b/apps/api/app/controllers/api/v1/users_controller.rb
@@ -59,12 +59,6 @@ module Api
           created_at: review.created_at
         }
       end
-
-      def photo_url_for(review)
-        return nil unless review.photo.attached?
-        host = ENV["PUBLIC_HOST"].presence || request.base_url
-        Rails.application.routes.url_helpers.rails_blob_url(review.photo, host: host)
-      end
     end
   end
 end


### PR DESCRIPTION
## DRY: one `photo_url_for`, one `public_host`

`photo_url_for` was defined **identically** (only the param name differed) in three controllers — `items`, `reviews`, `users` — each re-resolving the host via `ENV["PUBLIC_HOST"].presence || request.base_url`. A fourth copy of that host line lived in `restaurant_claims#build_verify_url`.

Lifted a generic **`photo_url_for(record)`** and a **`public_host`** helper onto `BaseController` (next to the existing shared `rescue_from` + pagination helpers), deleted the three duplicates, and routed `build_verify_url` through `public_host`. **Net −12 lines.**

Behavior-identical. Verified locally against a real test DB:
- items **25**, items_taste **6**, reviews **17**, users **5**, restaurant_claims **9** — all 0 failures, matching the pre-refactor baseline.
- No new rubocop offenses; no `photo_url_for` defs or `PUBLIC_HOST` reads remain outside `BaseController`.

`restaurant_claims_spec` exercises `build_verify_url`, so the shared `public_host` is covered on that path too. Slice 3 of the `/loop` code-quality pass; CI runs the full rspec suite as the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)