### PR TITLE
feat(api): account deletion endpoint (E2)

### DIFF
--- a/apps/api/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/apps/api/app/controllers/api/v1/auth/registrations_controller.rb
@@ -6,6 +6,7 @@ module Api
         respond_to :json
 
         before_action :configure_permitted_parameters
+        before_action :authenticate_user!, only: [:destroy]
 
         # Override Devise's create to avoid the automatic sign_up flow
         # that writes to the session — sessions are disabled in API
@@ -22,6 +23,20 @@ module Api
             clean_up_passwords(resource)
             render json: { errors: resource.errors.as_json }, status: :unprocessable_entity
           end
+        end
+
+        # DELETE /api/v1/auth/signup — permanently deletes the caller's
+        # account. Legal remediation E2 (Privacy Policy "Delete your
+        # account"). Routes the delete through the ORM so the model's
+        # `dependent:` rules run — the FKs have no ON DELETE CASCADE, so
+        # a raw DB delete would either orphan rows or violate a
+        # constraint. Personal records are destroyed; shared menu-graph
+        # rows are nullified (see User associations). The JWT is
+        # invalidated implicitly — its `jti`/`sub` no longer match any
+        # user once the row is gone.
+        def destroy
+          current_user.destroy!
+          head :no_content
         end
 
         private

--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -19,6 +19,23 @@ class User < ApplicationRecord
   has_many :overridden_items, through: :user_item_overrides, source: :item
   has_many :restaurant_visits, dependent: :destroy
 
+  # Legal remediation E2 — back-references with no ON DELETE rule at the
+  # DB level. Account deletion would hit a foreign-key violation unless
+  # these are nullified in Ruby first. The rows are part of the shared,
+  # crowd-built menu graph (see docs/vision.md) — it shouldn't vanish
+  # when one contributor leaves — so we drop the attribution, not the
+  # row. The user's own personal records (reviews, profile, overrides,
+  # visits) are destroyed above.
+  has_many :ingestion_runs, inverse_of: :user, dependent: :nullify
+  has_many :created_items, class_name: "Item", foreign_key: :created_by_user_id,
+           inverse_of: :created_by_user, dependent: :nullify
+  has_many :created_restaurants, class_name: "Restaurant", foreign_key: :created_by_user_id,
+           inverse_of: :created_by_user, dependent: :nullify
+  has_many :claimed_restaurants, class_name: "Restaurant", foreign_key: :claimed_by_user_id,
+           inverse_of: :claimed_by_user, dependent: :nullify
+  has_many :resolved_suggestions, class_name: "Suggestion", foreign_key: :resolved_by_user_id,
+           inverse_of: :resolved_by_user, dependent: :nullify
+
   validates :handle, presence: true, uniqueness: true,
                      format: { with: /\A[a-z0-9_]{3,30}\z/i }
 

--- a/apps/api/spec/integration/api/v1/auth/signup_spec.rb
+++ b/apps/api/spec/integration/api/v1/auth/signup_spec.rb
@@ -44,5 +44,42 @@ RSpec.describe "auth/signup", type: :request do
         run_test!
       end
     end
+
+    delete("Delete the caller's account (legal remediation E2)") do
+      tags "Auth"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true,
+                description: "Bearer <jwt>"
+
+      response(204, "account deleted — personal data removed, menu-graph attribution nulled") do
+        let(:account) { create(:user, password: "password123") }
+        let(:Authorization) do
+          token, _ = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+          "Bearer #{token}"
+        end
+
+        # Personal record that must be destroyed with the account.
+        let!(:review) { create(:review, user: account) }
+        # Shared menu-graph rows that must survive, with attribution nulled.
+        let!(:created_restaurant) { create(:restaurant, created_by_user: account) }
+        let!(:ingestion_run)      { create(:ingestion_run, user: account) }
+
+        run_test! do
+          expect(User.exists?(account.id)).to be(false)
+          expect(UserProfile.exists?(user_id: account.id)).to be(false)
+          # Personal review is gone.
+          expect(Review.exists?(review.id)).to be(false)
+          # Shared graph survives; the user attribution is nulled, not deleted.
+          expect(created_restaurant.reload.created_by_user_id).to be_nil
+          expect(ingestion_run.reload.user_id).to be_nil
+        end
+      end
+
+      response(401, "missing or invalid bearer token") do
+        let(:Authorization) { "" }
+        run_test!
+      end
+    end
   end
 end

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -314,6 +314,36 @@
           },
           "required": true
         }
+      },
+      "delete": {
+        "summary": "Delete the caller's account (legal remediation E2)",
+        "tags": [
+          "Auth"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "description": "Bearer <jwt>",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "account deleted — personal data removed, menu-graph attribution nulled"
+          },
+          "401": {
+            "description": "missing or invalid bearer token"
+          }
+        }
       }
     },
     "/api/v1/profile": {

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -255,7 +255,35 @@ export interface paths {
                 };
             };
         };
-        delete?: never;
+        /** Delete the caller's account (legal remediation E2) */
+        delete: {
+            parameters: {
+                query?: never;
+                header: {
+                    /** @description Bearer <jwt> */
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description account deleted — personal data removed, menu-graph attribution nulled */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description missing or invalid bearer token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;


### PR DESCRIPTION
## What

**Legal remediation E2** — makes the Privacy Policy *"Delete your account"* promise real (alignment-matrix row 3).

`DELETE /api/v1/auth/signup` permanently deletes the caller's account, **routed through the ORM** so the model `dependent:` rules run. The user-referencing FKs have no `ON DELETE CASCADE`, so a raw DB delete would orphan rows or violate a constraint.

- **Personal records destroyed**: profile, reviews, item overrides, restaurant visits.
- **Shared menu-graph rows nullified, not deleted** — the crowd-built graph (`docs/vision.md`) shouldn't vanish when one contributor leaves. Added `dependent: :nullify` back-references on `User` for the five orphan FKs the schema audit surfaced:
  - `ingestion_runs.user_id`
  - `items.created_by_user_id`
  - `restaurants.created_by_user_id`
  - `restaurants.claimed_by_user_id`
  - `suggestions.resolved_by_user_id`

  The last two weren't in the plan's list — caught while reading the actual schema FKs.
- The JWT is invalidated implicitly: its `jti`/`sub` no longer match any user once the row is gone.

## Verification
- rswag spec asserts **204** (with destroy/nullify split), **401** unauthorized.
- `bundle exec rspec` → 473 examples, 0 failures.
- `docs/openapi.json` + `api-types` regenerated; `pnpm typecheck` clean.

## Follow-ups (separate PRs, per plan)
- **E3** data export, **E5** visit-history retention purge.
- The interim manual deletion process (`privacy@`) can retire once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)