### PR TITLE
feat(web): vision doc + user-facing /story page

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -141,6 +141,9 @@ function Footer(): ReactElement {
           &copy; {new Date().getFullYear()} BiteWorthy &middot; Made in Durango, CO.
         </p>
         <nav className="flex flex-wrap gap-bw-4">
+          <a href="/story" className="hover:text-zinc-700" data-testid="footer-story">
+            Our story
+          </a>
           <a href="/privacy" className="hover:text-zinc-700" data-testid="footer-privacy">
             Privacy
           </a>

--- a/apps/web/src/app/story/__tests__/page.test.tsx
+++ b/apps/web/src/app/story/__tests__/page.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StoryPage, { metadata } from '../page';
+
+/**
+ * The /story page is the user-facing telling of docs/vision.md. The
+ * thing worth locking is that the product principle and the call to
+ * action actually render — copy can change, but "safety filters, taste
+ * ranks" and the path into the app are the spine.
+ */
+
+describe('StoryPage', () => {
+  it('leads with the value-prop headline', () => {
+    render(<StoryPage />);
+    expect(screen.getByTestId('story-headline')).toHaveTextContent(/leap of faith/i);
+  });
+
+  it('states the safety-vs-taste principle verbatim', () => {
+    render(<StoryPage />);
+    expect(screen.getByTestId('story-principle')).toHaveTextContent('Safety filters. Taste ranks.');
+  });
+
+  it('explains honest disclosure (strict mode + why)', () => {
+    render(<StoryPage />);
+    expect(screen.getByText(/strict mode/i)).toBeInTheDocument();
+  });
+
+  it('drives into the onboarding flow', () => {
+    render(<StoryPage />);
+    expect(screen.getByTestId('story-cta')).toHaveAttribute('href', '/onboarding');
+  });
+
+  it('sets canonical metadata for /story', () => {
+    expect(metadata.title).toBe('Our story — BiteWorthy');
+    expect(metadata.alternates?.canonical).toBe('/story');
+  });
+});

--- a/apps/web/src/app/story/page.tsx
+++ b/apps/web/src/app/story/page.tsx
@@ -1,0 +1,266 @@
+import type { Metadata } from 'next';
+import type { ReactElement, ReactNode } from 'react';
+import { buildLegalMetadata } from '../../lib/legal-meta';
+
+/**
+ * The BiteWorthy story — the user-facing version of `docs/vision.md`.
+ *
+ * Pure SSR, Tailwind only, same `bite` / `bw-*` tokens as the landing.
+ * Voice is warm and plain — this is the page you send someone to explain
+ * *why* the app exists, not how it works. The product principle ("safety
+ * filters, taste ranks; always show why") is the spine.
+ *
+ * Copy uses real typographic glyphs (’ “ ” — …) rather than HTML
+ * entities; the curly characters aren't ASCII, so they don't trip
+ * `react/no-unescaped-entities`.
+ */
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bite-worthy.com';
+
+export const metadata: Metadata = buildLegalMetadata({
+  pageTitle: 'Our story',
+  description:
+    'Why BiteWorthy exists: a pocket food filter that gives people with allergies, celiac, and every other dietary need back the freedom to walk into a restaurant and just eat.',
+  path: '/story',
+  siteUrl: SITE_URL,
+});
+
+export default function StoryPage(): ReactElement {
+  return (
+    <main className="bg-white">
+      <Hero />
+      <Problem />
+      <Inversion />
+      <Principle />
+      <Trust />
+      <Crowd />
+      <Durango />
+      <Horizon />
+      <ClosingCTA />
+      <Footer />
+    </main>
+  );
+}
+
+function Hero(): ReactElement {
+  return (
+    <section className="mx-auto max-w-3xl px-bw-6 pt-bw-16 pb-bw-10">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">Our story</p>
+      <h1
+        data-testid="story-headline"
+        className="mt-bw-3 text-bw-3xl font-bold leading-[1.1] text-zinc-900 md:text-bw-4xl"
+      >
+        Eating out shouldn’t take a leap of faith.
+      </h1>
+      <p className="mt-bw-6 text-bw-lg text-zinc-700">
+        For about a third of us, a menu isn’t a list of choices. It’s a wall of text hiding the two
+        or three things we can actually eat — and the quiet work of finding them falls on us, every
+        single time.
+      </p>
+      <p className="mt-bw-4 text-bw-lg text-zinc-700">
+        BiteWorthy is a pocket food filter that flips the menu around: scan it, and see only what’s
+        yours.
+      </p>
+    </section>
+  );
+}
+
+function Problem(): ReactElement {
+  return (
+    <Section eyebrow="The problem" title="The menu wasn’t built for you.">
+      <p>
+        If you have celiac, a food allergy, an intolerance, a religious practice, or a way of
+        eating you’ve chosen, you already know the routine: scan the menu twice, quietly interrogate
+        the server, google the place in the parking lot, and hope. Sometimes it’s an awkward
+        conversation. Sometimes it’s the social cost of being “the difficult one.” And sometimes —
+        for the celiac, the severely allergic — it’s a real medical gamble.
+      </p>
+      <p>
+        That work never shows up on the bill. But it’s the reason so many people order the same safe
+        thing every time, or just stay home.
+      </p>
+    </Section>
+  );
+}
+
+function Inversion(): ReactElement {
+  return (
+    <Section eyebrow="The idea" title="So we turned the menu inside out.">
+      <p>
+        Point your phone at any menu — the laminated one on the table, a PDF, a photo, a link. A few
+        seconds later you’re looking at the same menu, rewritten for you: the dishes you can eat,
+        front and center, and the ones you can’t, set aside.
+      </p>
+      <p>
+        No chains-only database. No waiting for a restaurant to fill out a form. If a place isn’t
+        listed yet, you scan it — and now it exists for the next person who eats the way you do.
+      </p>
+    </Section>
+  );
+}
+
+function Principle(): ReactElement {
+  return (
+    <section className="bg-bite-light/30 px-bw-6 py-bw-16">
+      <div className="mx-auto max-w-3xl">
+        <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">What we believe</p>
+        <blockquote
+          data-testid="story-principle"
+          className="mt-bw-4 border-l-4 border-bite pl-bw-5 text-bw-2xl font-bold leading-snug text-zinc-900"
+        >
+          Safety filters. Taste ranks.
+        </blockquote>
+        <div className="mt-bw-6 space-y-bw-4 text-bw-base text-zinc-700">
+          <p>
+            These are two different questions, and we never let them blur.{' '}
+            <span className="font-semibold text-zinc-900">Can I eat this?</span> is about safety —
+            it’s honest and absolute, and it decides what’s shown and what’s hidden.{' '}
+            <span className="font-semibold text-zinc-900">Will I love this?</span> is about taste —
+            it only changes the order, lifting your likely favorites to the top.
+          </p>
+          <p>
+            Taste never hides a safe dish. Safety never gets softened into a suggestion. Mixing up
+            “you might not enjoy this” with “this could hurt you” is the one mistake we refuse to
+            make.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Trust(): ReactElement {
+  return (
+    <Section eyebrow="Why you can trust it" title="Every hidden dish tells you why.">
+      <p>
+        BiteWorthy never just says “no.” A hidden item always shows its reason —{' '}
+        <span className="italic">“Contains dairy (cheese)”</span> — so you’re never guessing, and
+        you can overrule us for a single meal if you know better.
+      </p>
+      <p>
+        Behind each call is a confidence level and a source: was this confirmed by a person, read by
+        AI, or set by the restaurant itself? Turn on{' '}
+        <span className="font-semibold text-zinc-900">strict mode</span> and you’ll only see dishes
+        that are fully confirmed — the setting we built for the people for whom a mistake means the
+        ER.
+      </p>
+    </Section>
+  );
+}
+
+function Crowd(): ReactElement {
+  return (
+    <Section eyebrow="Built together" title="Every scan helps the next person.">
+      <p>
+        The map of what’s safe to eat doesn’t exist anywhere — menus live as photos and PDFs nobody
+        keeps current. So we’re building it together. Anyone can scan a menu and verify it, and that
+        work quietly improves the app for the next diner with the same allergy.
+      </p>
+      <p>
+        Community-added details start as{' '}
+        <span className="font-semibold text-zinc-900">suggested</span> and stay invisible to
+        strict-mode users until a human confirms them — so contributing is an act of care, and the
+        people who most need certainty stay protected.
+      </p>
+    </Section>
+  );
+}
+
+function Durango(): ReactElement {
+  return (
+    <Section eyebrow="Where we’re starting" title="Durango first. On purpose.">
+      <p>
+        We’re seeding the launch with independent Durango restaurants — real local places, not
+        chains, not delivery apps. A small town with a finite set of menus is exactly where a tool
+        like this can become genuinely complete, and where word travels.
+      </p>
+      <p>Other towns follow, once Durango proves the model.</p>
+    </Section>
+  );
+}
+
+function Horizon(): ReactElement {
+  return (
+    <Section eyebrow="Where it’s going" title="Toward a simple question, always answered.">
+      <p>
+        Picture walking down a street and seeing, at a glance, which few of the forty places around
+        you are both safe <span className="italic">and</span> something you’d love. Picture pointing
+        your phone at a menu in a language you don’t read, in a city you’ve never visited, and
+        getting a safe, ranked answer anyway.
+      </p>
+      <p>
+        That’s the whole point. Not more time on your phone — less. The question{' '}
+        <span className="font-semibold text-zinc-900">“can I eat here?”</span> answered before you
+        even have to ask.
+      </p>
+    </Section>
+  );
+}
+
+function ClosingCTA(): ReactElement {
+  return (
+    <section className="mx-auto max-w-3xl px-bw-6 py-bw-16 text-center">
+      <h2 className="text-bw-2xl font-bold text-zinc-900">Try it on your next meal out.</h2>
+      <p className="mx-auto mt-bw-3 max-w-xl text-bw-base text-zinc-700">
+        Six taps to a working profile. Free during the Durango beta — no ads, no email until you
+        choose to save a profile.
+      </p>
+      <div className="mt-bw-8 flex flex-wrap justify-center gap-bw-3">
+        <a
+          href="/onboarding"
+          data-testid="story-cta"
+          className="rounded-bw-md bg-bite px-bw-6 py-bw-3 text-bw-base font-bold text-white shadow-sm hover:bg-bite-dark"
+        >
+          Try the web app →
+        </a>
+        <a
+          href="/"
+          className="rounded-bw-md border border-zinc-200 bg-white px-bw-6 py-bw-3 text-bw-base font-semibold text-zinc-700 hover:border-zinc-300"
+        >
+          Back to home
+        </a>
+      </div>
+    </section>
+  );
+}
+
+function Footer(): ReactElement {
+  return (
+    <footer className="border-t border-zinc-200 bg-zinc-50 px-bw-6 py-bw-12">
+      <div className="mx-auto flex max-w-3xl flex-col gap-bw-3 text-bw-sm text-zinc-500 md:flex-row md:items-center md:justify-between">
+        <p>© {new Date().getFullYear()} BiteWorthy · Made in Durango, CO.</p>
+        <nav className="flex flex-wrap gap-bw-4">
+          <a href="/" className="hover:text-zinc-700">
+            Home
+          </a>
+          <a href="/privacy" className="hover:text-zinc-700">
+            Privacy
+          </a>
+          <a href="/terms" className="hover:text-zinc-700">
+            Terms
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}
+
+// ── Shared section block ────────────────────────────────────────────
+
+function Section({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <section className="mx-auto max-w-3xl px-bw-6 py-bw-12">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">{eyebrow}</p>
+      <h2 className="mt-bw-3 text-bw-2xl font-bold text-zinc-900">{title}</h2>
+      <div className="mt-bw-4 space-y-bw-4 text-bw-base text-zinc-700">{children}</div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/__tests__/sitemap.test.ts
+++ b/apps/web/src/lib/__tests__/sitemap.test.ts
@@ -4,12 +4,13 @@ import { buildSitemapEntries } from '../sitemap';
 const FROZEN = new Date('2026-04-30T19:00:00Z');
 
 describe('buildSitemapEntries', () => {
-  it('emits the static routes (/, /login, /signup) with sensible priorities', () => {
+  it('emits the static routes (/, /story, /login, /signup) with sensible priorities', () => {
     const entries = buildSitemapEntries('https://bite-worthy.com', {}, FROZEN);
 
     const urls = entries.map((e) => e.url);
     expect(urls).toEqual([
       'https://bite-worthy.com/',
+      'https://bite-worthy.com/story',
       'https://bite-worthy.com/login',
       'https://bite-worthy.com/signup',
     ]);
@@ -57,6 +58,7 @@ describe('buildSitemapEntries', () => {
     );
     expect(entries.map((e) => e.url)).toEqual([
       'https://bite-worthy.com/',
+      'https://bite-worthy.com/story',
       'https://bite-worthy.com/login',
       'https://bite-worthy.com/signup',
       'https://bite-worthy.com/durango/vegan',

--- a/apps/web/src/lib/sitemap.ts
+++ b/apps/web/src/lib/sitemap.ts
@@ -46,6 +46,7 @@ const STATIC_ROUTES: ReadonlyArray<{
   changeFrequency: ChangeFreq;
 }> = [
   { path: '/', priority: 1.0, changeFrequency: 'weekly' },
+  { path: '/story', priority: 0.6, changeFrequency: 'monthly' },
   { path: '/login', priority: 0.3, changeFrequency: 'monthly' },
   { path: '/signup', priority: 0.3, changeFrequency: 'monthly' },
 ];

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,127 @@
+# Vision — what BiteWorthy is, and where it goes
+
+> The product thesis, the moat, and the arc. This is the "why" behind
+> the roadmap. The phase plan lives in `roadmap.md`; this is the thing
+> the phases are in service of.
+
+## The thesis
+
+Strip away the stack and BiteWorthy is **an accessibility tool wearing a
+restaurant app's clothes.**
+
+For roughly a third of adults — celiac, allergies, intolerances,
+religious observance, lifestyle — a restaurant menu is a wall of text
+that hides the two or three things they can safely eat. The status-quo
+"solution" is interrogating a server, googling in the parking lot, the
+social tax of being "the difficult one," and, for some, a genuine
+medical gamble.
+
+BiteWorthy inverts the menu: **scan it, and see only what's yours —
+ranked by what you'll love.**
+
+What it really gives back is **dignity and spontaneity** — the freedom to
+walk into a place you didn't pre-vet and just *eat*.
+
+## The three convictions (baked into the schema, not bolted on)
+
+1. **Safety filters, taste ranks.** Safety is binary and honest; taste
+   only reorders. The two are kept religiously separate in the data
+   model, the API, and the copy — because conflating "you might not like
+   this" with "this could hospitalize you" is the one unforgivable bug.
+   (See `docs/schema.md`: avoid-lists hide; taste signals only sort.)
+
+2. **Honest disclosure is the product.** Every hidden item shows *why*
+   it's hidden, with a confidence level (`confirmed` / `suggested` /
+   `inferred`) and a source (`human` / `ai` / `owner`). Strict mode hides
+   anything not `confirmed`. In a domain where being wrong is dangerous,
+   **trust isn't a feature — it's the entire moat.**
+
+3. **The menu graph is crowd-built, ethically.** Anyone can scan;
+   community edits land at `suggested` confidence and stay invisible to
+   strict-mode users until an admin confirms them. Every scan makes the
+   shared map better for the next person with the same allergy —
+   contributing is an act of care, not extraction.
+
+## The arc
+
+**1 — Win the wedge (Durango).** A finite restaurant set + word-of-mouth
+in a real town. Prove the core loop: *scan → eat → review → the data
+gets better.* Resist going wide before the loop spins on its own.
+
+**2 — Build the moat nobody else has: a structured,
+dietary-annotated menu graph.** Menus live as unstructured PDFs and
+photos; no one owns the clean version because no one will hand-maintain
+it. AI + the crowd can. City by city, BiteWorthy accretes something
+genuinely defensible — not an app, a **dataset of what's safe to eat in
+America.**
+
+**3 — Turn on the supply side.** The restaurant claim flow already
+exists (Phase 4.9). Owners who maintain their own menu attract
+constrained diners — who are loyal, higher-spend, and bring the whole
+table. "BiteWorthy-safe" becomes a signal worth earning.
+
+**4 — Deepen personalization.** Today the taste weights are constants in
+code (`packages/filter-engine`, mirrored in SQL). Tomorrow they're
+learned from behavior (taps, reviews, overrides), then "people like
+you." The explainer line — *"because you love Thai and basil"* — becomes
+a real model, never a black box.
+
+**5 — Go ambient, then invisible.** Open-and-scan → "I'm on this block,
+which 6 of these 40 places are safe *and* great for me?" (near-me,
+deferred today on `expo-location`) → travel mode → reservation /
+delivery integrations → eventually an API + badge other apps embed. The
+endgame isn't more screen time; it's the question *"can I eat here?"*
+answered before you have to ask.
+
+## User stories
+
+### Today (the app already does these)
+- *As a celiac diner,* I scan a menu I've never seen and immediately see
+  only the gluten-free dishes — so dinner stops being an interrogation.
+- *As a parent of a tree-nut-allergic kid,* I turn on strict mode and
+  only see items every association has `confirmed`, and the hidden ones
+  tell me exactly **why** — so I can trust it with my child's safety.
+- *As a vegan,* I get a "Top Picks for you — because you love spicy and
+  basil" row above an already-safe menu — so I find the dish I'll love,
+  fast.
+- *As a traveler in a town that isn't listed,* I photograph the menu on
+  the wall and 60 seconds later I'm reading my own filtered version — and
+  I just made that restaurant exist for the next person like me.
+- *As a returning diner,* I pull up a restaurant I filtered last month
+  from my history and reuse it — no re-scanning.
+- *As a contributor,* I swipe-verify a staged menu and watch it go live —
+  strict users stay protected until an admin confirms my work.
+
+### Soon (next phases)
+- *As a low-FODMAP diner on a restaurant row,* I see "6 of these 40
+  places have something safe *and* great for you" without opening each
+  one (near-me).
+- *As a caretaker,* I keep separate profiles for my partner's celiac and
+  my own shellfish allergy and switch between them — or filter for *both*
+  at once for a shared meal.
+- *As someone observing halal,* I trust the religious-observance filter
+  the same way the celiac trusts theirs — same honest-disclosure
+  machinery, same confidence model.
+- *As a frequent user,* my Top Picks quietly get smarter from what I tap,
+  review, and override — without me ever managing settings.
+
+### Horizon (the vision)
+- *As an anxious traveler abroad,* I point my phone at a menu in another
+  language and get a safe, ranked, translated read — the highest-stakes,
+  highest-relief moment this product can own.
+- *As a restaurant owner,* I claim my listing, keep my menu current, and
+  earn a "BiteWorthy-safe" badge that brings in the loyal,
+  high-spend constrained-diner crowd.
+- *As a delivery / reservation app,* I embed BiteWorthy's safety layer so
+  my own users can filter — and BiteWorthy becomes infrastructure, not a
+  destination.
+- *As anyone, anywhere,* the question *"can I eat here?"* is answered
+  ambiently — by the time I've sat down, I already know.
+
+## The one thing to protect
+
+The wall between **safe** and **liked**, and the habit of always showing
+**why**. The moment a low-scored item reads as "unsafe," or a hidden item
+won't say its reason, the trust that makes this a medical-grade tool —
+not just another restaurant app — is gone. Everything else is
+negotiable. That isn't.


### PR DESCRIPTION
## Tell the BiteWorthy story — two halves

### `docs/vision.md` (internal)
The strategy doc behind the roadmap: the thesis (*an accessibility tool wearing a restaurant app's clothes*), the three convictions baked into the schema (safety filters / taste ranks · honest disclosure · the ethically crowd-built menu graph), the arc (wedge → data moat → supply side → personalization → ambient), the full set of user stories (today / soon / horizon), and the one thing to protect.

### `/story` (user-facing)
The warm, plain-voiced telling you can send someone to explain *why* the app exists. Pure SSR, same `bite` / `bw-*` tokens as the landing. Its spine is the product principle — **“Safety filters. Taste ranks.”** + always show *why* — and it closes into the onboarding flow. Linked from the landing footer and added to the sitemap.

### Notes
- Copy uses **real typographic glyphs** (’ “ ” — … ·), not HTML entities — the curly characters aren't ASCII, so they don't trip `react/no-unescaped-entities` (and they read cleanly in source).
- **Tested:** `story/__tests__/page.test.tsx` — the headline, the verbatim principle, the strict-mode disclosure copy, the `/onboarding` CTA, and the canonical `/story` metadata; sitemap assertions updated for the new route.
- web `typecheck` + `lint` clean, vitest **165 (+5)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)