### PR TITLE
feat(web): add "Read our story" link to the landing hero

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -67,6 +67,16 @@ function Hero(): ReactElement {
         <ComingSoonBadge label="Android app" />
       </div>
 
+      <p className="mt-bw-4">
+        <a
+          href="/story"
+          data-testid="hero-story"
+          className="text-bw-base font-bold text-bite hover:text-bite-dark"
+        >
+          Read our story →
+        </a>
+      </p>
+
       <p className="mt-bw-4 text-bw-xs text-zinc-500">
         Free during the Durango beta. No ads, no email signup until you choose to save a profile.
       </p>


### PR DESCRIPTION
## What

Adds a **"Read our story →"** link to the landing page hero. The `/story` page was previously only reachable from the footer; surfacing it in the hero gives it more pull.

## Details

- New secondary text link in the `Hero` component (`apps/web/src/app/page.tsx`), placed below the CTA/badge row and above the beta microcopy.
- Styled with the brand `bite` color (no fill) so it reads as **secondary** to the primary "Try the web app →" CTA rather than competing with it.
- Tagged `data-testid="hero-story"` to mirror the footer's `footer-story`.
- Footer "Our story" link unchanged — both point to `/story`.

## Verification

- `pnpm --filter @biteworthy/web typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)