### PR TITLE
feat(filter-engine): expire + log-redact shareable profile tokens (E6)

### DIFF
--- a/apps/api/app/services/profile_token.rb
+++ b/apps/api/app/services/profile_token.rb
@@ -6,29 +6,40 @@
 # implementation; this Ruby side must produce + accept byte-identical
 # tokens.
 #
-# Format: base64url(JSON.generate({ v:, ai:, at:, s: })). Short keys
-# keep URLs reasonable; `v` lets the schema evolve later.
+# Format: base64url(JSON.generate({ v:, ai:, at:, s:, exp: })). Short
+# keys keep URLs reasonable; `v` lets the schema evolve later.
+#
+# Legal remediation E6 — v2 adds `exp` (Unix-seconds expiry). A shared
+# link carries the sharer's avoid-lists + strictness (dietary data), so
+# it must not live forever; decode rejects an expired token. v1 tokens
+# (no expiry) are no longer accepted. See the TS module's header for why
+# the token is not cryptographically signed (it's minted client-side).
 
 class ProfileToken
-  VERSION = 1
+  VERSION = 2
   STRICTNESSES = %w[relaxed balanced strict].freeze
+  # Default lifetime of a shared link: 30 days.
+  TTL_SECONDS = 30 * 24 * 60 * 60
 
   Decoded = Struct.new(:avoid_ingredient_ids, :avoid_tag_ids, :strictness, keyword_init: true)
 
   class InvalidTokenError < StandardError; end
 
   class << self
-    def encode(avoid_ingredient_ids:, avoid_tag_ids:, strictness:)
+    # `expires_at` (Unix seconds) overrides the default TTL — used by the
+    # cross-language parity spec so the encoded bytes are deterministic.
+    def encode(avoid_ingredient_ids:, avoid_tag_ids:, strictness:, expires_at: nil)
       payload = {
-        v:  VERSION,
-        ai: Array(avoid_ingredient_ids),
-        at: Array(avoid_tag_ids),
-        s:  strictness
+        v:   VERSION,
+        ai:  Array(avoid_ingredient_ids),
+        at:  Array(avoid_tag_ids),
+        s:   strictness,
+        exp: expires_at || (Time.now.to_i + TTL_SECONDS)
       }
       Base64.urlsafe_encode64(JSON.generate(payload), padding: false)
     end
 
-    def decode(token)
+    def decode(token, now: Time.now.to_i)
       raise InvalidTokenError, "empty" if token.to_s.empty?
 
       json = begin
@@ -46,13 +57,16 @@ class ProfileToken
       raise InvalidTokenError, "not an object" unless payload.is_a?(Hash)
       raise InvalidTokenError, "unsupported version: #{payload['v']}" unless payload["v"] == VERSION
 
-      ai = payload["ai"]
-      at = payload["at"]
-      s  = payload["s"]
+      ai  = payload["ai"]
+      at  = payload["at"]
+      s   = payload["s"]
+      exp = payload["exp"]
 
       raise InvalidTokenError, "ai must be an array of strings" unless ai.is_a?(Array) && ai.all?(String)
       raise InvalidTokenError, "at must be an array of strings" unless at.is_a?(Array) && at.all?(String)
       raise InvalidTokenError, "s must be one of #{STRICTNESSES.join('|')}" unless STRICTNESSES.include?(s)
+      raise InvalidTokenError, "exp must be a number" unless exp.is_a?(Numeric)
+      raise InvalidTokenError, "expired" if exp <= now
 
       Decoded.new(avoid_ingredient_ids: ai, avoid_tag_ids: at, strictness: s)
     end

--- a/apps/api/config/initializers/filter_parameter_logging.rb
+++ b/apps/api/config/initializers/filter_parameter_logging.rb
@@ -1,0 +1,15 @@
+# Be sure to restart your server when you modify this file.
+
+# Configure parameters to be partially matched (e.g. passw matches password)
+# and filtered from the log file. Use this to limit dumping sensitive data
+# into the logs. If a value contains any of the listed substrings, the whole
+# value is filtered out.
+Rails.application.config.filter_parameters += %i[
+  passw secret token _key crypt salt certificate otp ssn
+]
+
+# Legal remediation E6 — the shareable profile token base64-encodes the
+# sharer's avoid-lists + strictness (dietary data). Keep its value out of
+# request logs. (`token` above already substring-matches `profile_token`,
+# but list it explicitly so the intent is unmistakable.)
+Rails.application.config.filter_parameters += %i[profile_token]

--- a/apps/api/spec/services/profile_token_spec.rb
+++ b/apps/api/spec/services/profile_token_spec.rb
@@ -38,17 +38,43 @@ RSpec.describe ProfileToken do
     # same payload here. These fixtures are the byte-for-byte output
     # of `encodeProfileToken({ avoid_ingredient_ids, avoid_tag_ids,
     # strictness })` for the two payloads below.
+    # Fixed exp (2100-01-01 UTC) so the bytes are deterministic across
+    # languages. Produced by encodeProfileToken(sample, { expiresAt:
+    # 4102444800 }) in the TS module.
+    FIXED_EXP = 4_102_444_800
+    TS_TOKEN  = "eyJ2IjoyLCJhaSI6WyJpbmctZGFpcnkiLCJpbmctZWdnIl0sImF0IjpbInRhZy1jb250YWlucy1kYWlyeSJdLCJzIjoiYmFsYW5jZWQiLCJleHAiOjQxMDI0NDQ4MDB9".freeze
+
     it "decodes a token produced by the TS encoder (sample payload)" do
-      ts_token = "eyJ2IjoxLCJhaSI6WyJpbmctZGFpcnkiLCJpbmctZWdnIl0sImF0IjpbInRhZy1jb250YWlucy1kYWlyeSJdLCJzIjoiYmFsYW5jZWQifQ"
-      decoded  = described_class.decode(ts_token)
+      decoded = described_class.decode(TS_TOKEN)
       expect(decoded.avoid_ingredient_ids).to eq(%w[ing-dairy ing-egg])
       expect(decoded.avoid_tag_ids).to        eq(%w[tag-contains-dairy])
       expect(decoded.strictness).to           eq("balanced")
     end
 
     it "encodes the same payload to the same string the TS encoder produces" do
-      ours = described_class.encode(**sample_payload)
-      expect(ours).to eq("eyJ2IjoxLCJhaSI6WyJpbmctZGFpcnkiLCJpbmctZWdnIl0sImF0IjpbInRhZy1jb250YWlucy1kYWlyeSJdLCJzIjoiYmFsYW5jZWQifQ")
+      ours = described_class.encode(**sample_payload, expires_at: FIXED_EXP)
+      expect(ours).to eq(TS_TOKEN)
+    end
+  end
+
+  describe "expiry (legal E6)" do
+    it "round-trips a token with a future expiry" do
+      token = described_class.encode(**sample_payload, expires_at: Time.now.to_i + 3600)
+      expect(described_class.decode(token).strictness).to eq("balanced")
+    end
+
+    it "rejects an expired token" do
+      token = described_class.encode(**sample_payload, expires_at: Time.now.to_i - 1)
+      expect { described_class.decode(token) }
+        .to raise_error(ProfileToken::InvalidTokenError, /expired/)
+    end
+
+    it "rejects a token whose exp is missing or non-numeric" do
+      bad = Base64.urlsafe_encode64(
+        JSON.generate(v: 2, ai: [], at: [], s: "balanced"), padding: false
+      )
+      expect { described_class.decode(bad) }
+        .to raise_error(ProfileToken::InvalidTokenError, /exp must be a number/)
     end
   end
 
@@ -69,13 +95,17 @@ RSpec.describe ProfileToken do
     end
 
     it "rejects invalid strictness values" do
-      bad = Base64.urlsafe_encode64(JSON.generate(v: 1, ai: [], at: [], s: "YOLO"), padding: false)
+      bad = Base64.urlsafe_encode64(
+        JSON.generate(v: 2, ai: [], at: [], s: "YOLO", exp: 4_102_444_800), padding: false
+      )
       expect { described_class.decode(bad) }
         .to raise_error(ProfileToken::InvalidTokenError, /s must be one of/)
     end
 
     it "rejects non-string ids" do
-      bad = Base64.urlsafe_encode64(JSON.generate(v: 1, ai: [42], at: [], s: "balanced"), padding: false)
+      bad = Base64.urlsafe_encode64(
+        JSON.generate(v: 2, ai: [42], at: [], s: "balanced", exp: 4_102_444_800), padding: false
+      )
       expect { described_class.decode(bad) }
         .to raise_error(ProfileToken::InvalidTokenError, /ai must be an array of strings/)
     end

--- a/packages/filter-engine/src/profile-token.test.ts
+++ b/packages/filter-engine/src/profile-token.test.ts
@@ -94,7 +94,9 @@ describe('decodeProfileToken — error cases', () => {
   });
 
   it('rejects invalid strictness values', () => {
-    const badToken = Buffer.from(JSON.stringify({ v: 1, ai: [], at: [], s: 'YOLO' }))
+    const badToken = Buffer.from(
+      JSON.stringify({ v: 2, ai: [], at: [], s: 'YOLO', exp: 4102444800 }),
+    )
       .toString('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
@@ -103,12 +105,45 @@ describe('decodeProfileToken — error cases', () => {
   });
 
   it('rejects non-string ids', () => {
-    const badToken = Buffer.from(JSON.stringify({ v: 1, ai: [42], at: [], s: 'balanced' }))
+    const badToken = Buffer.from(
+      JSON.stringify({ v: 2, ai: [42], at: [], s: 'balanced', exp: 4102444800 }),
+    )
       .toString('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=+$/, '');
     expect(() => decodeProfileToken(badToken)).toThrow(/ai must be string\[\]/);
+  });
+});
+
+describe('profile token expiry (legal E6)', () => {
+  it('round-trips a token with a future expiry', () => {
+    const token = encodeProfileToken(sample, { expiresAt: 4102444800 });
+    expect(decodeProfileToken(token)).toEqual(sample);
+  });
+
+  it('sets a ~30-day default expiry when none is given', () => {
+    const now = 1_000_000;
+    const token = encodeProfileToken(sample, { nowSeconds: now });
+    // Decoding "just before" the default TTL succeeds; "just after" fails.
+    expect(decodeProfileToken(token, { nowSeconds: now + 1 })).toEqual(sample);
+    expect(() => decodeProfileToken(token, { nowSeconds: now + 31 * 24 * 60 * 60 })).toThrow(
+      /expired/,
+    );
+  });
+
+  it('rejects an expired token', () => {
+    const token = encodeProfileToken(sample, { expiresAt: 500 });
+    expect(() => decodeProfileToken(token, { nowSeconds: 1000 })).toThrow(/expired/);
+  });
+
+  it('rejects a token whose exp is missing', () => {
+    const noExp = Buffer.from(JSON.stringify({ v: 2, ai: [], at: [], s: 'balanced' }))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    expect(() => decodeProfileToken(noExp)).toThrow(/exp must be a number/);
   });
 });
 

--- a/packages/filter-engine/src/profile-token.ts
+++ b/packages/filter-engine/src/profile-token.ts
@@ -8,20 +8,44 @@
  * format. The Ruby side has its own implementation (mirrored byte-
  * for-byte by the spec) so this module is the canonical contract.
  *
- * Token shape: base64url of JSON `{ v: 1, ai, at, s }`. Short keys
+ * Token shape: base64url of JSON `{ v: 2, ai, at, s, exp }`. Short keys
  * keep URLs reasonable; the `v` lets us evolve the schema later
  * without breaking old links.
+ *
+ * Legal remediation E6 — v2 adds `exp` (a Unix-seconds expiry). A
+ * shared link carries the sharer's avoid-lists + strictness (dietary
+ * data), so it must not live forever; decoders reject an expired token.
+ * v1 tokens (no expiry) are intentionally no longer accepted.
+ *
+ * Note on signing: these tokens are minted client-side (the Share
+ * button), so an HMAC secret would have to ship in the browser bundle
+ * and could be forged — signing here would be theater. The token grants
+ * no privilege (it only carries the sharer's own filter), so tamper-
+ * resistance has no security value; strict structural validation +
+ * expiry are the real protections. True signing would require minting
+ * the token server-side, a larger change deferred for now.
  */
 
 import type { FilterProfile, Strictness } from './index';
 
-export const PROFILE_TOKEN_VERSION = 1;
+export const PROFILE_TOKEN_VERSION = 2;
+
+/** Default lifetime of a shared link: 30 days (in seconds). */
+export const PROFILE_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 interface TokenPayload {
   v: number;
   ai: string[];
   at: string[];
   s: Strictness;
+  exp: number;
+}
+
+export interface EncodeProfileTokenOptions {
+  /** Absolute expiry, Unix seconds. Overrides the default TTL (tests/parity). */
+  expiresAt?: number;
+  /** "Now" in Unix seconds. Defaults to the real clock (tests). */
+  nowSeconds?: number;
 }
 
 export interface ShareableProfile {
@@ -39,17 +63,26 @@ export class InvalidProfileTokenError extends Error {
 
 const STRICTNESSES: ReadonlyArray<Strictness> = ['relaxed', 'balanced', 'strict'];
 
-export function encodeProfileToken(profile: ShareableProfile): string {
+export function encodeProfileToken(
+  profile: ShareableProfile,
+  opts: EncodeProfileTokenOptions = {},
+): string {
+  const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const exp = opts.expiresAt ?? now + PROFILE_TOKEN_TTL_SECONDS;
   const payload: TokenPayload = {
     v: PROFILE_TOKEN_VERSION,
     ai: profile.avoid_ingredient_ids,
     at: profile.avoid_tag_ids,
     s: profile.strictness,
+    exp,
   };
   return base64UrlEncode(JSON.stringify(payload));
 }
 
-export function decodeProfileToken(token: string): ShareableProfile {
+export function decodeProfileToken(
+  token: string,
+  opts: { nowSeconds?: number } = {},
+): ShareableProfile {
   if (typeof token !== 'string' || token.length === 0) {
     throw new InvalidProfileTokenError('empty');
   }
@@ -83,6 +116,14 @@ export function decodeProfileToken(token: string): ShareableProfile {
   }
   if (typeof s !== 'string' || !STRICTNESSES.includes(s as Strictness)) {
     throw new InvalidProfileTokenError(`s must be one of ${STRICTNESSES.join('|')}`);
+  }
+  const exp = obj.exp;
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+    throw new InvalidProfileTokenError('exp must be a number');
+  }
+  const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
+  if (exp <= now) {
+    throw new InvalidProfileTokenError('expired');
   }
   return {
     avoid_ingredient_ids: ai,


### PR DESCRIPTION
## What

**Legal remediation E6** — hardens the `?p=` share token, which carries the sharer's avoid-lists + strictness (dietary data) (alignment-matrix row 13).

- **Expiry**: token bumped to **v2** with a required `exp` (Unix seconds). `encodeProfileToken` / `ProfileToken.encode` default to a **30-day TTL**; both decoders reject an expired (or exp-less) token. v1 tokens are no longer accepted — pre-launch, and expiring old links is the goal. The TS module and Ruby service stay **byte-for-byte in parity** (deterministic via an injectable expiry; parity spec updated).
- **Log redaction**: a `filter_parameter_logging` initializer keeps `profile_token` out of Rails request logs, so the dietary-bearing token value never lands in access logs.

## On signing (deliberately omitted — surfacing the conflict)
The plan said "sign it," but the token is **minted client-side** (the Share button), so any HMAC secret would ship in the browser bundle and be forgeable — signing would be theater. The token grants **no privilege** (only the sharer's own filter), so tamper-resistance has no security value. Strict structural validation + expiry are the real protections. True signing would require **server-side minting** — a larger change I've noted as a follow-up rather than fake-implementing here.

## Verification
- filter-engine → 182 tests; Ruby `profile_token_spec` + `items_spec` green.
- Parity preserved (TS-produced fixture decodes/encodes identically in Ruby).
- `bundle exec rspec` → 474; `pnpm typecheck` + `pnpm lint` + `pnpm test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)