### PR TITLE
feat(api): personal-data export endpoint (E3)

### DIFF
--- a/apps/api/app/controllers/api/v1/account_exports_controller.rb
+++ b/apps/api/app/controllers/api/v1/account_exports_controller.rb
@@ -1,0 +1,88 @@
+module Api
+  module V1
+    # GET /api/v1/account/export — legal remediation E3.
+    #
+    # Returns the caller's personal data as a single JSON archive,
+    # backing the Privacy Policy "Access / export your data" right.
+    # Authenticated only — a user can export only their own data.
+    #
+    # Scope: the personal records tied to the account (profile, reviews,
+    # suggestions, visit history). It intentionally does NOT dump the
+    # shared menu graph (restaurants, items, taxonomy) — that's public
+    # data, not the user's personal data.
+    class AccountExportsController < BaseController
+      def show
+        user = current_user
+        render json: {
+          exported_at:       Time.current.iso8601,
+          account:           account_section(user),
+          profile:           profile_section(user.profile),
+          reviews:           user.reviews.order(:created_at).map { |r| review_section(r) },
+          suggestions:       user.suggestions.order(:created_at).map { |s| suggestion_section(s) },
+          restaurant_visits: user.restaurant_visits.newest_first.map { |v| visit_section(v) }
+        }
+      end
+
+      private
+
+      def account_section(user)
+        {
+          id:           user.id,
+          email:        user.email,
+          handle:       user.handle,
+          display_name: user.display_name,
+          provider:     user.provider,
+          created_at:   user.created_at.iso8601
+        }
+      end
+
+      def profile_section(profile)
+        return nil if profile.nil?
+        {
+          avoid_ingredient_ids:    profile.avoid_ingredient_ids,
+          avoid_tag_ids:           profile.avoid_tag_ids,
+          prefer_tag_ids:          profile.prefer_tag_ids,
+          liked_ingredient_ids:    profile.liked_ingredient_ids,
+          liked_tag_ids:           profile.liked_tag_ids,
+          disliked_ingredient_ids: profile.disliked_ingredient_ids,
+          disliked_tag_ids:        profile.disliked_tag_ids,
+          strictness:              profile.strictness,
+          primary_dietary_profile_slug: profile.primary_dietary_profile&.slug
+        }
+      end
+
+      def review_section(review)
+        {
+          id:         review.id,
+          item_id:    review.item_id,
+          rating:     review.rating,
+          body:       review.body,
+          hidden:     review.hidden?,
+          created_at: review.created_at.iso8601
+        }
+      end
+
+      def suggestion_section(suggestion)
+        {
+          id:           suggestion.id,
+          kind:         suggestion.kind,
+          subject_type: suggestion.subject_type,
+          subject_id:   suggestion.subject_id,
+          payload:      suggestion.payload,
+          status:       suggestion.status,
+          created_at:   suggestion.created_at.iso8601
+        }
+      end
+
+      def visit_section(visit)
+        {
+          id:                  visit.id,
+          restaurant_id:       visit.restaurant_id,
+          viewed_on:           visit.viewed_on,
+          items_visible_count: visit.items_visible_count,
+          items_hidden_count:  visit.items_hidden_count
+        }
+      end
+    end
+  end
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -55,6 +55,9 @@ Rails.application.routes.draw do
         # visits with the visible/hidden item counts at view time).
         get :history, to: "profile_history#index"
       end
+      # Legal remediation E3 — JSON archive of the caller's personal
+      # data (Privacy Policy "Access / export your data").
+      get "/account/export", to: "account_exports#show"
       resources :cities, only: [:index, :show]
       # Phase 5.6 — backs the SSR /durango/[diet] SEO pages. Flat
       # route (not nested) so the `:city_slug` param name is explicit;

--- a/apps/api/spec/integration/api/v1/account_export_spec.rb
+++ b/apps/api/spec/integration/api/v1/account_export_spec.rb
@@ -1,0 +1,67 @@
+require "swagger_helper"
+
+RSpec.describe "account/export", type: :request do
+  path "/api/v1/account/export" do
+    get("Export the caller's personal data as a JSON archive (legal E3)") do
+      tags "Account"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true,
+                description: "Bearer <jwt>"
+
+      response(200, "the personal-data archive") do
+        schema type: :object,
+               required: %w[exported_at account profile reviews suggestions restaurant_visits],
+               properties: {
+                 exported_at: { type: :string, format: "date-time" },
+                 account: {
+                   type: :object,
+                   required: %w[id email handle display_name provider created_at],
+                   properties: {
+                     id:           { type: :string, format: :uuid },
+                     email:        { type: :string },
+                     handle:       { type: :string },
+                     display_name: { type: :string, nullable: true },
+                     provider:     { type: :string, nullable: true },
+                     created_at:   { type: :string, format: "date-time" }
+                   }
+                 },
+                 profile: { type: :object, nullable: true },
+                 reviews: { type: :array, items: { type: :object } },
+                 suggestions: { type: :array, items: { type: :object } },
+                 restaurant_visits: { type: :array, items: { type: :object } }
+               }
+
+        let(:account) { create(:user, password: "password123") }
+        let(:Authorization) do
+          token, _ = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+          "Bearer #{token}"
+        end
+
+        let!(:review)     { create(:review, user: account, body: "Loved it") }
+        let!(:suggestion) { create(:item_suggestion_pending, user: account) }
+        let!(:visit)      { create(:restaurant_visit, user: account) }
+        # A record belonging to someone else must never leak into the export.
+        let!(:other_review) { create(:review, body: "Not mine") }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json["account"]["id"]).to eq(account.id)
+          expect(json["account"]["email"]).to eq(account.email)
+          expect(json["reviews"].map { |r| r["id"] }).to contain_exactly(review.id)
+          expect(json["reviews"].first["body"]).to eq("Loved it")
+          expect(json["suggestions"].map { |s| s["id"] }).to contain_exactly(suggestion.id)
+          expect(json["restaurant_visits"].map { |v| v["id"] }).to contain_exactly(visit.id)
+          expect(json["profile"]).to include("strictness", "avoid_ingredient_ids")
+          # No password hash, no JWT secret — only the user's own data.
+          expect(response.body).not_to include("encrypted_password")
+        end
+      end
+
+      response(401, "missing or invalid bearer token") do
+        let(:Authorization) { "" }
+        run_test!
+      end
+    end
+  end
+end

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6,6 +6,116 @@
     "description": "JSON API for the BiteWorthy v2 product. Generated from rswag specs."
   },
   "paths": {
+    "/api/v1/account/export": {
+      "get": {
+        "summary": "Export the caller's personal data as a JSON archive (legal E3)",
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "description": "Bearer <jwt>",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the personal-data archive",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "exported_at",
+                    "account",
+                    "profile",
+                    "reviews",
+                    "suggestions",
+                    "restaurant_visits"
+                  ],
+                  "properties": {
+                    "exported_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "account": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "email",
+                        "handle",
+                        "display_name",
+                        "provider",
+                        "created_at"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "handle": {
+                          "type": "string"
+                        },
+                        "display_name": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "provider": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    },
+                    "profile": {
+                      "type": "object",
+                      "nullable": true
+                    },
+                    "reviews": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "suggestions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "restaurant_visits": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid bearer token"
+          }
+        }
+      }
+    },
     "/api/v1/auth/login": {
       "post": {
         "summary": "Log in with email + password",

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -4,6 +4,69 @@
  */
 
 export interface paths {
+    "/api/v1/account/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Export the caller's personal data as a JSON archive (legal E3) */
+        get: {
+            parameters: {
+                query?: never;
+                header: {
+                    /** @description Bearer <jwt> */
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description the personal-data archive */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /** Format: date-time */
+                            exported_at: string;
+                            account: {
+                                /** Format: uuid */
+                                id: string;
+                                email: string;
+                                handle: string;
+                                display_name: string | null;
+                                provider: string | null;
+                                /** Format: date-time */
+                                created_at: string;
+                            };
+                            profile: Record<string, never> | null;
+                            reviews: Record<string, never>[];
+                            suggestions: Record<string, never>[];
+                            restaurant_visits: Record<string, never>[];
+                        };
+                    };
+                };
+                /** @description missing or invalid bearer token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/auth/login": {
         parameters: {
             query?: never;


### PR DESCRIPTION
## What

**Legal remediation E3** — makes the Privacy Policy *"Access / export your data"* right real (alignment-matrix row 2).

`GET /api/v1/account/export` returns the caller's personal data as a single JSON archive:
- account (id, email, handle, display name, provider, created_at)
- dietary profile (avoid/prefer/taste arrays, strictness, primary preset)
- reviews, suggestions, and restaurant-visit history

**Authenticated only** — a user can export only their own data. Scope is personal data; it deliberately does **not** dump the shared menu graph (restaurants, items, taxonomy), which is public.

## Verification
- rswag spec asserts **200** (archive shape + that another user's review never leaks in + no `encrypted_password`) and **401**.
- `bundle exec rspec` → 473 examples, 0 failures.
- `docs/openapi.json` + `api-types` regenerated; `pnpm typecheck` clean.

## Follow-up
- Once this + E2 ship, the interim manual export/deletion process (`privacy@`) can retire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)