### PR TITLE
refactor(web): extract proxyAuthed/relayUpstream for /api routes

### DIFF
--- a/apps/web/src/app/api/ingestion_runs/[id]/items/[itemId]/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/items/[itemId]/route.ts
@@ -2,36 +2,16 @@
  * Phase 6.5 — `PATCH /api/ingestion_runs/:id/items/:itemId` proxies
  * accept / reject / edit decisions from the web verify page.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../../../../lib/server-auth';
-
-import { API_BASE } from '../../../../../../lib/api-base';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../../../lib/api-proxy';
 
 export async function PATCH(
   request: NextRequest,
   context: { params: Promise<{ id: string; itemId: string }> },
 ) {
-  const jwt = await getServerJwt();
-  if (!jwt) {
-    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-  }
   const { id, itemId } = await context.params;
-  const body = await request.text();
-  const upstream = await fetch(
-    `${API_BASE}/api/v1/ingestion_runs/${encodeURIComponent(id)}/items/${encodeURIComponent(itemId)}`,
-    {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body,
-    },
+  return proxyAuthed(
+    `/api/v1/ingestion_runs/${encodeURIComponent(id)}/items/${encodeURIComponent(itemId)}`,
+    { method: 'PATCH', body: await request.text() },
   );
-  const responseText = await upstream.text();
-  return new NextResponse(responseText, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
-  });
 }

--- a/apps/web/src/app/api/ingestion_runs/[id]/items/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/items/route.ts
@@ -1,31 +1,14 @@
 /**
  * Phase 6.5 — `GET /api/ingestion_runs/:id/items` proxies the staged
  * item list for the web verify page (creator-or-admin per Phase 6.3).
+ * `no-store` so the verify page always sees fresh staging state.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../../../lib/server-auth';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../../lib/api-proxy';
 
-import { API_BASE } from '../../../../../lib/api-base';
-
-export async function GET(
-  _request: NextRequest,
-  context: { params: Promise<{ id: string }> },
-) {
-  const jwt = await getServerJwt();
-  if (!jwt) {
-    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-  }
+export async function GET(_request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params;
-  const upstream = await fetch(
-    `${API_BASE}/api/v1/ingestion_runs/${encodeURIComponent(id)}/items`,
-    {
-      headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
-      cache: 'no-store',
-    },
-  );
-  const responseText = await upstream.text();
-  return new NextResponse(responseText, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  return proxyAuthed(`/api/v1/ingestion_runs/${encodeURIComponent(id)}/items`, {
+    cache: 'no-store',
   });
 }

--- a/apps/web/src/app/api/ingestion_runs/[id]/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/route.ts
@@ -1,28 +1,11 @@
 /**
  * Phase 6.5 — `GET /api/ingestion_runs/:id` proxies run-status
- * polling for the web verify flow.
+ * polling for the web verify flow. `no-store` so polling isn't cached.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../../lib/server-auth';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../lib/api-proxy';
 
-import { API_BASE } from '../../../../lib/api-base';
-
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const jwt = await getServerJwt();
-  if (!jwt) {
-    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-  }
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const upstream = await fetch(`${API_BASE}/api/v1/ingestion_runs/${encodeURIComponent(id)}`, {
-    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
-    cache: 'no-store',
-  });
-  const responseText = await upstream.text();
-  return new NextResponse(responseText, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
-  });
+  return proxyAuthed(`/api/v1/ingestion_runs/${encodeURIComponent(id)}`, { cache: 'no-store' });
 }

--- a/apps/web/src/app/api/profile/history/route.ts
+++ b/apps/web/src/app/api/profile/history/route.ts
@@ -2,23 +2,9 @@
  * Phase 4.8 — proxy GET /api/profile/history to Rails with the
  * bw_session cookie's JWT.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../../lib/server-auth';
-
-import { API_BASE } from '../../../../lib/api-base';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../lib/api-proxy';
 
 export async function GET(request: NextRequest) {
-  const jwt = await getServerJwt();
-  if (!jwt) {
-    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-  }
-  const search = request.nextUrl.search ?? '';
-  const upstream = await fetch(`${API_BASE}/api/v1/profile/history${search}`, {
-    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
-  });
-  const body = await upstream.text();
-  return new NextResponse(body, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
-  });
+  return proxyAuthed(`/api/v1/profile/history${request.nextUrl.search ?? ''}`);
 }

--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -3,29 +3,9 @@
  * from the HttpOnly `bw_session` cookie. Lets the onboarding page
  * call `saveProfile` without ever touching the JWT in JS.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../lib/server-auth';
-
-import { API_BASE } from '../../../lib/api-base';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../lib/api-proxy';
 
 export async function PATCH(request: NextRequest) {
-  const jwt = await getServerJwt();
-  if (!jwt) {
-    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-  }
-  const body = await request.text();
-  const upstream = await fetch(`${API_BASE}/api/v1/profile`, {
-    method: 'PATCH',
-    headers: {
-      Authorization: `Bearer ${jwt}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body,
-  });
-  const responseText = await upstream.text();
-  return new NextResponse(responseText, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
-  });
+  return proxyAuthed('/api/v1/profile', { method: 'PATCH', body: await request.text() });
 }

--- a/apps/web/src/app/api/restaurants/[slug]/claim/route.ts
+++ b/apps/web/src/app/api/restaurants/[slug]/claim/route.ts
@@ -1,38 +1,15 @@
 /**
  * Phase 4.9 — proxy POST /api/restaurants/:slug/claim (request a
- * claim verification email) + GET /api/restaurants/:slug/claim/verify
- * (anonymous token verification).
- *
- * POST is auth-gated and runs through the cookie's JWT. GET is
- * anonymous (the URL token IS the credential), so we forward
- * straight through with no auth header.
+ * claim verification email) with the cookie's JWT. The anonymous
+ * token verification lives at .../claim/verify.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../../../lib/server-auth';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../../lib/api-proxy';
 
-import { API_BASE } from '../../../../../lib/api-base';
-
-export async function POST(
-  request: NextRequest,
-  context: { params: Promise<{ slug: string }> },
-) {
+export async function POST(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
   const { slug } = await context.params;
-  const jwt = await getServerJwt();
-  if (!jwt) return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-
-  const body = await request.text();
-  const upstream = await fetch(`${API_BASE}/api/v1/restaurants/${encodeURIComponent(slug)}/claim`, {
+  return proxyAuthed(`/api/v1/restaurants/${encodeURIComponent(slug)}/claim`, {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${jwt}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body,
-  });
-  const text = await upstream.text();
-  return new NextResponse(text, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+    body: await request.text(),
   });
 }

--- a/apps/web/src/app/api/restaurants/[slug]/suggestions/route.ts
+++ b/apps/web/src/app/api/restaurants/[slug]/suggestions/route.ts
@@ -2,26 +2,9 @@
  * Phase 4.10 — proxy GET /api/restaurants/:slug/suggestions
  * (owner-only queue) with the cookie's JWT.
  */
-import { NextResponse } from 'next/server';
-import { getServerJwt } from '../../../../../lib/server-auth';
+import { proxyAuthed } from '../../../../../lib/api-proxy';
 
-import { API_BASE } from '../../../../../lib/api-base';
-
-export async function GET(
-  _request: Request,
-  context: { params: Promise<{ slug: string }> },
-) {
+export async function GET(_request: Request, context: { params: Promise<{ slug: string }> }) {
   const { slug } = await context.params;
-  const jwt = await getServerJwt();
-  if (!jwt) return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-
-  const upstream = await fetch(
-    `${API_BASE}/api/v1/restaurants/${encodeURIComponent(slug)}/suggestions`,
-    { headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' } },
-  );
-  const text = await upstream.text();
-  return new NextResponse(text, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
-  });
+  return proxyAuthed(`/api/v1/restaurants/${encodeURIComponent(slug)}/suggestions`);
 }

--- a/apps/web/src/app/api/restaurants/route.ts
+++ b/apps/web/src/app/api/restaurants/route.ts
@@ -4,29 +4,9 @@
  * cookie. 409 possible_duplicate responses pass through verbatim so
  * the /ingest page can render the "did you mean…?" cards.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../lib/server-auth';
-
-import { API_BASE } from '../../../lib/api-base';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../lib/api-proxy';
 
 export async function POST(request: NextRequest) {
-  const jwt = await getServerJwt();
-  if (!jwt) {
-    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-  }
-  const body = await request.text();
-  const upstream = await fetch(`${API_BASE}/api/v1/restaurants`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${jwt}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body,
-  });
-  const responseText = await upstream.text();
-  return new NextResponse(responseText, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
-  });
+  return proxyAuthed('/api/v1/restaurants', { method: 'POST', body: await request.text() });
 }

--- a/apps/web/src/app/api/suggestions/[id]/route.ts
+++ b/apps/web/src/app/api/suggestions/[id]/route.ts
@@ -2,32 +2,13 @@
  * Phase 4.10 — proxy PATCH /api/suggestions/:id (owner accept/reject)
  * with the cookie's JWT.
  */
-import { NextResponse, type NextRequest } from 'next/server';
-import { getServerJwt } from '../../../../lib/server-auth';
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../lib/api-proxy';
 
-import { API_BASE } from '../../../../lib/api-base';
-
-export async function PATCH(
-  request: NextRequest,
-  context: { params: Promise<{ id: string }> },
-) {
+export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params;
-  const jwt = await getServerJwt();
-  if (!jwt) return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
-
-  const body = await request.text();
-  const upstream = await fetch(`${API_BASE}/api/v1/suggestions/${encodeURIComponent(id)}`, {
+  return proxyAuthed(`/api/v1/suggestions/${encodeURIComponent(id)}`, {
     method: 'PATCH',
-    headers: {
-      Authorization: `Bearer ${jwt}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body,
-  });
-  const text = await upstream.text();
-  return new NextResponse(text, {
-    status: upstream.status,
-    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+    body: await request.text(),
   });
 }

--- a/apps/web/src/lib/__tests__/api-proxy.test.ts
+++ b/apps/web/src/lib/__tests__/api-proxy.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { proxyAuthed, relayUpstream } from '../api-proxy';
+
+/**
+ * The proxy plumbing shared by every authenticated `/api/*` route
+ * handler. These handlers had no tests before the extraction — this
+ * file is the coverage for the logic they now delegate to.
+ */
+
+const mockGetServerJwt = vi.fn();
+vi.mock('../server-auth', () => ({
+  getServerJwt: () => mockGetServerJwt(),
+}));
+
+const API_BASE = 'http://localhost:3000';
+
+beforeEach(() => {
+  mockGetServerJwt.mockReset().mockResolvedValue('jwt-123');
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Plain mock rather than `new Response(...)`, which auto-adds a
+// text/plain Content-Type and so can't represent the "upstream omits
+// Content-Type" case relayUpstream defaults for.
+function upstream(body: string, status = 200, contentType: string | null = 'application/json') {
+  return {
+    status,
+    text: async () => body,
+    headers: { get: (name: string) => (name === 'Content-Type' ? contentType : null) },
+  } as unknown as Response;
+}
+
+describe('relayUpstream', () => {
+  it('mirrors status, body, and Content-Type', async () => {
+    const res = await relayUpstream(upstream('{"ok":true}', 201, 'application/json'));
+    expect(res.status).toBe(201);
+    expect(await res.text()).toBe('{"ok":true}');
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('defaults Content-Type to JSON when upstream omits it', async () => {
+    const res = await relayUpstream(upstream('x', 200, null));
+    expect(res.headers.get('Content-Type')).toBe('application/json');
+  });
+});
+
+describe('proxyAuthed', () => {
+  it('401s without calling Rails when the caller is not signed in', async () => {
+    mockGetServerJwt.mockResolvedValue(null);
+    const res = await proxyAuthed('/api/v1/profile', { method: 'PATCH', body: '{}' });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Not signed in' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('forwards a GET with Bearer + Accept and no body / Content-Type', async () => {
+    vi.mocked(fetch).mockResolvedValue(upstream('{"visits":[]}'));
+    await proxyAuthed('/api/v1/profile/history?limit=5');
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!;
+    expect(url).toBe(`${API_BASE}/api/v1/profile/history?limit=5`);
+    expect(init?.method).toBe('GET');
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer jwt-123');
+    expect(headers.Accept).toBe('application/json');
+    expect(headers['Content-Type']).toBeUndefined();
+    expect(init?.body).toBeUndefined();
+  });
+
+  it('forwards a mutation with the body and the JSON Content-Type', async () => {
+    vi.mocked(fetch).mockResolvedValue(upstream('{"id":"r1"}', 200));
+    await proxyAuthed('/api/v1/profile', { method: 'PATCH', body: '{"strictness":"strict"}' });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0]!;
+    expect(url).toBe(`${API_BASE}/api/v1/profile`);
+    expect(init?.method).toBe('PATCH');
+    expect(init?.body).toBe('{"strictness":"strict"}');
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('passes cache through (e.g. no-store for status polling)', async () => {
+    vi.mocked(fetch).mockResolvedValue(upstream('{}'));
+    await proxyAuthed('/api/v1/ingestion_runs/abc', { cache: 'no-store' });
+    expect(vi.mocked(fetch).mock.calls[0]![1]?.cache).toBe('no-store');
+  });
+
+  it('relays the upstream status + body back to the caller', async () => {
+    vi.mocked(fetch).mockResolvedValue(upstream('{"error":"nope"}', 422));
+    const res = await proxyAuthed('/api/v1/restaurants', { method: 'POST', body: '{}' });
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: 'nope' });
+  });
+});

--- a/apps/web/src/lib/api-proxy.ts
+++ b/apps/web/src/lib/api-proxy.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared plumbing for the `/api/*` route handlers that proxy to the
+ * Rails API.
+ *
+ * Every handler does the same two things: forward the request to Rails
+ * with the session JWT (from the HttpOnly `bw_session` cookie) as a
+ * Bearer token, and relay the upstream response back to the browser
+ * verbatim. This is the one place that logic lives.
+ *
+ * Handlers with non-standard shapes keep their own code: multipart
+ * uploads (`ingestion_runs`, item reviews) forward the raw body +
+ * boundary; optional-auth routes (`items/:id/suggestions`) don't 401;
+ * `auth/[action]` sets cookies. Those import nothing from here.
+ */
+import { NextResponse } from 'next/server';
+import { API_BASE } from './api-base';
+import { getServerJwt } from './server-auth';
+
+/**
+ * Relay a Rails response back to the browser verbatim — same status,
+ * body, and Content-Type (defaulting to JSON when upstream omits it).
+ */
+export async function relayUpstream(upstream: Response): Promise<NextResponse> {
+  const body = await upstream.text();
+  return new NextResponse(body, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}
+
+export interface ProxyInit {
+  method?: string;
+  /** Forwarded request body (mutations). Adds the JSON Content-Type. */
+  body?: string;
+  /** Passed through to `fetch` — e.g. `'no-store'` for status polling. */
+  cache?: RequestCache;
+}
+
+/**
+ * Forward to `${API_BASE}${apiPath}` with the session JWT as a Bearer
+ * token and relay the response. Returns a 401 when the caller isn't
+ * signed in. Pass `body` for mutations (GET/DELETE omit it, and the
+ * JSON Content-Type that goes with it).
+ */
+export async function proxyAuthed(apiPath: string, init: ProxyInit = {}): Promise<NextResponse> {
+  const jwt = await getServerJwt();
+  if (!jwt) return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${jwt}`,
+    Accept: 'application/json',
+  };
+  if (init.body !== undefined) headers['Content-Type'] = 'application/json';
+
+  const upstream = await fetch(`${API_BASE}${apiPath}`, {
+    method: init.method ?? 'GET',
+    headers,
+    ...(init.body !== undefined ? { body: init.body } : {}),
+    ...(init.cache !== undefined ? { cache: init.cache } : {}),
+  });
+  return relayUpstream(upstream);
+}


### PR DESCRIPTION
## DRY + first-ever tests for the `/api/*` proxy layer

Every Next.js route handler hand-rolled the **same** proxy: read the session JWT → 401 if missing → `fetch(\`\${API_BASE}/api/v1/...\`)` with the Bearer header → relay the upstream status/body/Content-Type verbatim. ~30 lines copy-pasted per route.

Extracted **`proxyAuthed(apiPath, { method, body, cache })`** + **`relayUpstream(upstream)`** into `lib/api-proxy.ts`. The **9** standard authenticated JSON handlers collapse to one-line delegations:

```ts
export async function PATCH(request: NextRequest) {
  return proxyAuthed('/api/v1/profile', { method: 'PATCH', body: await request.text() });
}
```

### Deliberately left alone (not forced into the helper)
- **Multipart uploaders** (`ingestion_runs` POST, item `reviews` POST) — forward the raw body + boundary, can't flatten to JSON.
- **`items/:id/suggestions`** — optional auth (doesn't 401), a different shape.
- **`auth/[action]`** — sets cookies; **anonymous** routes (waitlist, claim/verify); **reviews/[id]** + **never_hide** — already DRY with their own local `proxy()`.

### Well tested — these routes had *zero* tests before
Adds `api-proxy.test.ts` (7 cases): the 401 gate (no upstream call), GET headers (Bearer + Accept, **no** Content-Type/body), mutation (body + JSON Content-Type), `cache` passthrough (`no-store` polling), status/body relay, and the JSON Content-Type default.

Converted handlers are **byte-identical** in behavior (same URL, headers, body, relay). Verified: `typecheck` + `lint` clean, vitest **160 (+7)**. Net: route layer −~200 lines, replaced by 62 lines of shared, tested logic.

Slice 5 of the `/loop` code-quality pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)