### PR TITLE
refactor(api): extract ResolveStageJob template for the resolve pipeline

### DIFF
--- a/apps/api/app/jobs/resolve_ingredients_job.rb
+++ b/apps/api/app/jobs/resolve_ingredients_job.rb
@@ -6,92 +6,19 @@
 # onto ingredient slugs from the curated catalog, writes the resolved
 # + unresolved arrays back into staging.
 #
-# On success, fires ResolveTagsJob (which finishes the resolve work
-# and transitions the run into `:staged`).
-#
-# Failure modes mirror ExtractMenuJob: ApiError → fail with status,
-# ValidationError → fail with the validator's first 3 errors.
-class ResolveIngredientsJob < ApplicationJob
-  queue_as :ingestion
+# On success, fires ResolveTagsJob (which finishes the resolve work and
+# transitions the run into `:staged`). The load → resolve → record
+# skeleton lives in ResolveStageJob.
+class ResolveIngredientsJob < ResolveStageJob
+  def stage        = "resolve_ingredients"
+  def prompt       = Ingestion::ResolveIngredientsPrompt
+  def catalog_text = Ingestion::CatalogBuilder.ingredients_text
 
-  def perform(ingestion_run_id)
-    run = IngestionRun.find(ingestion_run_id)
-    return if run.staged? || run.published? || run.failed?
-
-    items = collect_items(run.staging)
-    if items.empty?
-      run.fail!("resolve_ingredients: no_items_in_staging")
-      return
-    end
-
-    client  = AnthropicClient.new
-    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    begin
-      result = client.messages_create(
-        system:          Ingestion::ResolveIngredientsPrompt.system(client, Ingestion::CatalogBuilder.ingredients_text),
-        messages:        Ingestion::ResolveIngredientsPrompt.user_messages(items),
-        response_schema: Ingestion::ResolutionSchema
-      )
-    rescue AnthropicClient::ApiError => e
-      run.fail!("resolve_ingredients_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
-      return
-    rescue AnthropicClient::ValidationError => e
-      # Billed 200 with a non-conforming body — still accrue its cost.
-      run.record_api_usage!(client.last_usage, model: client.model)
-      run.fail!("resolve_ingredients_validation_failed: #{e.errors.first(3).join('; ')}")
-      return
-    end
-
-    elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
-
-    run.record_api_usage!(client.last_usage, model: client.model)
+  def apply_and_advance(run, result, elapsed_ms)
     run.update!(
       staging:    apply_resolution(run.staging, result, key: :ingredients),
       latency_ms: elapsed_ms
     )
-
     ResolveTagsJob.perform_later(run.id)
-  end
-
-  # Flatten the section→items tree into a flat array; each entry
-  # carries its parent section name for the prompt context.
-  def self.collect_items(staging)
-    Array(staging["sections"] || staging[:sections]).flat_map do |section|
-      section_name = section["name"] || section[:name]
-      Array(section["items"] || section[:items]).map do |item|
-        { name: item["name"] || item[:name],
-          description: item["description"] || item[:description],
-          section: section_name }
-      end
-    end
-  end
-
-  def collect_items(staging) = self.class.collect_items(staging)
-
-  # Mutate a deep copy of staging by zipping the API response back
-  # onto each item by index, writing two new keys: `<key>` (resolved)
-  # and `unresolved_<key>`.
-  def apply_resolution(staging, result, key:)
-    new_staging   = JSON.parse(staging.to_json) # deep copy + stringify
-    sections      = Array(new_staging["sections"])
-    flat_index    = 0
-    by_index      = result["items"].index_by { |row| row["index"] }
-
-    sections.each do |section|
-      Array(section["items"]).each do |item|
-        row = by_index[flat_index]
-        if row
-          item[key.to_s]                  = row["resolved"]
-          item["unresolved_#{key}".to_s]  = row["unresolved"]
-        else
-          item[key.to_s]                 ||= []
-          item["unresolved_#{key}".to_s] ||= []
-        end
-        flat_index += 1
-      end
-    end
-
-    new_staging
   end
 end

--- a/apps/api/app/jobs/resolve_stage_job.rb
+++ b/apps/api/app/jobs/resolve_stage_job.rb
@@ -1,0 +1,108 @@
+# Phase 2.4 — shared skeleton for the two AI "resolve" stages of the
+# ingestion pipeline (ResolveIngredientsJob → ResolveTagsJob).
+#
+# Both stages do the same thing: load the run, ask Anthropic to map the
+# staged items onto a curated catalog (ingredients or tags), record the
+# API usage + latency, and write the resolution back into staging. They
+# differ only in the prompt + catalog, the stage name (used in failure
+# messages and as the resolution key), and what happens after a
+# successful resolve. Subclasses supply those via the hooks below.
+#
+# Failure modes: ApiError → fail with status; ValidationError → still
+# accrue the (billed) cost, then fail with the validator's first 3
+# errors.
+class ResolveStageJob < ApplicationJob
+  queue_as :ingestion
+
+  def perform(ingestion_run_id)
+    run = IngestionRun.find(ingestion_run_id)
+    return if run.staged? || run.published? || run.failed?
+
+    items = collect_items(run.staging)
+    if items.empty?
+      run.fail!("#{stage}: no_items_in_staging")
+      return
+    end
+
+    client  = AnthropicClient.new
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    begin
+      result = client.messages_create(
+        system:          prompt.system(client, catalog_text),
+        messages:        prompt.user_messages(items),
+        response_schema: Ingestion::ResolutionSchema
+      )
+    rescue AnthropicClient::ApiError => e
+      run.fail!("#{stage}_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
+      return
+    rescue AnthropicClient::ValidationError => e
+      # Billed 200 with a non-conforming body — still accrue its cost.
+      run.record_api_usage!(client.last_usage, model: client.model)
+      run.fail!("#{stage}_validation_failed: #{e.errors.first(3).join('; ')}")
+      return
+    end
+
+    elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
+    run.record_api_usage!(client.last_usage, model: client.model)
+
+    apply_and_advance(run, result, elapsed_ms)
+  end
+
+  # ── Subclass hooks ────────────────────────────────────────────────
+
+  # Short stage name, used in failure messages (e.g. "resolve_tags").
+  def stage = raise(NotImplementedError)
+
+  # The Ingestion::Resolve*Prompt module for this stage.
+  def prompt = raise(NotImplementedError)
+
+  # The curated catalog text the prompt is primed with.
+  def catalog_text = raise(NotImplementedError)
+
+  # Persist a successful resolution and advance the pipeline. Receives
+  # the run, the API result, and the elapsed milliseconds.
+  def apply_and_advance(_run, _result, _elapsed_ms) = raise(NotImplementedError)
+
+  # ── Shared staging helpers ────────────────────────────────────────
+
+  # Flatten the section→items tree into a flat array; each entry
+  # carries its parent section name for the prompt context.
+  def self.collect_items(staging)
+    Array(staging["sections"] || staging[:sections]).flat_map do |section|
+      section_name = section["name"] || section[:name]
+      Array(section["items"] || section[:items]).map do |item|
+        { name: item["name"] || item[:name],
+          description: item["description"] || item[:description],
+          section: section_name }
+      end
+    end
+  end
+
+  def collect_items(staging) = self.class.collect_items(staging)
+
+  # Mutate a deep copy of staging by zipping the API response back onto
+  # each item by index, writing two new keys: `<key>` (resolved) and
+  # `unresolved_<key>`.
+  def apply_resolution(staging, result, key:)
+    new_staging = JSON.parse(staging.to_json) # deep copy + stringify
+    flat_index  = 0
+    by_index    = result["items"].index_by { |row| row["index"] }
+
+    Array(new_staging["sections"]).each do |section|
+      Array(section["items"]).each do |item|
+        row = by_index[flat_index]
+        if row
+          item[key.to_s]            = row["resolved"]
+          item["unresolved_#{key}"] = row["unresolved"]
+        else
+          item[key.to_s]            ||= []
+          item["unresolved_#{key}"] ||= []
+        end
+        flat_index += 1
+      end
+    end
+
+    new_staging
+  end
+end

--- a/apps/api/app/jobs/resolve_tags_job.rb
+++ b/apps/api/app/jobs/resolve_tags_job.rb
@@ -1,50 +1,21 @@
 # Phase 2.4 — third stage of the AI ingestion pipeline.
 #
-# Triggered by ResolveIngredientsJob on success. Same shape but with
-# the tag catalog instead of the ingredient catalog. After writing
-# the tag resolution back to staging, this job:
+# Triggered by ResolveIngredientsJob on success. Same shape as the
+# ingredient stage (skeleton in ResolveStageJob) but with the tag
+# catalog. After writing the tag resolution back to staging, this job:
 #
 # 1. Materializes IngestionItem rows (one per item in staging) with
 #    `decision: pending` so the swipe-verify UI in Phase 2.7 has
 #    something to show.
 # 2. Transitions the run to `:staged` (Phase 2.5's verify UI takes
 #    over from there).
-class ResolveTagsJob < ApplicationJob
-  queue_as :ingestion
+class ResolveTagsJob < ResolveStageJob
+  def stage        = "resolve_tags"
+  def prompt       = Ingestion::ResolveTagsPrompt
+  def catalog_text = Ingestion::CatalogBuilder.tags_text
 
-  def perform(ingestion_run_id)
-    run = IngestionRun.find(ingestion_run_id)
-    return if run.staged? || run.published? || run.failed?
-
-    items = ResolveIngredientsJob.collect_items(run.staging)
-    if items.empty?
-      run.fail!("resolve_tags: no_items_in_staging")
-      return
-    end
-
-    client  = AnthropicClient.new
-    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    begin
-      result = client.messages_create(
-        system:          Ingestion::ResolveTagsPrompt.system(client, Ingestion::CatalogBuilder.tags_text),
-        messages:        Ingestion::ResolveTagsPrompt.user_messages(items),
-        response_schema: Ingestion::ResolutionSchema
-      )
-    rescue AnthropicClient::ApiError => e
-      run.fail!("resolve_tags_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
-      return
-    rescue AnthropicClient::ValidationError => e
-      # Billed 200 with a non-conforming body — still accrue its cost.
-      run.record_api_usage!(client.last_usage, model: client.model)
-      run.fail!("resolve_tags_validation_failed: #{e.errors.first(3).join('; ')}")
-      return
-    end
-
-    elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
-
-    run.record_api_usage!(client.last_usage, model: client.model)
-    new_staging = ResolveIngredientsJob.new.apply_resolution(run.staging, result, key: :tags)
+  def apply_and_advance(run, result, elapsed_ms)
+    new_staging = apply_resolution(run.staging, result, key: :tags)
 
     run.transaction do
       run.update!(staging: new_staging, latency_ms: elapsed_ms)


### PR DESCRIPTION
## DRY: a template-method base for the two AI "resolve" stages

`ResolveIngredientsJob` and `ResolveTagsJob` duplicated their **entire ~40-line `perform` skeleton**: load run → guard terminal states → collect items → timed `AnthropicClient.messages_create` with identical `ApiError` / `ValidationError` handling (including the subtle "still bill the cost on a validation failure" branch) → record usage. They differed only in:
- the prompt module + catalog text,
- the stage name (failure messages + the staging resolution key),
- the post-resolve step.

`ResolveTagsJob` even reached into `ResolveIngredientsJob` for `collect_items` / `apply_resolution`.

Introduced **`ResolveStageJob`** (template method): it owns the skeleton + the shared `collect_items` / `apply_resolution` helpers and calls four subclass hooks — `stage`, `prompt`, `catalog_text`, `apply_and_advance(run, result, elapsed_ms)`. Each job now expresses only its distinctive ~20 lines.

```ruby
class ResolveIngredientsJob < ResolveStageJob
  def stage        = "resolve_ingredients"
  def prompt       = Ingestion::ResolveIngredientsPrompt
  def catalog_text = Ingestion::CatalogBuilder.ingredients_text
  def apply_and_advance(run, result, elapsed_ms)
    run.update!(staging: apply_resolution(run.staging, result, key: :ingredients), latency_ms: elapsed_ms)
    ResolveTagsJob.perform_later(run.id)
  end
end
```

**Behavior-identical.** Verified locally against a real test DB:
- `resolve_ingredients` + `resolve_tags` job specs **11/11** (unchanged from baseline), `extract_menu_job` **8/8**.
- Full ingestion suite — run/item/publication/usage/cost services + the `ingestion_runs` (28) and `ingestion_items` (15) request specs — **107 examples, 0 failures**.
- No new rubocop offense kinds (the `Metrics/*` offenses on `perform` existed on the original jobs; the duplicate is now gone).

Slice 6 of the `/loop` code-quality pass; CI runs the full rspec suite as the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)