### PR TITLE
feat(api): visit-history retention backstop job (E5)

### DIFF
--- a/apps/api/app/jobs/purge_orphaned_restaurant_visits_job.rb
+++ b/apps/api/app/jobs/purge_orphaned_restaurant_visits_job.rb
@@ -1,0 +1,25 @@
+# Legal remediation E5 — visit-history retention backstop.
+#
+# Account deletion (E2) destroys a user's restaurant_visits immediately
+# via dependent: :destroy, well inside the Privacy Policy's "removed
+# from active systems within 30 days" window. This recurring job is the
+# belt-and-suspenders that backs the "fully purged within 12 months"
+# guarantee: it deletes any visit row that has lost its owning user —
+# the kind of orphan a bulk SQL operation, a restore-from-backup, or a
+# future schema change could leave behind even though the foreign key
+# normally prevents it.
+#
+# There is intentionally NO rolling age cap while an account is open —
+# visit history is kept for the account's lifetime (founder decision).
+# This job only removes rows whose user is already gone.
+class PurgeOrphanedRestaurantVisitsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    purged = RestaurantVisit
+             .where("NOT EXISTS (SELECT 1 FROM users WHERE users.id = restaurant_visits.user_id)")
+             .delete_all
+    Rails.logger.info("[retention] purged #{purged} orphaned restaurant_visits") if purged.positive?
+    purged
+  end
+end

--- a/apps/api/config/recurring.yml
+++ b/apps/api/config/recurring.yml
@@ -1,0 +1,12 @@
+# Solid Queue recurring tasks. Loaded by `solid_queue:start` (the
+# worker the deploy boots; see config/deploy.yml). Dev/test don't run
+# the supervisor, so no schedule fires there.
+#
+# Legal remediation E5 — the visit-history retention backstop. Runs
+# daily so any orphaned visit row (owner already deleted) is gone well
+# inside the Privacy Policy's 12-month "fully purged" guarantee.
+production:
+  purge_orphaned_restaurant_visits:
+    class: PurgeOrphanedRestaurantVisitsJob
+    queue: default
+    schedule: "every day at 4am"

--- a/apps/api/spec/jobs/purge_orphaned_restaurant_visits_job_spec.rb
+++ b/apps/api/spec/jobs/purge_orphaned_restaurant_visits_job_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe PurgeOrphanedRestaurantVisitsJob, type: :job do
+  let(:user)       { create(:user) }
+  let(:restaurant) { create(:restaurant, :published) }
+
+  it "leaves visits whose owner still exists untouched" do
+    create(:restaurant_visit, user: user, restaurant: restaurant)
+
+    expect {
+      described_class.perform_now
+    }.not_to change(RestaurantVisit, :count)
+  end
+
+  it "purges a visit row whose owning user is gone" do
+    live_visit = create(:restaurant_visit, user: user, restaurant: restaurant)
+
+    # The users FK normally makes orphans impossible. The backstop exists
+    # for the case where referential integrity was bypassed (bulk SQL, a
+    # restore, a future schema change), so the test simulates exactly
+    # that: insert a visit pointing at a since-deleted user.
+    ghost_id = SecureRandom.uuid
+    orphan_id = SecureRandom.uuid
+    ActiveRecord::Base.connection.disable_referential_integrity do
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        INSERT INTO restaurant_visits
+          (id, user_id, restaurant_id, viewed_on, items_visible_count, items_hidden_count, created_at, updated_at)
+        VALUES
+          ('#{orphan_id}', '#{ghost_id}', '#{restaurant.id}', CURRENT_DATE, 3, 1, NOW(), NOW())
+      SQL
+    end
+
+    expect(RestaurantVisit.exists?(orphan_id)).to be(true)
+
+    purged = described_class.perform_now
+
+    expect(purged).to eq(1)
+    expect(RestaurantVisit.exists?(orphan_id)).to be(false)
+    expect(RestaurantVisit.exists?(live_visit.id)).to be(true)
+  end
+end


### PR DESCRIPTION
## What

**Legal remediation E5** — backs the Privacy Policy *"fully purged within 12 months"* guarantee for restaurant-visit history (alignment-matrix row 12).

- `PurgeOrphanedRestaurantVisitsJob` deletes any `restaurant_visits` row whose owning user no longer exists.
- Scheduled **daily** via `config/recurring.yml` (Solid Queue), loaded by the `solid_queue:start` worker the deploy boots.

### Why a backstop (and not a rolling cap)
- Account deletion (**E2**) already destroys a user's visits immediately via `dependent: :destroy` — well inside the 30-day "removed from active systems" window.
- This job is the belt-and-suspenders for orphans a bulk SQL op, restore-from-backup, or future schema change could leave behind (the FK normally prevents them).
- **No rolling age cap while an account is open** — visit history is kept for the account's lifetime (founder decision). The job only removes rows whose user is already gone.

## Verification
- Spec uses `disable_referential_integrity` to create the orphan the FK would otherwise block, then asserts the purge (and that a live visit survives).
- Verified the `"every day at 4am"` schedule parses to a valid Fugit cron (won't break worker boot).
- `bundle exec rspec` → 473 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)