### PR TITLE
refactor(mobile): single source of truth for API_BASE

### DIFF
--- a/apps/mobile/__tests__/lib/api-base.test.ts
+++ b/apps/mobile/__tests__/lib/api-base.test.ts
@@ -1,0 +1,22 @@
+describe('API_BASE', () => {
+  const original = process.env.EXPO_PUBLIC_API_BASE;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.EXPO_PUBLIC_API_BASE;
+    else process.env.EXPO_PUBLIC_API_BASE = original;
+    jest.resetModules();
+  });
+
+  it('defaults to the local API on :3000 when the env var is unset', () => {
+    delete process.env.EXPO_PUBLIC_API_BASE;
+    jest.resetModules();
+    // Re-require so the module-level const re-reads process.env.
+    expect(require('../../lib/api-base').API_BASE).toBe('http://localhost:3000');
+  });
+
+  it('uses EXPO_PUBLIC_API_BASE when set (deployed / LAN origin)', () => {
+    process.env.EXPO_PUBLIC_API_BASE = 'https://api.example.test';
+    jest.resetModules();
+    expect(require('../../lib/api-base').API_BASE).toBe('https://api.example.test');
+  });
+});

--- a/apps/mobile/lib/api-base.ts
+++ b/apps/mobile/lib/api-base.ts
@@ -1,0 +1,9 @@
+/**
+ * The origin of the BiteWorthy Rails API.
+ *
+ * Single source of truth: every `lib/api/*` fetch helper and the auth
+ * module import this instead of re-deriving it. Defaults to the local
+ * API on :3000; a build sets `EXPO_PUBLIC_API_BASE` to the deployed
+ * origin (and, for a physical device, the machine's LAN IP).
+ */
+export const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';

--- a/apps/mobile/lib/api/history.ts
+++ b/apps/mobile/lib/api/history.ts
@@ -3,7 +3,7 @@
  * Mirrors apps/web/src/lib/history.ts; mobile uses the JWT directly
  * via the keychain (no Next proxy on mobile).
  */
-const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../api-base';
 
 export interface HistoryRestaurantCity {
   slug: string;

--- a/apps/mobile/lib/api/ingestion-runs.ts
+++ b/apps/mobile/lib/api/ingestion-runs.ts
@@ -7,8 +7,7 @@
  * an admin user — Phase 4 will introduce a contributor role.
  */
 
-const API_BASE =
-  process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../api-base';
 
 export interface CapturedPage {
   /** A `file://` URI from `expo-camera`'s captured photo. */

--- a/apps/mobile/lib/api/onboarding.ts
+++ b/apps/mobile/lib/api/onboarding.ts
@@ -9,7 +9,7 @@
 
 import type { DietaryPreset } from '@biteworthy/filter-engine';
 
-const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../api-base';
 
 export interface IngredientSearchResult {
   id: string;

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -23,7 +23,7 @@ export type {
   TasteReason,
 } from '@biteworthy/filter-engine';
 
-const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../api-base';
 
 export interface FetchOptions {
   fetchImpl?: typeof fetch;

--- a/apps/mobile/lib/api/reviews.ts
+++ b/apps/mobile/lib/api/reviews.ts
@@ -8,7 +8,7 @@
  * Photo upload uses multipart with the file URI from expo-camera.
  */
 
-const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../api-base';
 
 export interface ReviewAuthor {
   id: string;

--- a/apps/mobile/lib/api/users.ts
+++ b/apps/mobile/lib/api/users.ts
@@ -3,7 +3,7 @@
  *
  * Anonymous endpoint, no JWT needed. Mirrors apps/web/src/lib/users.ts.
  */
-const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from '../api-base';
 
 export interface UserReviewItem {
   id: string;

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -14,7 +14,7 @@
  */
 import * as SecureStore from 'expo-secure-store';
 
-const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000';
+import { API_BASE } from './api-base';
 const TOKEN_KEY = 'bw_jwt';
 
 export interface UserPayload {


### PR DESCRIPTION
## DRY: one `API_BASE` on mobile too

`const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? 'http://localhost:3000'` was copy-pasted into **7 modules** — `lib/auth.ts` and the six `lib/api/*` fetch helpers (`history`, `onboarding`, `ingestion-runs`, `restaurants`, `users`, `reviews`). One used a line-wrapped form.

Extracted to **`lib/api-base.ts`** and imported everywhere — the mobile mirror of the web-side dedupe (#316).

Behavior-identical. Verified:
- `pnpm --filter @biteworthy/mobile typecheck` + `lint` clean.
- jest **122** (+2): a new `api-base` spec covering the `localhost:3000` default and the `EXPO_PUBLIC_API_BASE` override. The existing `auth`/`history`/`reviews`/etc. specs already exercise the consumers.

Slice 4 of the `/loop` code-quality pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)