### PR TITLE
docs: legal remediation plan + honest privacy/ToS copy (Phase 1)

### DIFF
--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -8,10 +8,16 @@ import { buildLegalMetadata } from '../../lib/legal-meta';
  * **DRAFT — needs lawyer review before App Store submission.**
  *
  * Fills the App Privacy disclosures with BiteWorthy's actual data
- * flows (Phases 1–5). The boilerplate sections (cookies, GDPR
- * rights, CCPA, contact) are written for what we DO collect; if a
+ * flows (Phases 1–8). The boilerplate sections (retention, privacy
+ * rights, children, contact) are written for what we DO collect; if a
  * lawyer adds collection paths we don't yet have, they update both
  * this page AND the App Store privacy questionnaire to match.
+ *
+ * Legal-remediation Phase 1 (see docs/plans/legal-remediation.md):
+ * corrected hosting facts (Hetzner + Neon, not Fly.io), added
+ * retention + CCPA-rights + public-information sections, disclosed the
+ * waitlist and shareable-filter-link data flows, and made the
+ * analytics and deletion wording match what the code actually does.
  *
  * Resolves the Phase 5.5 marketing landing footer's `/privacy`
  * placeholder href.
@@ -27,15 +33,13 @@ export const metadata: Metadata = buildLegalMetadata({
   siteUrl: SITE_URL,
 });
 
-const LAST_UPDATED = '2026-04-30';
+const LAST_UPDATED = '2026-06-14';
 
 export default function PrivacyPage(): ReactElement {
   return (
     <main className="mx-auto max-w-3xl px-bw-6 pt-bw-12 pb-bw-16">
       <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">Legal</p>
-      <h1 className="mt-bw-3 text-bw-3xl font-bold text-zinc-900 md:text-bw-4xl">
-        Privacy Policy
-      </h1>
+      <h1 className="mt-bw-3 text-bw-3xl font-bold text-zinc-900 md:text-bw-4xl">Privacy Policy</h1>
       <p className="mt-bw-2 text-bw-sm text-zinc-500">Last updated: {LAST_UPDATED}</p>
 
       <DraftBanner />
@@ -43,9 +47,10 @@ export default function PrivacyPage(): ReactElement {
       <article className="prose prose-zinc mt-bw-8 max-w-none text-zinc-800">
         <Section title="The short version">
           <p>
-            BiteWorthy keeps the data we need to make the dietary filter work and not much more.
-            We don&rsquo;t sell your data. We don&rsquo;t share it with advertisers. The list of
-            third-party services we use is short and named below.
+            BiteWorthy keeps the data we need to make the dietary filter work and not much more. We
+            don’t sell or share your personal information. We don’t share it with advertisers. The
+            list of third-party services we use is short and named below. You must be at least 13
+            years old to use BiteWorthy.
           </p>
         </Section>
 
@@ -56,13 +61,15 @@ export default function PrivacyPage(): ReactElement {
               sign in with Apple or Google), display handle. Optional photo.
             </li>
             <li>
-              <strong>Dietary profile:</strong> the ingredients and tags you mark &ldquo;avoid,&rdquo;
-              the dietary preset (e.g. <em>Celiac</em>) you picked, your strictness setting. Stored
-              against your account so it follows you across devices.
+              <strong>Dietary profile:</strong> the ingredients and tags you mark “avoid,” the
+              dietary preset (e.g. <em>Celiac</em>) you picked, your strictness setting, and any
+              taste signals (ingredients/tags you like or dislike) you add to improve your picks.
+              Stored against your account so it follows you across devices.
             </li>
             <li>
               <strong>Reviews:</strong> the rating, body, and optional photo you submit on a dish.
-              Photos are stored on Cloudflare R2 (see &ldquo;Where data lives&rdquo;).
+              Reviews are public — see “What’s public” below. Photos are stored on Cloudflare R2
+              (see “Where data lives”).
             </li>
             <li>
               <strong>Restaurant visits:</strong> when you open a filtered restaurant page while
@@ -70,9 +77,13 @@ export default function PrivacyPage(): ReactElement {
               <em>My filtered menus</em>. Anonymous browsing creates no such row.
             </li>
             <li>
-              <strong>Suggested edits:</strong> if you submit a fix to a dish (e.g. &ldquo;this
-              actually contains dairy&rdquo;), we keep the suggestion + its decision history for the
-              moderation queue.
+              <strong>Suggested edits:</strong> if you submit a fix to a dish (e.g. “this actually
+              contains dairy”), we keep the suggestion + its decision history for the moderation
+              queue.
+            </li>
+            <li>
+              <strong>Waitlist:</strong> if you join the launch waitlist, we store your email
+              address so we can tell you when BiteWorthy is available.
             </li>
           </ul>
         </Section>
@@ -86,11 +97,30 @@ export default function PrivacyPage(): ReactElement {
           </ul>
         </Section>
 
+        <Section title="What's public">
+          <p>
+            Your reviews — the rating, text, and any photo — appear publicly next to your display
+            handle on the dish page and on your profile at <em>/u/your-handle</em>. Your{' '}
+            <strong>dietary profile is never shown publicly</strong>: what you avoid, your presets,
+            your strictness, and your taste signals stay private to your account. Be aware that a
+            pattern of public reviews can let someone infer your preferences.
+          </p>
+          <p>
+            If you share a filtered menu link, the link itself encodes your avoid-lists and
+            strictness so the recipient sees the same filter. It does not include your identity,
+            email, or taste signals — but treat a shared link like any private link, since anyone
+            who has it can read those filter settings.
+          </p>
+        </Section>
+
         <Section title="Where data lives">
           <ul>
             <li>
-              <strong>Postgres on Fly.io</strong> (region: Denver, USA): your account, profile,
-              reviews text, suggestions.
+              <strong>Neon Postgres</strong> (AWS, US East): your account, profile, review text,
+              suggestions, and visit history.
+            </li>
+            <li>
+              <strong>Hetzner</strong> (Ashburn, USA): the servers that run the API.
             </li>
             <li>
               <strong>Cloudflare R2</strong>: review photos and the cropped per-dish photos that the
@@ -103,56 +133,91 @@ export default function PrivacyPage(): ReactElement {
             </li>
             <li>
               <strong>Postmark</strong>: outbound email (claim verification, password reset). The
-              recipient address and message body pass through Postmark; we don&rsquo;t store the
-              message itself.
+              recipient address and message body pass through Postmark; we don’t store the message
+              itself.
             </li>
             <li>
-              <strong>PostHog</strong> (optional, if you opt in): anonymous funnel events like{' '}
-              <em>app_open</em>, <em>menu_filtered</em>. No content of reviews or profile fields is
-              sent. See <a href="/terms#analytics">Terms § Analytics</a> for the opt-in flow.
+              <strong>PostHog</strong>: product analytics. See “Your rights and controls” for
+              exactly what we send and how to opt out.
             </li>
           </ul>
         </Section>
 
-        <Section title="Your controls">
+        <Section title="How long we keep it">
           <ul>
             <li>
-              <strong>Export your data:</strong> email <a href="mailto:privacy@bite-worthy.com">privacy@bite-worthy.com</a>{' '}
-              and we&rsquo;ll send a JSON archive within 30 days.
+              <strong>Account & dietary profile:</strong> kept for as long as your account is open;
+              removed when you delete it (see below).
             </li>
             <li>
-              <strong>Delete your account:</strong> same email, same response window. Reviews are
-              anonymized (set to <em>removed_user</em>) by default; let us know if you want them
-              hard-deleted instead.
+              <strong>Reviews & suggested edits:</strong> kept as part of the shared menu graph; if
+              you delete your account we delete or anonymize them.
             </li>
             <li>
-              <strong>Opt out of analytics:</strong> on web, set the toggle in{' '}
-              <em>/profile/settings</em>. On mobile, analytics are off by default — they only fire
-              if you explicitly enable them in <em>Settings → Analytics</em>. We honor browser
-              Do-Not-Track on the web side automatically.
+              <strong>Restaurant-visit history:</strong> kept for as long as your account is open.
+              After you delete your account it’s removed from active systems within 30 days and
+              fully purged within 12 months.
             </li>
           </ul>
+        </Section>
+
+        <Section title="Your rights and controls">
+          <ul>
+            <li>
+              <strong>Access / export your data:</strong> email{' '}
+              <a href="mailto:privacy@bite-worthy.com">privacy@bite-worthy.com</a> and we’ll send a
+              JSON archive within 30 days.
+            </li>
+            <li>
+              <strong>Delete your account:</strong> same email, same window. We remove your personal
+              data within 30 days and delete or anonymize your reviews. Some records may be retained
+              where the law requires it.
+            </li>
+            <li>
+              <strong>Correct your data:</strong> update your dietary profile any time in the app;
+              for anything else, email us and we’ll fix it.
+            </li>
+            <li>
+              <strong>Opt out of analytics:</strong> on web, analytics are on by default — turn them
+              off with the toggle in <em>/profile/settings</em>, and we honor your browser’s
+              Do-Not-Track signal automatically. On mobile, analytics are off by default and only
+              fire if you enable them in <em>Settings → Analytics</em>. When analytics are on and
+              you’re signed in, the funnel events (e.g. <em>app_open</em>, <em>menu_filtered</em>)
+              are linked to your account and include coarse signals such as your strictness setting,
+              which dietary preset you use, and counts of hidden/visible items. We never send review
+              text, your email, or your specific avoid-lists.
+            </li>
+            <li>
+              <strong>We do not sell or share</strong> your personal information, and we will not
+              discriminate against you for exercising any of these rights.
+            </li>
+          </ul>
+          <p>
+            BiteWorthy is available in the United States at launch. If you’re in the EU or UK,
+            additional rights may apply — contact us and we’ll honor them.
+          </p>
         </Section>
 
         <Section title="Children">
           <p>
-            BiteWorthy is for adults — restaurants, allergens, dining out. If we learn we&rsquo;ve
-            collected data from someone under 13, we delete it. (BiteWorthy is not directed at
-            children.)
+            BiteWorthy is for diners managing their own or their family’s dietary needs. You must be
+            at least 13 to create an account. If we learn we’ve collected personal data from a child
+            under 13, we delete it. BiteWorthy is not directed at children under 13.
           </p>
         </Section>
 
         <Section title="Changes">
           <p>
-            We&rsquo;ll update the date at the top when this page changes. Material changes get a
+            We’ll update the date at the top when this page changes. Material changes get a
             highlighted note on the homepage and an email to active accounts.
           </p>
         </Section>
 
         <Section title="Contact">
           <p>
-            <a href="mailto:privacy@bite-worthy.com">privacy@bite-worthy.com</a> for anything in
-            this policy. Questions about specific data, takedowns, or legal requests.
+            Email <a href="mailto:privacy@bite-worthy.com">privacy@bite-worthy.com</a> for anything
+            in this policy, including data access, deletion, or correction requests. For copyright
+            takedowns, see <a href="/terms#copyright">Terms § Copyright & DMCA</a>.
           </p>
         </Section>
       </article>
@@ -167,7 +232,7 @@ function DraftBanner(): ReactElement {
       className="mt-bw-6 rounded-bw-md border border-warn/40 bg-warn/10 p-bw-4 text-bw-sm text-zinc-800"
       data-testid="draft-banner"
     >
-      <strong>Draft.</strong> This template fills the App Privacy disclosures with BiteWorthy&rsquo;s
+      <strong>Draft.</strong> This template fills the App Privacy disclosures with BiteWorthy’s
       actual data flows but has not yet had final lawyer review. The launch checklist (Phase 5.9)
       requires that pass before App Store / Play Store submission.
     </div>

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -7,6 +7,14 @@ import { buildLegalMetadata } from '../../lib/legal-meta';
  *
  * **DRAFT — needs lawyer review before App Store submission.**
  *
+ * Legal-remediation Phase 1 (see docs/plans/legal-remediation.md)
+ * added the standard protective clauses a real ToS needs: warranty
+ * disclaimer (AS IS), limitation of liability, indemnification,
+ * arbitration + class-action waiver (with 30-day opt-out), a Copyright
+ * & DMCA section, and an acceptance clause. These are solid drafts;
+ * a licensed Colorado attorney finalizes them before the DRAFT banner
+ * comes off (legal-remediation L1).
+ *
  * Resolves the Phase 5.5 marketing landing footer's `/terms`
  * placeholder href.
  */
@@ -21,7 +29,7 @@ export const metadata: Metadata = buildLegalMetadata({
   siteUrl: SITE_URL,
 });
 
-const LAST_UPDATED = '2026-04-30';
+const LAST_UPDATED = '2026-06-14';
 
 export default function TermsPage(): ReactElement {
   return (
@@ -35,12 +43,19 @@ export default function TermsPage(): ReactElement {
       <DraftBanner />
 
       <article className="prose prose-zinc mt-bw-8 max-w-none text-zinc-800">
+        <Section title="Acceptance of these terms">
+          <p>
+            By creating an account or using BiteWorthy, you agree to these Terms and to our{' '}
+            <a href="/privacy">Privacy Policy</a>. If you don’t agree, please don’t use the service.
+            You must be at least 13 years old to use BiteWorthy.
+          </p>
+        </Section>
+
         <Section title="The bargain">
           <p>
             BiteWorthy is a free dietary filter for restaurant menus. By using it you agree to use
-            it in good faith and to understand what it can and can&rsquo;t promise (see &ldquo;The
-            allergen disclaimer&rdquo; below). If those don&rsquo;t work for you, please don&rsquo;t
-            use the service.
+            it in good faith and to understand what it can and can’t promise (see “The allergen
+            disclaimer” below). If those don’t work for you, please don’t use the service.
           </p>
         </Section>
 
@@ -53,18 +68,57 @@ export default function TermsPage(): ReactElement {
           </p>
           <ul>
             <li>
+              <strong>We can be wrong in the dangerous direction.</strong> We may fail to flag an
+              allergen the menu text didn’t spell out, so a dish that isn’t safe for you can still
+              appear in your filtered results. Treat every result as a starting point, not a
+              guarantee.
+            </li>
+            <li>
               Always confirm with the restaurant before ordering anything that triggers a serious
               allergy.
             </li>
             <li>
-              The &ldquo;hidden — contains dairy (cheese)&rdquo; chip is our best guess. The
-              &ldquo;visible&rdquo; chip is also our best guess.
+              The “hidden — contains dairy (cheese)” chip is our best guess. The “visible” chip is
+              also our best guess.
             </li>
             <li>
               We do not recommend BiteWorthy as the sole tool for managing anaphylactic allergies.
               Carry your prescribed treatment.
             </li>
           </ul>
+        </Section>
+
+        <Section title="Disclaimer of warranties">
+          <p>
+            BiteWorthy is provided <strong>“as is”</strong> and <strong>“as available,”</strong>{' '}
+            without warranties of any kind, whether express or implied — including implied
+            warranties of merchantability, fitness for a particular purpose, accuracy, and
+            non-infringement. We do not warrant that the dietary information is accurate, complete,
+            or current, or that the service will be uninterrupted or error-free. Some jurisdictions
+            don’t allow the exclusion of certain warranties, so parts of this may not apply to you.
+          </p>
+        </Section>
+
+        <Section title="Limitation of liability">
+          <p>
+            To the maximum extent permitted by law, BiteWorthy and its operators will not be liable
+            for any indirect, incidental, special, consequential, or punitive damages, or for any
+            loss arising from your reliance on the dietary information — including any allergic
+            reaction, illness, or injury. Our total liability for any claim relating to the service
+            is limited to USD 100. Some jurisdictions don’t allow these limitations, and{' '}
+            <strong>
+              nothing in these Terms limits any liability that can’t be limited by law.
+            </strong>
+          </p>
+        </Section>
+
+        <Section title="Indemnification">
+          <p>
+            You agree to indemnify and hold harmless BiteWorthy and its operators from any claim or
+            demand arising out of content you submit (reviews, photos, suggested edits), any URL or
+            menu you submit to the ingestion pipeline, your violation of these Terms, or your
+            violation of any law or third-party right.
+          </p>
         </Section>
 
         <Section title="Content you submit">
@@ -81,41 +135,63 @@ export default function TermsPage(): ReactElement {
             </li>
             <li>
               <strong>Photos:</strong> you grant BiteWorthy a license to display them alongside the
-              dish or restaurant. Don&rsquo;t upload anything you don&rsquo;t have rights to.
+              dish or restaurant. Don’t upload anything you don’t have rights to.
             </li>
           </ul>
         </Section>
 
+        <Section title="Copyright & DMCA" id="copyright">
+          <p>
+            BiteWorthy respects intellectual property. If you believe content on BiteWorthy
+            infringes your copyright — including a menu image or a dish photo — send a notice to{' '}
+            <a href="mailto:legal@bite-worthy.com">legal@bite-worthy.com</a> that includes: (1)
+            identification of the work; (2) the URL or location of the material on BiteWorthy; (3)
+            your contact information; (4) a statement that you have a good-faith belief the use
+            isn’t authorized; (5) a statement, under penalty of perjury, that the notice is accurate
+            and that you’re the owner or authorized to act for them; and (6) your signature.
+          </p>
+          <p>
+            We remove material that infringes and terminate repeat infringers. If you believe your
+            content was removed in error, you may send a counter-notice to the same address.
+          </p>
+        </Section>
+
         <Section title="Restaurant claims">
           <p>
-            Phase 4.9&rsquo;s claim flow lets a restaurant owner verify ownership via a domain-email
+            Phase 4.9’s claim flow lets a restaurant owner verify ownership via a domain-email
             check. Once verified, the owner can edit menu items and respond to reviews. Verifying
-            doesn&rsquo;t grant the owner the right to delete unfavorable reviews — moderation
-            still goes through the queue.
+            doesn’t grant the owner the right to delete unfavorable reviews — moderation still goes
+            through the queue.
           </p>
         </Section>
 
         <Section title="Acceptable use">
           <ul>
             <li>No spam, abuse, harassment, or bot-driven submissions.</li>
-            <li>Don&rsquo;t scrape the API at a rate that affects other users.</li>
+            <li>Don’t scrape the API at a rate that affects other users.</li>
             <li>
-              Don&rsquo;t pretend to be a restaurant owner you&rsquo;re not. The claim flow exists
-              for a reason.
+              Don’t pretend to be a restaurant owner you’re not. The claim flow exists for a reason.
             </li>
             <li>
-              Don&rsquo;t upload menu images you don&rsquo;t have permission to share. Most public
-              menus are fine; some restaurants explicitly forbid republication.
+              Don’t upload menu images you don’t have permission to share. Most public menus are
+              fine; some restaurants explicitly forbid republication.
+            </li>
+            <li>
+              When you submit a menu URL or upload for ingestion, you confirm you have the right to
+              share that content with us and that doing so doesn’t violate the source site’s terms
+              or anyone’s copyright.
             </li>
           </ul>
         </Section>
 
         <Section title="Analytics" id="analytics">
           <p>
-            On web, BiteWorthy uses PostHog for funnel analytics (anonymous events like{' '}
-            <em>app_open</em>, <em>menu_filtered</em>; never review text or profile fields). We
-            honor browser <em>Do-Not-Track</em> automatically and a per-user opt-out at{' '}
-            <em>/profile/settings</em>.
+            On web, BiteWorthy uses PostHog for funnel analytics (events like <em>app_open</em>,{' '}
+            <em>menu_filtered</em>). When you’re signed in these events are linked to your account
+            and include coarse signals like your strictness setting, which dietary preset you use,
+            and counts of hidden/visible items — never review text, your email, or your specific
+            avoid-lists. We honor browser <em>Do-Not-Track</em> automatically and a per-user opt-out
+            at <em>/profile/settings</em>.
           </p>
           <p>
             On mobile, analytics are <strong>off by default</strong>. They only fire if you
@@ -124,25 +200,41 @@ export default function TermsPage(): ReactElement {
           </p>
         </Section>
 
-        <Section title="Termination">
+        <Section title="Dispute resolution" id="disputes">
           <p>
-            You can delete your account at any time (see <a href="/privacy">Privacy Policy</a>). We
-            can suspend accounts that violate these terms; we&rsquo;ll explain why if it happens.
+            Please contact us first — most issues can be resolved by email. For any dispute that
+            can’t be resolved informally, you and BiteWorthy agree to resolve it through{' '}
+            <strong>binding individual arbitration</strong>, not in court, and you each waive the
+            right to a jury trial and to participate in a <strong>class action</strong>.
+          </p>
+          <p>
+            You may opt out of this arbitration agreement by emailing{' '}
+            <a href="mailto:legal@bite-worthy.com">legal@bite-worthy.com</a> within 30 days of first
+            accepting these Terms; opting out won’t affect the rest of the Terms. This section
+            doesn’t apply to small-claims matters or to requests for injunctive relief.
           </p>
         </Section>
 
         <Section title="Governing law">
           <p>
-            These terms are governed by the laws of the State of Colorado, USA. Disputes go to the
-            state or federal courts located in La Plata County, Colorado.
+            These terms are governed by the laws of the State of Colorado, USA. Subject to the
+            arbitration agreement above, disputes go to the state or federal courts located in La
+            Plata County, Colorado.
+          </p>
+        </Section>
+
+        <Section title="Termination">
+          <p>
+            You can delete your account at any time (see <a href="/privacy">Privacy Policy</a>). We
+            can suspend accounts that violate these terms; we’ll explain why if it happens.
           </p>
         </Section>
 
         <Section title="Contact">
           <p>
             <a href="mailto:hello@bite-worthy.com">hello@bite-worthy.com</a> for anything in these
-            terms. Legal notices to{' '}
-            <a href="mailto:legal@bite-worthy.com">legal@bite-worthy.com</a>.
+            terms. Legal notices to <a href="mailto:legal@bite-worthy.com">legal@bite-worthy.com</a>
+            .
           </p>
         </Section>
       </article>

--- a/docs/plans/legal-remediation.md
+++ b/docs/plans/legal-remediation.md
@@ -1,0 +1,253 @@
+# Legal remediation plan
+
+Derived from the pre-launch legal risk memo (2026-06-14). Sequenced so the
+two things fully in our control with no external dependency — the **Privacy
+Policy** and **Terms of Service** copy — go first, then the engineering work,
+then the items that genuinely need a licensed Colorado attorney or an external
+registration.
+
+**Owner tags:** `[ENG]` we build it · `[COPY]` text-only edit to a legal page ·
+`[DECISION]` needs a founder call before the text can be written ·
+`[ATTORNEY]` needs a licensed lawyer · `[OPS]` an external registration/process.
+
+**Source files for Phase 1:**
+
+- `apps/web/src/app/privacy/page.tsx`
+- `apps/web/src/app/terms/page.tsx`
+
+---
+
+## Decisions that gate the Phase 1 copy
+
+**Answered 2026-06-14:** (1) arbitration + class-waiver **included, 30-day
+opt-out**; (2) **US-only** at launch (CCPA now, GDPR stubbed); (3) minimum age
+**13+**; (4) analytics **opt-in + strip dietary fields** to be built (E7), Phase
+1 writes honest interim wording; (5) keep the **manual** email-driven
+deletion/export promise, drop the `removed_user` technical claim.
+
+These change the words we put on the page, so they're answered before (or
+alongside) Phase 1. Defaults in **bold** are my recommendation.
+
+1. **Arbitration + class-action waiver in the ToS?** `[DECISION]`
+   For a product with mass-tort-shaped downside (many similarly-situated
+   allergic users), a mandatory-arbitration + class-waiver clause with a 30-day
+   opt-out is the standard structural defense. Downsides: per-claim arbitration
+   fees, some user goodwill cost. **Recommend: include it, with opt-out.**
+2. **Launch audience: US-only, or EU/UK too?** `[DECISION]`
+   The store listings say US-only at launch. If true, Phase 1 writes
+   CCPA/CPRA-style state-privacy rights now and defers full GDPR
+   (lawful-basis, data-controller, EU representative, 16-yr threshold) to when
+   we go international. **Recommend: US-only now; GDPR section stubbed + queued.**
+3. **Minimum age: 13 or 16?** `[DECISION]`
+   Current policy says "for adults" but enforces against under-13 (COPPA). With
+   no age gate today (Phase 2 builds one), the policy should state a real
+   minimum. **Recommend: 16+ to create an account** (clears COPPA cleanly and
+   most of GDPR Art. 8), stated in both pages.
+4. **Interim deletion/export: commit to manual fulfillment now?** `[DECISION]`
+   The policy already promises email-driven export + deletion "within 30 days."
+   A human can honor that manually until Phase 2 ships the endpoints. **Recommend:
+   yes — keep the promise, assign the inbox, drop the specific `removed_user`
+   technical claim** (reword to "we delete or anonymize your reviews").
+5. **Web analytics direction.** `[DECISION]`
+   Today web analytics default to **opt-out** (on) and send `strictness` +
+   dietary-preset slugs + avoid/hidden counts tied to an identified user — which
+   contradicts the policy's "anonymous / opt-in" wording. Two honest paths:
+   (a) reword the policy to match today's behavior, or (b) flip web to opt-in +
+   strip dietary fields (Phase 2) and keep the cleaner wording. **Recommend: (b)
+   — do the engineering, keep the strong privacy promise.** Phase 1 writes the
+   interim-honest wording until (b) lands.
+
+---
+
+## Phase 1 — Privacy & ToS copy (do first) `[COPY]`
+
+All edits land in the two page files above. Bump `LAST_UPDATED` on both. Keep
+the `DraftBanner` until an attorney signs off (Phase 3).
+
+### 1A — Privacy Policy
+
+- [x] **P1. Fix stale infra facts.** "Where data lives" still says _Postgres on
+      Fly.io (Denver)_. We moved to **Neon Postgres (AWS us-east-1)** + **Hetzner
+      compute (Ashburn, US)** per ADR 0007 (#182, Fly.io retired). Correct the
+      hosting list; keep R2 / Anthropic / Postmark / PostHog.
+- [x] **P2. Add a "Data retention" section.** State how long we keep profile,
+      reviews, and `restaurant_visits`, and the deletion timeline. (Memo Issue 3.)
+- [x] **P3. Add a "Your privacy rights" (CCPA/CPRA) section.** Right to know /
+      delete / correct, the explicit "**We do not sell or share your personal
+      information**" magic words, and no-discrimination. (Memo Issue 6.) Stub a
+      GDPR subsection per Decision 2.
+- [x] **P4. Disclose that reviews are public.** Note handle + review text/photo
+      are public and can reveal preferences. (Memo Issue 6 — de-anonymization.)
+- [x] **P5. Reconcile the Children section** to the Decision-3 minimum age;
+      align the COPPA/GDPR threshold wording.
+- [x] **P6. Make the analytics wording honest** (Decision 5). Until Phase 2's
+      opt-in/strip ships: state web analytics are on-by-default with an opt-out +
+      DNT, and disclose the coarse dietary signals sent (strictness, preset, counts).
+- [x] **P7. Make the deletion/export wording honest** (Decision 4). Keep the
+      manual email process; drop the specific `removed_user` claim.
+- [x] **P8. Tighten the Contact section** (fix the sentence fragment; point
+      takedowns at the DMCA contact added in 1B/T6).
+- [x] **P9. Disclose waitlist email collection** (matrix row 14) — the landing
+      waitlist form stores emails; added to "What we collect".
+- [x] **P10. Disclose shareable-filter-link data** (matrix row 13) — `?p=` links
+      carry avoid-lists + strictness; added to "What's public".
+- [x] **P11. Retention = account lifetime + 12-month purge** after deletion
+      (matrix row 12; founder decision 2026-06-14), not a fixed clock.
+
+### 1B — Terms of Service
+
+- [x] **T1. Add "Disclaimer of warranties (AS IS)."** `[ATTORNEY]` to finalize;
+      Phase 1 lands solid draft language.
+- [x] **T2. Add "Limitation of liability"** (exclude consequential damages, cap
+      liability). `[ATTORNEY]` to finalize.
+- [x] **T3. Add "Indemnification"** — users indemnify for their uploads and any
+      URL they submit to the ingestion fetcher. `[ATTORNEY]` to finalize.
+- [x] **T4. Add "Dispute resolution: arbitration + class-action waiver"** with a
+      30-day opt-out, per Decision 1. `[ATTORNEY]` to finalize.
+- [x] **T5. Strengthen the allergen disclaimer** to name the false-negative case
+      explicitly ("we may fail to flag an allergen the menu didn't spell out") and
+      to say the disclaimer is also shown in the app (true once Phase 2 ships the
+      in-app banner). (Memo Issue 1.)
+- [x] **T6. Add "Copyright & DMCA"** — designated-agent contact, notice +
+      counter-notice procedure, repeat-infringer policy. (Memo Issue 4; text now,
+      agent registration is Phase 3 / OPS.)
+- [x] **T7. Extend Acceptable use** to cover the URL-fetch path (user must have
+      rights to content they point us at), not just uploads.
+- [x] **T8. Add an "Acceptance of terms" clause** — use constitutes acceptance;
+      reference the onboarding acknowledgment (live once Phase 2 ships it).
+
+**Phase 1 acceptance:** both pages typecheck/lint/build; `pnpm --filter
+@biteworthy/web test` green (the draft-banner test still passes); every promise
+on the page is either backed by code today or by a committed manual process; no
+stale infra facts. Ship as one PR: `docs:`/`feat(web):` per conventional-commit
+rules. **Does not** remove the DRAFT banners — that waits on Phase 3.
+
+---
+
+## Legal ↔ code alignment matrix
+
+The audit (verified 2026-06-14 against the working tree) of every promise the
+legal pages now make, what the code actually does, and the task that closes the
+gap. **Direction:** `code→legal` = build code to honor a promise · `legal→code`
+= copy already adjusted to match code (done in Phase 1) · `both` = needs each.
+
+| #   | Legal statement (page)                                                                   | Code reality (verified)                                                          | Status                 | Action                                | Direction        |
+| --- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------- | ------------------------------------- | ---------------- |
+| 1   | Allergen disclaimer / "best guess" (ToS)                                                 | only on `/terms`; no in-app banner, no acceptance                                | ABSENT in-app          | **E1**                                | code→legal       |
+| 2   | "export … JSON archive within 30 days" (Privacy)                                         | no export endpoint; manual only                                                  | ABSENT                 | **E3** (interim: manual)              | code→legal       |
+| 3   | "delete your account … within 30 days; delete or anonymize reviews" (Privacy)            | no `destroy` action; no anonymization                                            | ABSENT                 | **E2** (interim: manual)              | code→legal       |
+| 4   | "update your dietary profile in the app" (Privacy)                                       | `PATCH /api/v1/profile` + onboarding flow exist                                  | EXISTS                 | —                                     | aligned          |
+| 5   | review correction implied by "edit … reviews"                                            | review PATCH/DELETE API exists; **no UI**                                        | PARTIAL                | **E11**                               | code→legal       |
+| 6   | "opt out … toggle in /profile/settings" + DNT (Privacy/ToS)                              | DNT + `bw_analytics_opt_out` honored in `track.ts`; **no settings UI to set it** | PARTIAL                | **E7a**                               | code→legal       |
+| 7   | "mobile analytics off by default … enable in Settings → Analytics"                       | default-off enforced; **no Settings → Analytics screen**                         | PARTIAL                | **E7b**                               | code→legal       |
+| 8   | analytics send "coarse signals (strictness/preset/counts) linked to account"             | matches code today                                                               | EXISTS                 | **E7c** strip → reword to "anonymous" | both             |
+| 9   | "we do not sell or share"; no ad IDs (Privacy)                                           | true; no ad SDKs / data sales                                                    | EXISTS                 | keep; E7 must not undermine           | aligned          |
+| 10  | "dietary profile is never shown publicly" (Privacy)                                      | public user endpoint excludes it; spec asserts exact keys                        | EXISTS (test indirect) | **E13** add explicit field assertions | hardening        |
+| 11  | "you must be at least 13" (Privacy/ToS)                                                  | no age field, no gate                                                            | ABSENT                 | **E4**                                | code→legal       |
+| 12  | visit history "kept for account lifetime; purged within 12 months of deletion" (Privacy) | no purge/retention job                                                           | ABSENT                 | **E5**                                | code→legal       |
+| 13  | "a shared link encodes your avoid-lists and strictness … not identity/taste" (Privacy)   | token does exactly this; plaintext, no expiry                                    | EXISTS                 | copy done; **E6** harden              | both             |
+| 14  | "Waitlist: we store your email" (Privacy)                                                | waitlist form + endpoint live                                                    | EXISTS                 | copy added Phase 1 (P9)               | legal→code ✓     |
+| 15  | "Copyright & DMCA … we remove infringing material and terminate repeat infringers" (ToS) | no takedown intake or repeat-infringer process                                   | ABSENT                 | **E10** + **L2**                      | code→legal + ops |
+| 16  | "we may hide reviews that trip the moderation heuristics" (ToS)                          | Phase 4.6 heuristics + admin queue exist                                         | EXISTS                 | —                                     | aligned          |
+| 17  | "don't scrape the API at a rate that affects others" (ToS)                               | no rack-attack / throttle                                                        | ABSENT (rule only)     | **E12** (optional)                    | code→legal       |
+| 18  | warranty / liability / indemnity / arbitration (ToS)                                     | draft text only; nothing to build                                                | n/a                    | **L1** attorney                       | attorney         |
+| 19  | handle shown publicly (Privacy "What's public")                                          | default handle derived from email local-part                                     | leak                   | **E9**                                | code→legal       |
+
+---
+
+## Phase 2 — Engineering remediation (in our control) `[ENG]`
+
+The build work that closes the `code→legal` rows above. Priority order; each is
+its own PR.
+
+- [ ] **E1. Point-of-use allergen disclaimer + onboarding acknowledgment.**
+      (Row 1; Memo Issue 1 — top exposure.) Persistent, non-dismissable disclaimer
+      on the filtered-menu view (web `restaurants/[slug]/RestaurantClient.tsx` +
+      mobile equivalent); a one-time acknowledgment at onboarding (especially when
+      an allergen avoid-list or strict mode is selected), recorded with a timestamp
+      on the user/profile. Then ToS can truthfully say "shown in the app" (T5
+      follow-up). Single highest-leverage item.
+- [ ] **E2. Account deletion endpoint.** (Row 3; Memo Issue 2.) Implement
+      `destroy` in `api/v1/auth/registrations_controller.rb`; route through the ORM
+      (DB FKs have no `ON DELETE CASCADE`); add `dependent:` to the orphan FKs
+      (`created_by_user_id`, `claimed_by_user_id`, `ingestion_runs.user_id`);
+      implement the review delete/anonymize the policy describes. rswag + codegen.
+- [ ] **E3. Data-export endpoint.** (Row 2; Memo Issue 2.) JSON archive of the
+      user's account, profile, reviews, suggestions, visits. rswag + codegen.
+- [ ] **E4. Age gate (13+).** (Row 11; Memo Issue 3.) Collect/confirm age at
+      signup; gate account creation. Store no more than needed (a boolean
+      over-13 flag or birth year — not full DOB).
+- [ ] **E5. Visit-history retention purge.** (Row 12; Memo Issue 3.) On account
+      deletion, purge `restaurant_visits` from active stores within 30 days and a
+      backstop sweep within 12 months. Recurring job; no rolling age cap while the
+      account is open.
+- [ ] **E6. Harden share tokens.** (Row 13; Memo Issue 3.) Add an expiry to the
+      `?p=` profile token (`packages/filter-engine/src/profile-token.ts` +
+      `apps/api/app/services/profile_token.rb`); sign it; keep the decoded dietary
+      fields out of access logs. Both implementations + the parity tests stay green.
+- [ ] **E7. Analytics: opt-in + strip dietary fields.** (Rows 6/7/8; Decision 5.) - **E7a** — web `/profile/settings` page with an analytics toggle that
+      writes `bw_analytics_opt_out` (the read path already exists in `track.ts`). - **E7b** — mobile Settings → Analytics screen that flips `optedIn`
+      (default-off already enforced in `apps/mobile/lib/track.ts`). - **E7c** — remove `strictness` / preset-slug / dietary counts from
+      identified events in `packages/analytics`, then reword the privacy/ToS
+      analytics copy back to the cleaner "anonymous" promise.
+- [ ] **E8. User-facing "report this review."** (Row 17-adjacent; Memo Issue 6.) A
+      report affordance that routes into the existing moderation queue (today it's
+      heuristic + admin-only). Defensive; no current legal claim depends on it.
+- [ ] **E9. Public-handle email leak.** (Row 19; Memo Issue 6.) Stop deriving the
+      public handle from the email local-part (`user.rb` `default_handle_from_email`);
+      use a neutral default.
+- [ ] **E10. DMCA takedown intake.** (Row 15; Memo Issue 4.) A `/dmca` page/form +
+      a repeat-infringer tracking process backing the ToS § Copyright clause.
+      Pairs with L2 (register the agent).
+- [ ] **E11. Review edit/delete UI.** (Row 5.) Wire the existing review PATCH/DELETE
+      API into the web (`ReviewsClient.tsx`) and mobile (`items/[id].tsx`) screens so
+      "correct your data" is true in-app, not just by email.
+- [ ] **E12. API rate limiting (optional).** (Row 17.) Add rack-attack throttling so
+      "don't scrape the API" is enforced, not just stated. Low priority — a ToS rule
+      is valid without technical enforcement; do it for abuse protection, not legal
+      necessity.
+- [ ] **E13. Strengthen the "profile never public" test.** (Row 10.) The current
+      spec asserts exact public keys (solid but indirect); add explicit assertions
+      that named dietary fields (`avoid_ingredient_ids`, `strictness`, taste arrays)
+      never appear in any public response. (CLAUDE.md Rule 7.)
+
+---
+
+## Phase 3 — Attorney / external `[ATTORNEY]` `[OPS]`
+
+Can't be closed by code; these are the checks worth writing.
+
+- [ ] **L1. Licensed Colorado attorney review** of the finalized Privacy + ToS,
+      including the T1–T4 protective clauses. Only after this do we remove the
+      DRAFT banners and the source-file DRAFT comments. (Memo Issue 5 + launch gate.)
+- [ ] **L2. Register a DMCA designated agent** with the U.S. Copyright Office
+      (~$6) to secure §512 safe harbor. Wire the agent contact into ToS §Copyright
+      and the `/dmca` page. (Memo Issue 4.) `[OPS]`
+- [ ] **L3. Attorney call on the dish-photo cropping/rehosting.**
+      (`dish_photo_cropper.rb` crops third-party menu photos and rehosts on R2.)
+      Honest fair-use read is weak; likely move to a restaurant-uploads/claim-based
+      photo model or owner opt-in. Decision drives whether the auto-crop ships at
+      launch. (Memo Issue 4.) `[ATTORNEY]` + likely follow-on `[ENG]`.
+- [ ] **L4. "BiteWorthy" trademark clearance** (basic knockout search) and a
+      decision on the `[OPS]` LICENSE file for the public repo. (Memo §III.)
+- [ ] **L5. Defer "BiteWorthy-safe" badge** (endorsement liability) to the
+      supply-side phase — flag only, no work now.
+
+---
+
+## Mapping back to the memo
+
+| Memo issue                                     | Covered by                                                  |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| 1 — disclaimer placement                       | E1 (in-app + onboarding), T5 (ToS text)                     |
+| 2 — policy promises vs code                    | P6/P7 (honest interim text), E2/E3 (build it), E11 (review) |
+| 3 — health data: age/retention/URL             | P2/P11 (text), E4/E5/E6                                     |
+| 4 — photo copyright + DMCA                     | T6 (text), E10 (intake), L2/L3 (register + fair-use)        |
+| 5 — missing ToS protective clauses             | T1–T4 (draft text), L1 (attorney)                           |
+| III — cookies/CCPA/handle/reporting/license/TM | P3/P4 (text), E7/E8/E9/E13 (build), L4                      |
+
+**Sequence:** Phase 1 (copy) is shipped. Phase 2 items are independent PRs —
+**E1 first** (top exposure), then E2/E3 (make the deletion/export promises true),
+then E4–E13. Phase 3 runs in parallel and is the true launch gate. Each Phase 2
+PR that closes a `code→legal` row should, in the same PR, tighten any interim
+copy that row left soft (e.g. E7c rewords analytics; E1 lets T5 say "in-app").


### PR DESCRIPTION
## What

Phase 1 of the pre-launch legal remediation — the copy-only changes fully in our control, plus the plan doc (`docs/plans/legal-remediation.md`) that sequences everything else.

### Privacy Policy (`apps/web/src/app/privacy/page.tsx`)
- Corrected stale infra facts → Neon Postgres (AWS us-east-1) + Hetzner (Ashburn), not Fly.io (ADR 0007).
- Added retention, CCPA/CPRA rights ("we do not sell or share"), what's-public, and children (13+) sections.
- Disclosed two undocumented data flows: launch **waitlist** email, and the **shareable filter link** (encodes avoid-lists + strictness).
- Made analytics + deletion/export wording honest about what the code does *today* (interim text until E2/E3/E7 land).
- Retention = account lifetime + 12-month purge after deletion.

### Terms of Service (`apps/web/src/app/terms/page.tsx`)
- Added AS-IS warranty disclaimer, limitation of liability (USD 100 cap + savings clause), indemnification, arbitration + class-action waiver (30-day opt-out).
- Added Copyright & DMCA (notice / counter-notice / repeat-infringer).
- Strengthened the allergen disclaimer to name the false-negative case.
- Extended acceptable-use to the URL-fetch ingestion path.

### Plan
- `docs/plans/legal-remediation.md`: decisions, Phase 1 checklist, the **legal↔code alignment matrix** (19 rows), and the **E1–E13** engineering queue.

## Not in this PR
- DRAFT banners stay until attorney review (**L1**).
- The engineering items (E1–E13) ship as their own PRs.

## Verification
- `pnpm --filter @biteworthy/web lint` ✅
- `pnpm --filter @biteworthy/web typecheck` ✅
- `pnpm --filter @biteworthy/web test` → 165/165 ✅
- No HTML entities / no mojibake (real Unicode glyphs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)