### PR TITLE
feat(web): in-app allergen disclaimer + onboarding acknowledgment (E1)

### DIFF
--- a/apps/api/app/controllers/api/v1/profiles_controller.rb
+++ b/apps/api/app/controllers/api/v1/profiles_controller.rb
@@ -38,6 +38,16 @@ module Api
           apply_preset!(profile, preset)
         end
 
+        # Legal remediation E1 — `acknowledge_disclaimer: true` records
+        # that the user saw and accepted the in-app allergen disclaimer
+        # (onboarding sends it on the final save). The time is stamped
+        # server-side, not taken from the client, and only the first
+        # acknowledgment is kept.
+        if ActiveModel::Type::Boolean.new.cast(params[:acknowledge_disclaimer]) &&
+           profile.disclaimer_acknowledged_at.nil?
+          profile.disclaimer_acknowledged_at = Time.current
+        end
+
         if profile.save
           render json: profile_payload(profile)
         else
@@ -85,7 +95,8 @@ module Api
           disliked_ingredient_ids: profile.disliked_ingredient_ids,
           disliked_tag_ids:        profile.disliked_tag_ids,
           strictness:           profile.strictness,
-          primary_dietary_profile: dietary_profile_summary(profile.primary_dietary_profile)
+          primary_dietary_profile: dietary_profile_summary(profile.primary_dietary_profile),
+          disclaimer_acknowledged_at: profile.disclaimer_acknowledged_at&.iso8601
         }
       end
 

--- a/apps/api/db/migrate/20260614120000_add_disclaimer_acknowledged_at_to_user_profiles.rb
+++ b/apps/api/db/migrate/20260614120000_add_disclaimer_acknowledged_at_to_user_profiles.rb
@@ -1,0 +1,9 @@
+# Legal remediation E1 — records that the user saw and accepted the
+# allergen disclaimer at onboarding. Server-stamped (never a
+# client-supplied time); nullable because profiles created before this
+# migration, and anonymous browsing, have no acknowledgment.
+class AddDisclaimerAcknowledgedAtToUserProfiles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_profiles, :disclaimer_acknowledged_at, :datetime, null: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_13_002000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -359,6 +359,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_002000) do
     t.uuid "avoid_ingredient_ids", default: [], null: false, array: true
     t.uuid "avoid_tag_ids", default: [], null: false, array: true
     t.datetime "created_at", null: false
+    t.datetime "disclaimer_acknowledged_at"
     t.uuid "disliked_ingredient_ids", default: [], null: false, array: true
     t.uuid "disliked_tag_ids", default: [], null: false, array: true
     t.uuid "liked_ingredient_ids", default: [], null: false, array: true

--- a/apps/api/spec/integration/api/v1/profile_spec.rb
+++ b/apps/api/spec/integration/api/v1/profile_spec.rb
@@ -46,7 +46,12 @@ RSpec.describe "profile", type: :request do
           disliked_ingredient_ids: { type: :array, items: { type: :string, format: :uuid } },
           disliked_tag_ids:        { type: :array, items: { type: :string, format: :uuid } },
           strictness:           { type: :string, enum: %w[relaxed balanced strict] },
-          dietary_profile_slug: { type: :string }
+          dietary_profile_slug: { type: :string },
+          acknowledge_disclaimer: {
+            type: :boolean,
+            description: "When true, server-stamps disclaimer_acknowledged_at " \
+                         "(first acknowledgment only). Sent by onboarding."
+          }
         }
       }
 
@@ -59,6 +64,22 @@ RSpec.describe "profile", type: :request do
         end
         let(:body) { { strictness: "strict" } }
         run_test!
+      end
+
+      response(200, "acknowledging the allergen disclaimer stamps a timestamp") do
+        schema "$ref" => "#/components/schemas/ProfilePayload"
+        let(:account)       { create(:user, password: "password123") }
+        let(:Authorization) do
+          token, _ = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+          "Bearer #{token}"
+        end
+        let(:body) { { acknowledge_disclaimer: true } }
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          # The flag is server-stamped, not echoed from the client.
+          expect(json["disclaimer_acknowledged_at"]).to be_present
+          expect(account.profile.reload.disclaimer_acknowledged_at).to be_present
+        end
       end
 
       response(404, "unknown dietary_profile_slug") do

--- a/apps/api/spec/swagger_helper.rb
+++ b/apps/api/spec/swagger_helper.rb
@@ -77,7 +77,8 @@ RSpec.configure do |config|
             required: %w[avoid_ingredient_ids avoid_tag_ids prefer_tag_ids
                          liked_ingredient_ids liked_tag_ids
                          disliked_ingredient_ids disliked_tag_ids
-                         strictness primary_dietary_profile],
+                         strictness primary_dietary_profile
+                         disclaimer_acknowledged_at],
             properties: {
               avoid_ingredient_ids: { type: :array, items: { type: :string, format: :uuid } },
               avoid_tag_ids:        { type: :array, items: { type: :string, format: :uuid } },
@@ -96,7 +97,11 @@ RSpec.configure do |config|
                   slug: { type: :string },
                   name: { type: :string }
                 }
-              }
+              },
+              # Legal remediation E1 — ISO-8601 timestamp of when the
+              # user accepted the in-app allergen disclaimer, or null if
+              # they never have. Server-stamped.
+              disclaimer_acknowledged_at: { type: :string, format: "date-time", nullable: true }
             }
           }
         }

--- a/apps/mobile/__tests__/screens/onboarding.render.test.tsx
+++ b/apps/mobile/__tests__/screens/onboarding.render.test.tsx
@@ -252,11 +252,36 @@ describe('OnboardingScreen — Step 5: review', () => {
     fireEvent.press(screen.getByLabelText('next-to-taste'));
     fireEvent.press(screen.getByLabelText('next-to-done'));
 
+    // Legal remediation E1 — the allergen disclaimer gates the save.
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText('acknowledge-disclaimer'));
+    });
+
     await act(async () => {
       fireEvent.press(screen.getByLabelText('finish'));
     });
 
     expect(mockReplace).toHaveBeenCalledWith('/login?next=%2Fonboarding');
     expect(mockSaveProfile).not.toHaveBeenCalled();
+  });
+
+  // Legal remediation E1 — finalize must not run until the user accepts
+  // the allergen disclaimer.
+  it('does not finalize until the allergen disclaimer is acknowledged', async () => {
+    render(<OnboardingScreen />);
+    await screen.findByLabelText('preset-vegan');
+
+    fireEvent.press(screen.getByLabelText('next-to-ingredients'));
+    fireEvent.press(screen.getByLabelText('next-to-strictness'));
+    fireEvent.press(screen.getByLabelText('next-to-taste'));
+    fireEvent.press(screen.getByLabelText('next-to-done'));
+
+    // Press finish while unacknowledged — the disabled Pressable swallows
+    // the press, so neither the save nor the login redirect fires.
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText('finish'));
+    });
+    expect(mockSaveProfile).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/app/onboarding/index.tsx
+++ b/apps/mobile/app/onboarding/index.tsx
@@ -68,6 +68,9 @@ export default function OnboardingScreen() {
   const [tasteQuery, setTasteQuery] = useState('');
   const [tasteResults, setTasteResults] = useState<IngredientSearchResult[]>([]);
   const [saving, setSaving] = useState(false);
+  // Legal remediation E1 — the user must accept the allergen disclaimer
+  // before the profile saves; the acceptance is recorded server-side.
+  const [acknowledged, setAcknowledged] = useState(false);
 
   // Load presets once.
   useEffect(() => {
@@ -138,7 +141,9 @@ export default function OnboardingScreen() {
     try {
       setSaving(true);
       const payload = toProfilePayload(draft, presets);
-      await saveProfile(payload, jwt);
+      // Legal remediation E1 — the done step gates this save behind the
+      // allergen-disclaimer toggle, so record the acknowledgment.
+      await saveProfile({ ...payload, acknowledge_disclaimer: true }, jwt);
       tracker.track('profile_set', {
         preset_slug: draft.selectedPresetSlugs[0] ?? null,
         avoid_ingredient_count: payload.avoid_ingredient_ids.length,
@@ -438,10 +443,26 @@ export default function OnboardingScreen() {
       </Text>
 
       <Pressable
+        accessibilityLabel="acknowledge-disclaimer"
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: acknowledged }}
+        onPress={() => setAcknowledged((v) => !v)}
+        style={styles.ackRow}
+      >
+        <View style={[styles.ackBox, acknowledged && styles.ackBoxChecked]}>
+          {acknowledged && <Text style={styles.ackCheck}>✓</Text>}
+        </View>
+        <Text style={styles.ackText}>
+          I understand BiteWorthy is a planning tool, not a guarantee — results can miss an
+          allergen, and I’ll confirm with the restaurant before ordering for a serious allergy.
+        </Text>
+      </Pressable>
+
+      <Pressable
         accessibilityLabel="finish"
         onPress={finalize}
-        disabled={saving}
-        style={[styles.primary, saving && { opacity: 0.5 }]}
+        disabled={saving || !acknowledged}
+        style={[styles.primary, (saving || !acknowledged) && { opacity: 0.5 }]}
       >
         <Text style={styles.primaryText}>{saving ? 'Saving…' : 'Save profile'}</Text>
       </Pressable>
@@ -560,6 +581,42 @@ const styles = StyleSheet.create({
     color: colors.bg,
     fontWeight: '700',
     fontSize: fontSize.base,
+  },
+  ackRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: space['3'],
+    padding: space['3'],
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.warn,
+    backgroundColor: 'rgba(245, 159, 0, 0.1)',
+    marginTop: space['2'],
+  },
+  ackBox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ackBoxChecked: {
+    borderColor: colors.bite,
+    backgroundColor: colors.bite,
+  },
+  ackCheck: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.sm,
+  },
+  ackText: {
+    flex: 1,
+    fontSize: fontSize.sm,
+    color: colors.text,
+    lineHeight: 20,
   },
   skip: {
     alignItems: 'center',

--- a/apps/mobile/app/restaurants/[id].tsx
+++ b/apps/mobile/app/restaurants/[id].tsx
@@ -232,6 +232,8 @@ export default function RestaurantScreen() {
       <ShareLinkButton slug={restaurant.slug} filter={filter} />
       <RescanButton restaurantId={restaurant.id} restaurantName={restaurant.name} />
 
+      <AllergenNotice />
+
       <TopPicksRow items={rawItems} />
 
       {overriddenSections.map((section) => (
@@ -250,6 +252,26 @@ export default function RestaurantScreen() {
         <Text style={styles.empty}>No published items at this restaurant yet.</Text>
       )}
     </ScrollView>
+  );
+}
+
+/**
+ * Legal remediation E1 — point-of-use allergen disclaimer.
+ *
+ * Persistent and non-dismissable: it sits at the top of every filtered
+ * menu so "safe to eat" is never read as a guarantee. Mirrors the web
+ * <AllergenNotice> and the ToS allergen disclaimer.
+ */
+function AllergenNotice() {
+  return (
+    <View style={styles.allergenNotice} accessibilityLabel="allergen-notice">
+      <Text style={styles.allergenText}>
+        <Text style={styles.allergenStrong}>A filter, not a guarantee. </Text>
+        BiteWorthy reads menus with AI and your dietary filter — but recipes change and a result
+        can still miss an allergen. Always confirm with the restaurant before ordering for a
+        serious allergy.
+      </Text>
+    </View>
   );
 }
 
@@ -574,6 +596,22 @@ const styles = StyleSheet.create({
     fontSize: fontSize.xs,
     color: colors.hide,
     fontWeight: '600',
+  },
+  allergenNotice: {
+    marginTop: space['2'],
+    padding: space['3'],
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.warn,
+    backgroundColor: 'rgba(245, 159, 0, 0.1)',
+  },
+  allergenText: {
+    fontSize: fontSize.sm,
+    color: colors.text,
+    lineHeight: 20,
+  },
+  allergenStrong: {
+    fontWeight: '700',
   },
   hiddenToggle: {
     paddingVertical: space['2'],

--- a/apps/mobile/lib/api/onboarding.ts
+++ b/apps/mobile/lib/api/onboarding.ts
@@ -80,6 +80,12 @@ export interface SaveProfilePayload {
   disliked_tag_ids?: string[];
   liked_ingredient_ids?: string[];
   disliked_ingredient_ids?: string[];
+  /**
+   * Legal remediation E1 — when true, the server stamps
+   * `disclaimer_acknowledged_at`. Onboarding sends it on the final
+   * save once the user accepts the allergen disclaimer.
+   */
+  acknowledge_disclaimer?: boolean;
 }
 
 export interface SaveTastePayload {

--- a/apps/web/src/app/onboarding/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/__tests__/page.test.tsx
@@ -118,3 +118,36 @@ describe('OnboardingPage — taste step in the full flow', () => {
     expect(screen.getByText('Ready?')).toBeInTheDocument();
   });
 });
+
+describe('OnboardingPage — allergen acknowledgment (legal E1)', () => {
+  beforeEach(() => mockGet.mockReturnValue(null));
+
+  const goToReview = async () => {
+    render(<OnboardingPage />);
+    fireEvent.click(await screen.findByTestId('next-to-ingredients'));
+    fireEvent.click(screen.getByTestId('next-to-strictness'));
+    fireEvent.click(screen.getByTestId('next-to-taste'));
+    fireEvent.click(screen.getByTestId('skip-taste'));
+  };
+
+  it('blocks the save until the disclaimer is acknowledged, then records it', async () => {
+    await goToReview();
+
+    // Save is disabled and saveProfile is never called while unchecked.
+    expect(screen.getByTestId('finish')).toBeDisabled();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('finish'));
+    });
+    expect(mockSaveProfile).not.toHaveBeenCalled();
+
+    // Check the box → save enables and sends acknowledge_disclaimer.
+    fireEvent.click(screen.getByTestId('acknowledge-disclaimer'));
+    expect(screen.getByTestId('finish')).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('finish'));
+    });
+    await waitFor(() => expect(mockSaveProfile).toHaveBeenCalledTimes(1));
+    expect(mockSaveProfile.mock.calls[0]![0]).toMatchObject({ acknowledge_disclaimer: true });
+  });
+});

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -139,7 +139,9 @@ function OnboardingFlow() {
       setSaving(true);
       setSaveError(null);
       const payload = toProfilePayload(draft, presets);
-      await saveProfile(payload);
+      // Legal remediation E1 — the review step gates this submit behind
+      // the allergen-disclaimer checkbox, so record the acknowledgment.
+      await saveProfile({ ...payload, acknowledge_disclaimer: true });
       tracker.track('profile_set', {
         preset_slug: draft.selectedPresetSlugs[0] ?? null,
         avoid_ingredient_count: payload.avoid_ingredient_ids.length,
@@ -682,6 +684,9 @@ function ReviewStep({
   error: string | null;
   onSubmit: (e: FormEvent) => void;
 }) {
+  // Legal remediation E1 — the user must accept the allergen disclaimer
+  // before the profile saves; the acceptance is recorded server-side.
+  const [acknowledged, setAcknowledged] = useState(false);
   return (
     <form onSubmit={onSubmit}>
       <StepHeader step={5} title="Ready?" body="Saving will replace any existing avoid lists on your profile." />
@@ -698,6 +703,20 @@ function ReviewStep({
         , strictness <span className="font-bold">{strictness}</span>.
       </p>
 
+      <label className="mt-bw-6 flex items-start gap-bw-3 rounded-bw-md border border-warn/40 bg-warn/10 p-bw-3 text-bw-sm text-zinc-800">
+        <input
+          type="checkbox"
+          checked={acknowledged}
+          onChange={(e) => setAcknowledged(e.target.checked)}
+          data-testid="acknowledge-disclaimer"
+          className="mt-bw-1 h-4 w-4 shrink-0"
+        />
+        <span>
+          I understand BiteWorthy is a planning tool, not a guarantee — results can miss an
+          allergen, and I’ll confirm with the restaurant before ordering for a serious allergy.
+        </span>
+      </label>
+
       {error && (
         <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
           {error}
@@ -706,11 +725,11 @@ function ReviewStep({
 
       <button
         type="submit"
-        disabled={saving}
+        disabled={saving || !acknowledged}
         data-testid="finish"
         className={[
           'mt-bw-6 w-full rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
-          saving ? 'opacity-60' : 'hover:bg-bite-dark',
+          saving || !acknowledged ? 'opacity-60' : 'hover:bg-bite-dark',
         ].join(' ')}
       >
         {saving ? 'Saving…' : 'Save profile'}

--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -195,6 +195,8 @@ export function RestaurantClient({
         </p>
       )}
 
+      <AllergenNotice />
+
       <TopPicksRow items={rawItems} restaurantSlug={slug} />
 
       {overriddenSections.length === 0 && (
@@ -214,6 +216,28 @@ export function RestaurantClient({
         />
       ))}
     </main>
+  );
+}
+
+/**
+ * Legal remediation E1 — the point-of-use allergen disclaimer.
+ *
+ * Persistent and non-dismissable: it sits at the top of every filtered
+ * menu so the "safe to eat" framing is never read as a guarantee. Names
+ * the false-negative case explicitly (a result can still miss an
+ * allergen), matching the ToS allergen disclaimer.
+ */
+export function AllergenNotice() {
+  return (
+    <div
+      role="note"
+      data-testid="allergen-notice"
+      className="mt-bw-4 rounded-bw-md border border-warn/40 bg-warn/10 p-bw-3 text-bw-sm text-zinc-800"
+    >
+      <strong>A filter, not a guarantee.</strong> BiteWorthy reads menus with AI and your
+      dietary filter — but recipes change and a result can still miss an allergen. Always
+      confirm with the restaurant before ordering for a serious allergy.
+    </div>
   );
 }
 

--- a/apps/web/src/app/restaurants/[slug]/__tests__/RestaurantClient.render.test.tsx
+++ b/apps/web/src/app/restaurants/[slug]/__tests__/RestaurantClient.render.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { HiddenReasonChip, StrictnessToggle } from '../RestaurantClient';
+import { AllergenNotice, HiddenReasonChip, StrictnessToggle } from '../RestaurantClient';
 
 /**
  * Phase post-5 — first JSX render tests for the web app.
@@ -52,6 +52,21 @@ describe('HiddenReasonChip', () => {
       />,
     );
     expect(screen.getByTestId('chip-unconfirmed_strict')).toHaveTextContent('inferred');
+  });
+});
+
+describe('AllergenNotice', () => {
+  // Legal remediation E1 — the point-of-use disclaimer must be present
+  // and non-dismissable on every filtered menu, and must name the
+  // false-negative case (a result can still miss an allergen).
+  it('renders the disclaimer with no dismiss control', () => {
+    render(<AllergenNotice />);
+    const notice = screen.getByTestId('allergen-notice');
+    expect(notice).toHaveTextContent(/not a guarantee/i);
+    expect(notice).toHaveTextContent(/miss an allergen/i);
+    expect(notice).toHaveTextContent(/confirm with the restaurant/i);
+    // Non-dismissable: no button inside the notice to close it.
+    expect(notice.querySelector('button')).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/onboarding.ts
+++ b/apps/web/src/lib/onboarding.ts
@@ -33,6 +33,12 @@ export interface SaveProfilePayload {
   disliked_tag_ids?: string[];
   liked_ingredient_ids?: string[];
   disliked_ingredient_ids?: string[];
+  /**
+   * Legal remediation E1 — when true, the server stamps
+   * `disclaimer_acknowledged_at`. Onboarding sends it on the final
+   * save once the user checks the allergen-disclaimer box.
+   */
+  acknowledge_disclaimer?: boolean;
 }
 
 export interface SaveTastePayload {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -267,7 +267,7 @@
         ],
         "responses": {
           "200": {
-            "description": "updated profile payload",
+            "description": "acknowledging the allergen disclaimer stamps a timestamp",
             "content": {
               "application/json": {
                 "schema": {
@@ -363,6 +363,10 @@
                   },
                   "dietary_profile_slug": {
                     "type": "string"
+                  },
+                  "acknowledge_disclaimer": {
+                    "type": "boolean",
+                    "description": "When true, server-stamps disclaimer_acknowledged_at (first acknowledgment only). Sent by onboarding."
                   }
                 }
               }
@@ -728,7 +732,8 @@
           "disliked_ingredient_ids",
           "disliked_tag_ids",
           "strictness",
-          "primary_dietary_profile"
+          "primary_dietary_profile",
+          "disclaimer_acknowledged_at"
         ],
         "properties": {
           "avoid_ingredient_ids": {
@@ -803,6 +808,11 @@
                 "type": "string"
               }
             }
+          },
+          "disclaimer_acknowledged_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         }
       }

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -265,11 +265,13 @@ export interface paths {
                         /** @enum {string} */
                         strictness?: "relaxed" | "balanced" | "strict";
                         dietary_profile_slug?: string;
+                        /** @description When true, server-stamps disclaimer_acknowledged_at (first acknowledgment only). Sent by onboarding. */
+                        acknowledge_disclaimer?: boolean;
                     };
                 };
             };
             responses: {
-                /** @description updated profile payload */
+                /** @description acknowledging the allergen disclaimer stamps a timestamp */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -454,6 +456,8 @@ export interface components {
                 slug?: string;
                 name?: string;
             } | null;
+            /** Format: date-time */
+            disclaimer_acknowledged_at: string | null;
         };
     };
     responses: never;


### PR DESCRIPTION
## What

**Legal remediation E1** — the top-exposure item from the legal memo (alignment-matrix row 1). Two deliverables:

### 1. Point-of-use allergen disclaimer
A persistent, **non-dismissable** `<AllergenNotice>` at the top of every filtered-menu view, on both web (`RestaurantClient.tsx`) and mobile (`restaurants/[id].tsx`). It names the false-negative case explicitly — *a result can still miss an allergen* — matching the ToS allergen disclaimer.

### 2. Onboarding acknowledgment
- The final onboarding step (web + mobile) now requires the user to accept the allergen disclaimer before the profile saves.
- Acceptance is recorded **server-side**: `PATCH /api/v1/profile` accepts `acknowledge_disclaimer: true` and stamps a new `user_profiles.disclaimer_acknowledged_at` (first acknowledgment only; the timestamp is server-set, never taken from the client).
- `ProfilePayload` now returns `disclaimer_acknowledged_at`. rswag spec + `docs/openapi.json` + `api-types` regenerated.

This lets the ToS truthfully say the disclaimer is "shown in the app" (the T5 reword follows once this + the Phase 1 copy PR are both merged).

## Verification
- API: `bundle exec rspec` → 472 examples, 0 failures (+1)
- Web: `pnpm --filter @biteworthy/web test` → 167 (+2)
- Mobile: `pnpm --filter @biteworthy/mobile test` → 123 (+1)
- `pnpm typecheck` + `pnpm lint` clean across the workspace
- api-types codegen regenerated (no drift)

## Notes
- Real Unicode glyphs throughout (no HTML entities).
- New migration `20260614120000` adds a nullable `disclaimer_acknowledged_at` to `user_profiles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)