### PR TITLE
refactor(api): extract TimedAnthropicCall for the ingestion jobs

### DIFF
--- a/apps/api/app/jobs/concerns/timed_anthropic_call.rb
+++ b/apps/api/app/jobs/concerns/timed_anthropic_call.rb
@@ -1,0 +1,41 @@
+# Shared Anthropic-call handling for the ingestion jobs (ExtractMenuJob
+# + the ResolveStageJob subclasses).
+#
+# Every stage makes one timed `messages_create` and handles failure the
+# same way. Centralised here so the cost-accrual invariant lives in ONE
+# place: a 200 that fails our schema was still billed, so its usage must
+# be recorded even though the run fails — otherwise a run could leak past
+# the daily cost ceiling by failing validation.
+module TimedAnthropicCall
+  extend ActiveSupport::Concern
+
+  private
+
+  # Yields a fresh AnthropicClient so the caller can build + send its
+  # prompt, times the call, and applies the shared failure handling.
+  # Records the API usage on success AND on a validation failure (both
+  # were billed). The `*_error` labels keep each stage's failure-message
+  # prefix.
+  #
+  # Returns `[result, elapsed_ms]`, or `nil` when the call failed and the
+  # run was already marked failed (so callers `return if out.nil?`).
+  def timed_anthropic_call(run, api_error:, validation_error:)
+    client  = AnthropicClient.new
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    begin
+      result = yield client
+    rescue AnthropicClient::ApiError => e
+      run.fail!("#{api_error}: #{e.status} #{e.body.to_s.truncate(500)}")
+      return nil
+    rescue AnthropicClient::ValidationError => e
+      run.record_api_usage!(client.last_usage, model: client.model)
+      run.fail!("#{validation_error}: #{e.errors.first(3).join('; ')}")
+      return nil
+    end
+
+    elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
+    run.record_api_usage!(client.last_usage, model: client.model)
+    [result, elapsed_ms]
+  end
+end

--- a/apps/api/app/jobs/extract_menu_job.rb
+++ b/apps/api/app/jobs/extract_menu_job.rb
@@ -16,6 +16,8 @@
 # Idempotence: re-running on a run already past `:extracting`
 # is a no-op (transition_to! is idempotent).
 class ExtractMenuJob < ApplicationJob
+  include TimedAnthropicCall
+
   queue_as :ingestion
 
   def perform(ingestion_run_id)
@@ -33,29 +35,16 @@ class ExtractMenuJob < ApplicationJob
       return
     end
 
-    client = AnthropicClient.new
-    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    begin
-      result = client.messages_create(
+    out = timed_anthropic_call(run, api_error: "anthropic_api_error", validation_error: "schema_validation_failed") do |client|
+      client.messages_create(
         system:          Ingestion::ExtractMenuPrompt.system(client),
         messages:        Ingestion::ExtractMenuPrompt.user_messages(client, blobs),
         response_schema: Ingestion::MenuExtractionSchema
       )
-    rescue AnthropicClient::ApiError => e
-      run.fail!("anthropic_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
-      return
-    rescue AnthropicClient::ValidationError => e
-      # The 200 was billed even though its body failed our schema —
-      # accrue it so the cost ceiling can't leak via failed runs.
-      run.record_api_usage!(client.last_usage, model: client.model)
-      run.fail!("schema_validation_failed: #{e.errors.first(3).join('; ')}")
-      return
     end
+    return if out.nil?
+    result, elapsed_ms = out
 
-    elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
-
-    run.record_api_usage!(client.last_usage, model: client.model)
     run.update!(
       staging:    result,
       latency_ms: elapsed_ms

--- a/apps/api/app/jobs/resolve_stage_job.rb
+++ b/apps/api/app/jobs/resolve_stage_job.rb
@@ -12,6 +12,8 @@
 # accrue the (billed) cost, then fail with the validator's first 3
 # errors.
 class ResolveStageJob < ApplicationJob
+  include TimedAnthropicCall
+
   queue_as :ingestion
 
   def perform(ingestion_run_id)
@@ -24,27 +26,15 @@ class ResolveStageJob < ApplicationJob
       return
     end
 
-    client  = AnthropicClient.new
-    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    begin
-      result = client.messages_create(
+    out = timed_anthropic_call(run, api_error: "#{stage}_api_error", validation_error: "#{stage}_validation_failed") do |client|
+      client.messages_create(
         system:          prompt.system(client, catalog_text),
         messages:        prompt.user_messages(items),
         response_schema: Ingestion::ResolutionSchema
       )
-    rescue AnthropicClient::ApiError => e
-      run.fail!("#{stage}_api_error: #{e.status} #{e.body.to_s.truncate(500)}")
-      return
-    rescue AnthropicClient::ValidationError => e
-      # Billed 200 with a non-conforming body — still accrue its cost.
-      run.record_api_usage!(client.last_usage, model: client.model)
-      run.fail!("#{stage}_validation_failed: #{e.errors.first(3).join('; ')}")
-      return
     end
-
-    elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
-    run.record_api_usage!(client.last_usage, model: client.model)
+    return if out.nil?
+    result, elapsed_ms = out
 
     apply_and_advance(run, result, elapsed_ms)
   end


### PR DESCRIPTION
## DRY: one home for the timed Anthropic call + its cost-accrual invariant

`ExtractMenuJob` and `ResolveStageJob` each hand-rolled the **same ~14-line block**: `AnthropicClient.new` → timed `messages_create` → `rescue ApiError` (fail the run) / `ValidationError` (**record the billed usage, then** fail) → record usage + compute `elapsed_ms`.

The "record usage even on a validation failure" branch is a **cost-ceiling invariant** — a 200 whose body fails our schema was still billed, so it must be accrued or a run could leak past the daily ceiling by failing validation. That's correctness-sensitive logic that should live in one place, not two.

Extracted into a **`TimedAnthropicCall`** concern: it yields a client (each job builds + sends its own prompt) and returns `[result, elapsed_ms]`, or `nil` on failure (so callers `return if out.nil?`). Each job passes its own failure-message labels, so the stored failure prefixes are **byte-identical**:
- extract → `anthropic_api_error` / `schema_validation_failed`
- resolve → `#{stage}_api_error` / `#{stage}_validation_failed`

### Behavior-identical & well covered
The extract + resolve job specs assert the **exact** failure-message prefixes on both error paths (`ApiError`, `ValidationError`) *and* the usage-accrual on validation failure — so any drift fails the build. Verified locally: **19/19**. CI runs the full rspec suite as the backstop.

Slice 8 of the `/loop` pass — completes the ingestion-pipeline consolidation (jobs #321, prompts #322, now the shared call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)