### PR TITLE
refactor(api): extract ResolvePrompt base for the two resolve prompts

### DIFF
--- a/apps/api/app/services/ingestion/resolve_ingredients_prompt.rb
+++ b/apps/api/app/services/ingestion/resolve_ingredients_prompt.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Ingestion
-  class ResolveIngredientsPrompt
+  # Maps menu-item descriptions onto ingredient slugs. Request shape +
+  # item rendering live in ResolvePrompt; this is just the instructions.
+  class ResolveIngredientsPrompt < ResolvePrompt
     SYSTEM_INSTRUCTIONS = <<~MD.strip
       You map menu-item descriptions onto ingredient slugs from a
       curated catalog. The catalog is below — it's the only source of
@@ -23,41 +25,5 @@ module Ingestion
         * Items in the response must appear in the same order as the input.
         * Output JSON only. No prose, no markdown fences.
     MD
-
-    # Build the system blocks. The catalog is the LAST block, marked
-    # cached — Anthropic caches the prefix up to and including the
-    # last cache_control block, so we get the catalog cached without
-    # paying for caching the (smaller) instruction text.
-    def self.system(client, catalog_text)
-      client.system_blocks(
-        { text: SYSTEM_INSTRUCTIONS },
-        { text: catalog_text, cache: true }
-      )
-    end
-
-    def self.user_messages(items)
-      [{
-        role: "user",
-        content: [
-          { type: "text",
-            text: "Resolve ingredients for the following items:\n\n" + items_block(items) }
-        ]
-      }]
-    end
-
-    # `items` is an array of `{name:, description:, section:}` hashes.
-    # Renders a compact numbered list the model can index.
-    def self.items_block(items)
-      items.each_with_index.map do |item, i|
-        section     = item[:section] || item["section"]
-        name        = item[:name] || item["name"]
-        description = item[:description] || item["description"]
-
-        line = "[#{i}] #{name}"
-        line += " (section: #{section})" if section.present?
-        line += "\n    description: #{description}" if description.present?
-        line
-      end.join("\n")
-    end
   end
 end

--- a/apps/api/app/services/ingestion/resolve_prompt.rb
+++ b/apps/api/app/services/ingestion/resolve_prompt.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Ingestion
+  # Shared machinery for the two "resolve" prompts (ResolveIngredients,
+  # ResolveTags). Both build the same request shape — instruction block
+  # + cached catalog block as the system prompt, and one numbered
+  # user-message listing the items to resolve. They differ only in the
+  # instruction text, which each subclass supplies as SYSTEM_INSTRUCTIONS.
+  class ResolvePrompt
+    # Build the system blocks. The catalog is the LAST block, marked
+    # cached — Anthropic caches the prefix up to and including the last
+    # cache_control block, so we get the (large) catalog cached without
+    # paying to cache the (smaller) instruction text. `self::` resolves
+    # the calling subclass's SYSTEM_INSTRUCTIONS.
+    def self.system(client, catalog_text)
+      client.system_blocks(
+        { text: self::SYSTEM_INSTRUCTIONS },
+        { text: catalog_text, cache: true }
+      )
+    end
+
+    def self.user_messages(items)
+      [{
+        role: "user",
+        content: [
+          { type: "text",
+            text: "Resolve ingredients for the following items:\n\n" + items_block(items) }
+        ]
+      }]
+    end
+
+    # `items` is an array of `{name:, description:, section:}` hashes
+    # (string or symbol keys). Renders a compact numbered list the model
+    # can index back into.
+    def self.items_block(items)
+      items.each_with_index.map do |item, i|
+        section     = item[:section] || item["section"]
+        name        = item[:name] || item["name"]
+        description = item[:description] || item["description"]
+
+        line = "[#{i}] #{name}"
+        line += " (section: #{section})" if section.present?
+        line += "\n    description: #{description}" if description.present?
+        line
+      end.join("\n")
+    end
+  end
+end

--- a/apps/api/app/services/ingestion/resolve_tags_prompt.rb
+++ b/apps/api/app/services/ingestion/resolve_tags_prompt.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module Ingestion
-  class ResolveTagsPrompt
+  # Assigns cuisine / prep / diet / allergen tags to menu items. Request
+  # shape + item rendering are inherited from ResolvePrompt; this is just
+  # the instructions.
+  class ResolveTagsPrompt < ResolvePrompt
     SYSTEM_INSTRUCTIONS = <<~MD.strip
       You assign cuisine / preparation / diet / allergen tags to menu
       items. The tag catalog is below — it's the only source of truth
@@ -22,16 +25,5 @@ module Ingestion
         * Order preserved.
         * Output JSON only.
     MD
-
-    def self.system(client, catalog_text)
-      client.system_blocks(
-        { text: SYSTEM_INSTRUCTIONS },
-        { text: catalog_text, cache: true }
-      )
-    end
-
-    def self.user_messages(items)
-      Ingestion::ResolveIngredientsPrompt.user_messages(items)
-    end
   end
 end

--- a/apps/api/spec/services/ingestion/resolve_prompt_spec.rb
+++ b/apps/api/spec/services/ingestion/resolve_prompt_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+# The two resolve prompts share ResolvePrompt's request-building
+# machinery (system blocks + the numbered user message) and differ only
+# in their SYSTEM_INSTRUCTIONS. These specs lock the wire-payload shape
+# the AnthropicClient is handed — previously only covered indirectly via
+# the resolve job specs.
+RSpec.describe Ingestion::ResolvePrompt do
+  let(:items) do
+    [
+      { name: "Pad Thai", description: "rice noodles, peanuts", section: "Noodles" },
+      { name: "Plain Rice", description: nil, section: nil },
+    ]
+  end
+
+  describe ".items_block" do
+    it "renders a numbered list with section + description, skipping blanks" do
+      expect(Ingestion::ResolveIngredientsPrompt.items_block(items)).to eq(
+        "[0] Pad Thai (section: Noodles)\n    description: rice noodles, peanuts\n[1] Plain Rice"
+      )
+    end
+
+    it "accepts string keys as well as symbols" do
+      block = Ingestion::ResolveIngredientsPrompt.items_block(
+        [{ "name" => "Soup", "section" => "Starters", "description" => "broth" }]
+      )
+      expect(block).to eq("[0] Soup (section: Starters)\n    description: broth")
+    end
+  end
+
+  describe ".user_messages" do
+    it "wraps the items block in a single user text message" do
+      msgs = Ingestion::ResolveIngredientsPrompt.user_messages(items)
+      expect(msgs.size).to eq(1)
+      expect(msgs.first[:role]).to eq("user")
+      text = msgs.first.dig(:content, 0, :text)
+      expect(text).to start_with("Resolve ingredients for the following items:")
+      expect(text).to include("[0] Pad Thai")
+    end
+
+    it "is identical for both prompts (shared machinery)" do
+      expect(Ingestion::ResolveTagsPrompt.user_messages(items))
+        .to eq(Ingestion::ResolveIngredientsPrompt.user_messages(items))
+    end
+  end
+
+  describe ".system" do
+    # A double records the blocks each prompt hands the client, so we
+    # assert the prompt's contribution independent of system_blocks' own
+    # transform.
+    def captured_blocks_for(prompt_class, catalog)
+      client = instance_double(AnthropicClient)
+      captured = nil
+      allow(client).to receive(:system_blocks) { |*blocks| captured = blocks }
+      prompt_class.system(client, catalog)
+      captured
+    end
+
+    it "sends the subclass instructions first, then the cached catalog" do
+      blocks = captured_blocks_for(Ingestion::ResolveIngredientsPrompt, "CATALOG")
+      expect(blocks).to eq([
+        { text: Ingestion::ResolveIngredientsPrompt::SYSTEM_INSTRUCTIONS },
+        { text: "CATALOG", cache: true },
+      ])
+    end
+
+    it "resolves SYSTEM_INSTRUCTIONS per subclass (tags ≠ ingredients)" do
+      tag_blocks = captured_blocks_for(Ingestion::ResolveTagsPrompt, "TAGS")
+      expect(tag_blocks.first[:text]).to eq(Ingestion::ResolveTagsPrompt::SYSTEM_INSTRUCTIONS)
+      expect(tag_blocks.first[:text]).to include("tags")
+      expect(Ingestion::ResolveTagsPrompt::SYSTEM_INSTRUCTIONS)
+        .not_to eq(Ingestion::ResolveIngredientsPrompt::SYSTEM_INSTRUCTIONS)
+    end
+  end
+end


### PR DESCRIPTION
## DRY: a base for the two AI resolve prompts (sibling to #321)

`ResolveIngredientsPrompt` and `ResolveTagsPrompt` had a **byte-identical `self.system`** (instruction block + cached-catalog block), and `ResolveTagsPrompt` reached cross-class into `ResolveIngredientsPrompt` for `user_messages` (which owns `items_block`). Only the `SYSTEM_INSTRUCTIONS` text genuinely differs.

Introduced **`Ingestion::ResolvePrompt`** holding `system` / `user_messages` / `items_block`; `system` reads `self::SYSTEM_INSTRUCTIONS`, so each subclass supplies only its instruction text. Same template-method shape as the `ResolveStageJob` split (#321) — the prompt files are now *just* their instructions.

### Behavior-identical
The produced system blocks + user message are byte-for-byte the same. The user-message lead-in stays `"Resolve ingredients for the following items:"` verbatim — which is exactly what the tags prompt already sent via the old cross-class delegation. (Rewording it for tags would change the wire payload sent to Anthropic, so it's deliberately left as-is — a behavior-preserving refactor, not a prompt edit.)

### Well tested — the prompts had no direct spec
Adds `resolve_prompt_spec.rb` (6 cases): `items_block` formatting (symbol + string keys, blank-skipping), the shared user message, and that `.system` emits instructions-then-cached-catalog with the correct per-subclass `SYSTEM_INSTRUCTIONS`.

Verified locally: new spec **6/6**, resolve + extract job specs **19/19** (unchanged from baseline). CI runs the full rspec suite as the backstop.

Slice 7 of the `/loop` code-quality pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)