### PR TITLE
feat(api): age gate (13+) at signup (E4)

### DIFF
--- a/apps/api/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/apps/api/app/controllers/api/v1/auth/registrations_controller.rb
@@ -13,7 +13,17 @@ module Api
         # devise-jwt's warden hook dispatches a token in the response
         # Authorization header.
         def create
+          # Legal remediation E4 — age gate. The client must affirm the
+          # 13+ minimum (COPPA; Privacy Policy + ToS). We record only the
+          # affirmation time, never a birth date.
+          unless ActiveModel::Type::Boolean.new.cast(params.dig(:user, :age_confirmation))
+            return render json: {
+              errors: { age_confirmation: ["You must confirm you are at least 13 years old."] }
+            }, status: :unprocessable_entity
+          end
+
           build_resource(sign_up_params)
+          resource.age_confirmed_at = Time.current
 
           if resource.save
             sign_in(resource_name, resource, store: false)

--- a/apps/api/db/migrate/20260614130000_add_age_confirmed_at_to_users.rb
+++ b/apps/api/db/migrate/20260614130000_add_age_confirmed_at_to_users.rb
@@ -1,0 +1,11 @@
+# Legal remediation E4 — records that the user affirmed they are at
+# least 13 at signup (COPPA; Privacy Policy + ToS state a 13+ minimum).
+# We store only the affirmation timestamp — not a birth date — keeping
+# the data minimal. Nullable: accounts created before the gate (and
+# OAuth accounts, which rely on the provider's own age policy) have no
+# stamp.
+class AddAgeConfirmedAtToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :age_confirmed_at, :datetime, null: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_14_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -377,6 +377,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_120000) do
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "age_confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "confirmation_token"
     t.datetime "confirmed_at"

--- a/apps/api/spec/integration/api/v1/auth/signup_spec.rb
+++ b/apps/api/spec/integration/api/v1/auth/signup_spec.rb
@@ -12,13 +12,16 @@ RSpec.describe "auth/signup", type: :request do
         properties: {
           user: {
             type: :object,
-            required: %w[email password password_confirmation handle],
+            required: %w[email password password_confirmation handle age_confirmation],
             properties: {
               email:                 { type: :string, format: :email },
               password:              { type: :string, minLength: 8 },
               password_confirmation: { type: :string, minLength: 8 },
               handle:                { type: :string, pattern: "^[a-z0-9_]{3,30}$" },
-              display_name:          { type: :string, nullable: true }
+              display_name:          { type: :string, nullable: true },
+              # Legal remediation E4 — must be true; the user affirms the
+              # 13+ minimum. The server stamps users.age_confirmed_at.
+              age_confirmation:      { type: :boolean }
             }
           }
         }
@@ -29,9 +32,11 @@ RSpec.describe "auth/signup", type: :request do
         let(:user) do
           { user: { email: "fresh@example.com", password: "password123",
                     password_confirmation: "password123", handle: "fresh_user",
-                    display_name: "Fresh User" } }
+                    display_name: "Fresh User", age_confirmation: true } }
         end
-        run_test!
+        run_test! do
+          expect(User.find_by(email: "fresh@example.com").age_confirmed_at).to be_present
+        end
       end
 
       response(422, "validation failed (e.g. duplicate email or invalid handle)") do
@@ -39,9 +44,21 @@ RSpec.describe "auth/signup", type: :request do
         let(:user) do
           create(:user, email: "taken@example.com")
           { user: { email: "taken@example.com", password: "password123",
-                    password_confirmation: "password123", handle: "taken_user" } }
+                    password_confirmation: "password123", handle: "taken_user",
+                    age_confirmation: true } }
         end
         run_test!
+      end
+
+      response(422, "age not confirmed — under-13 gate (legal E4)") do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:user) do
+          { user: { email: "minor@example.com", password: "password123",
+                    password_confirmation: "password123", handle: "young_user" } }
+        end
+        run_test! do
+          expect(User.find_by(email: "minor@example.com")).to be_nil
+        end
       end
     end
   end

--- a/apps/api/spec/requests/api/v1/auth/signup_spec.rb
+++ b/apps/api/spec/requests/api/v1/auth/signup_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe "POST /api/v1/auth/signup", type: :request do
         password: "password123",
         password_confirmation: "password123",
         handle: "new_user",
-        display_name: "New User"
+        display_name: "New User",
+        # Legal remediation E4 — the 13+ affirmation is required.
+        age_confirmation: true
       }
     }
   end
@@ -27,6 +29,19 @@ RSpec.describe "POST /api/v1/auth/signup", type: :request do
     user = User.find_by(email: "new@example.com")
     expect(user.profile).to be_present
     expect(user.profile.strictness).to eq("balanced")
+    # Legal remediation E4 — the affirmation is recorded server-side.
+    expect(user.age_confirmed_at).to be_present
+  end
+
+  it "rejects signup without the 13+ age confirmation (legal E4)" do
+    expect {
+      post "/api/v1/auth/signup",
+           params: valid_params.tap { |p| p[:user].delete(:age_confirmation) },
+           as: :json
+    }.not_to change(User, :count)
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body["errors"]).to have_key("age_confirmation")
   end
 
   it "rejects a duplicate email with 422" do

--- a/apps/mobile/__tests__/lib/auth.test.ts
+++ b/apps/mobile/__tests__/lib/auth.test.ts
@@ -106,10 +106,13 @@ describe('signup', () => {
       { user: { id: 'u2', email: 'b@c.com', handle: null, display_name: null } },
       { Authorization: 'Bearer fresh.token.here' },
     );
-    await signup('b@c.com', 'longerpw1', { fetchImpl });
+    await signup('b@c.com', 'longerpw1', true, { fetchImpl });
     const url = String(fetchImpl.mock.calls[0]![0]);
     expect(url).toContain('/api/v1/auth/signup');
     expect(await getJwt()).toBe('fresh.token.here');
+    // Legal remediation E4 — the affirmation rides in the body.
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string).user).toMatchObject({ age_confirmation: true });
   });
 });
 

--- a/apps/mobile/app/signup.tsx
+++ b/apps/mobile/app/signup.tsx
@@ -15,6 +15,7 @@ export default function SignupScreen() {
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const onSubmit = async () => {
@@ -26,9 +27,13 @@ export default function SignupScreen() {
       Alert.alert('Password too short', 'Use 8 or more characters.');
       return;
     }
+    if (!ageConfirmed) {
+      Alert.alert('Age confirmation required', 'You must confirm you are at least 13 years old.');
+      return;
+    }
     try {
       setSubmitting(true);
-      await signup(email, password);
+      await signup(email, password, ageConfirmed);
       router.replace(next);
     } catch (err) {
       const status = err instanceof AuthError ? err.status : 0;
@@ -66,10 +71,23 @@ export default function SignupScreen() {
       />
 
       <Pressable
+        accessibilityLabel="age-confirm"
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: ageConfirmed }}
+        onPress={() => setAgeConfirmed((v) => !v)}
+        style={styles.ageRow}
+      >
+        <View style={[styles.ageBox, ageConfirmed && styles.ageBoxChecked]}>
+          {ageConfirmed && <Text style={styles.ageCheck}>✓</Text>}
+        </View>
+        <Text style={styles.ageText}>I am at least 13 years old.</Text>
+      </Pressable>
+
+      <Pressable
         accessibilityLabel="signup-submit"
         onPress={onSubmit}
-        disabled={submitting}
-        style={[styles.primary, submitting && { opacity: 0.5 }]}
+        disabled={submitting || !ageConfirmed}
+        style={[styles.primary, (submitting || !ageConfirmed) && { opacity: 0.5 }]}
       >
         {submitting ? (
           <ActivityIndicator color={colors.bg} />
@@ -116,6 +134,35 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: space['3'],
     fontSize: fontSize.base,
+    color: colors.text,
+  },
+  ageRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space['2'],
+    marginTop: space['2'],
+  },
+  ageBox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ageBoxChecked: {
+    borderColor: colors.bite,
+    backgroundColor: colors.bite,
+  },
+  ageCheck: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.sm,
+  },
+  ageText: {
+    fontSize: fontSize.sm,
     color: colors.text,
   },
   primary: {

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -65,9 +65,13 @@ export async function login(
 export async function signup(
   email: string,
   password: string,
+  // Legal remediation E4 — the 13+ affirmation, sent as age_confirmation.
+  ageConfirmation: boolean,
   opts: AuthOptions = {},
 ): Promise<UserPayload> {
-  return await postCredentials('/api/v1/auth/signup', email, password, opts);
+  return await postCredentials('/api/v1/auth/signup', email, password, opts, {
+    age_confirmation: ageConfirmation,
+  });
 }
 
 export async function logout(opts: AuthOptions = {}): Promise<void> {
@@ -89,12 +93,15 @@ async function postCredentials(
   email: string,
   password: string,
   opts: AuthOptions,
+  // Extra user fields merged into the request (e.g. age_confirmation on
+  // signup). Login passes nothing.
+  extraUserFields: Record<string, unknown> = {},
 ): Promise<UserPayload> {
   const { fetchImpl = fetch } = opts;
   const res = await fetchImpl(`${API_BASE}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify({ user: { email, password } }),
+    body: JSON.stringify({ user: { email, password, ...extraUserFields } }),
   });
   if (!res.ok) {
     let detail: string | null = null;

--- a/apps/web/src/app/api/auth/[action]/route.ts
+++ b/apps/web/src/app/api/auth/[action]/route.ts
@@ -25,6 +25,8 @@ const ACTIONS = new Set(['login', 'signup', 'logout']);
 interface CredentialsBody {
   email?: string;
   password?: string;
+  // Legal remediation E4 — present on signup only; the 13+ affirmation.
+  age_confirmation?: boolean;
 }
 
 export async function POST(
@@ -50,10 +52,15 @@ async function handleLoginOrSignup(action: string, body: CredentialsBody) {
   }
 
   const path = action === 'login' ? '/api/v1/auth/login' : '/api/v1/auth/signup';
+  // Forward the 13+ affirmation on signup only (login ignores it).
+  const user =
+    action === 'signup'
+      ? { email: body.email, password: body.password, age_confirmation: body.age_confirmation }
+      : { email: body.email, password: body.password };
   const upstream = await fetch(`${API_BASE}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify({ user: { email: body.email, password: body.password } }),
+    body: JSON.stringify({ user }),
   });
 
   if (!upstream.ok) {

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -18,6 +18,7 @@ export default function SignupPage() {
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,9 +33,13 @@ export default function SignupPage() {
       setError('Password must be at least 8 characters.');
       return;
     }
+    if (!ageConfirmed) {
+      setError('You must confirm you are at least 13 years old.');
+      return;
+    }
     try {
       setSubmitting(true);
-      await signup(email, password);
+      await signup(email, password, ageConfirmed);
       // `next` is a runtime query value — typedRoutes can't prove it.
       router.replace(next as Route);
     } catch (err) {
@@ -80,6 +85,17 @@ export default function SignupPage() {
           <span className="text-bw-xs text-zinc-500">8+ characters.</span>
         </label>
 
+        <label className="flex items-start gap-bw-2 text-bw-sm text-zinc-700">
+          <input
+            type="checkbox"
+            checked={ageConfirmed}
+            onChange={(e) => setAgeConfirmed(e.target.checked)}
+            data-testid="age-confirm"
+            className="mt-bw-1 h-4 w-4 shrink-0"
+          />
+          <span>I am at least 13 years old.</span>
+        </label>
+
         {error && (
           <p className="rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
             {error}
@@ -88,11 +104,11 @@ export default function SignupPage() {
 
         <button
           type="submit"
-          disabled={submitting}
+          disabled={submitting || !ageConfirmed}
           data-testid="signup-submit"
           className={[
             'mt-bw-2 rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
-            submitting ? 'opacity-60' : 'hover:bg-bite-dark',
+            submitting || !ageConfirmed ? 'opacity-60' : 'hover:bg-bite-dark',
           ].join(' ')}
         >
           {submitting ? 'Creating…' : 'Create account'}

--- a/apps/web/src/lib/__tests__/auth.test.ts
+++ b/apps/web/src/lib/__tests__/auth.test.ts
@@ -41,13 +41,16 @@ describe('login', () => {
 describe('signup', () => {
   it('POSTs to /api/auth/signup', async () => {
     const fetchImpl = fakeFetch(200, { user: { id: 'u2', email: 'b@c.com', handle: null, display_name: null } });
-    await signup('b@c.com', 'longerpw1', { fetchImpl });
+    await signup('b@c.com', 'longerpw1', true, { fetchImpl });
     expect(String(fetchImpl.mock.calls[0]![0])).toBe('/api/auth/signup');
+    // Legal remediation E4 — the affirmation rides in the body.
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toMatchObject({ age_confirmation: true });
   });
 
   it('throws AuthError on duplicate email', async () => {
     const fetchImpl = fakeFetch(422, { error: 'taken' });
-    await expect(signup('b@c.com', 'longerpw1', { fetchImpl })).rejects.toBeInstanceOf(AuthError);
+    await expect(signup('b@c.com', 'longerpw1', true, { fetchImpl })).rejects.toBeInstanceOf(AuthError);
   });
 });
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -74,9 +74,16 @@ export function login(
 export function signup(
   email: string,
   password: string,
+  // Legal remediation E4 — the 13+ affirmation, forwarded to Rails as
+  // age_confirmation. The form gates submit on it being true.
+  ageConfirmation: boolean,
   opts: FetchOptions = {},
 ): Promise<AuthResponse> {
-  return authPost<AuthResponse>('/api/auth/signup', { email, password }, opts);
+  return authPost<AuthResponse>(
+    '/api/auth/signup',
+    { email, password, age_confirmation: ageConfirmation },
+    opts,
+  );
 }
 
 export async function logout(opts: FetchOptions = {}): Promise<void> {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -258,7 +258,7 @@
             }
           },
           "422": {
-            "description": "validation failed (e.g. duplicate email or invalid handle)",
+            "description": "age not confirmed — under-13 gate (legal E4)",
             "content": {
               "application/json": {
                 "schema": {
@@ -283,7 +283,8 @@
                       "email",
                       "password",
                       "password_confirmation",
-                      "handle"
+                      "handle",
+                      "age_confirmation"
                     ],
                     "properties": {
                       "email": {
@@ -305,6 +306,9 @@
                       "display_name": {
                         "type": "string",
                         "nullable": true
+                      },
+                      "age_confirmation": {
+                        "type": "boolean"
                       }
                     }
                   }

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -230,6 +230,7 @@ export interface paths {
                             password_confirmation: string;
                             handle: string;
                             display_name?: string | null;
+                            age_confirmation: boolean;
                         };
                     };
                 };
@@ -244,7 +245,7 @@ export interface paths {
                         "application/json": components["schemas"]["AuthResponse"];
                     };
                 };
-                /** @description validation failed (e.g. duplicate email or invalid handle) */
+                /** @description age not confirmed — under-13 gate (legal E4) */
                 422: {
                     headers: {
                         [name: string]: unknown;


### PR DESCRIPTION
## What

**Legal remediation E4** — makes the Privacy Policy + ToS **13+ minimum** enforceable at account creation (alignment-matrix row 11; COPPA).

- Email/password signup now requires an `age_confirmation: true` flag. The server gates account creation on it (**422** otherwise) and stamps a new `users.age_confirmed_at`. We store only the **affirmation timestamp, never a birth date** (data minimization).
- Web + mobile signup forms add a required *"I am at least 13 years old"* checkbox that gates submit and threads the flag through to Rails (web via the `/api/auth` proxy, mobile direct).

## Scope
Email/password signup. OAuth (Google/Apple) signups rely on the provider's own age policy — gating the redirect flow is out of scope for this PR.

## Verification
- rswag + request specs cover **201** (with stamp), **under-13 422**, and the existing validation paths.
- API `bundle exec rspec` → 473; web → 165; mobile → 122 — all green.
- `docs/openapi.json` + `api-types` regenerated; `pnpm typecheck` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)