### PR TITLE
feat(analytics): opt-in controls + strip dietary fields from events (E7)

### DIFF
--- a/apps/mobile/__tests__/lib/analytics-prefs.test.ts
+++ b/apps/mobile/__tests__/lib/analytics-prefs.test.ts
@@ -1,0 +1,54 @@
+// In-memory expo-secure-store, same pattern as the auth test, so the
+// prefs wrapper exercises real persistence semantics.
+jest.mock('expo-secure-store', () => {
+  const store = new Map<string, string>();
+  return {
+    __memstore: store,
+    getItemAsync: jest.fn(async (key: string) => store.get(key) ?? null),
+    setItemAsync: jest.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    deleteItemAsync: jest.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+});
+
+import { getAnalyticsOptIn, setAnalyticsOptIn, OPT_IN_KEY } from '../../lib/analytics-prefs';
+
+const SecureStore = jest.requireMock('expo-secure-store') as {
+  __memstore: Map<string, string>;
+  getItemAsync: jest.Mock;
+};
+
+beforeEach(() => {
+  SecureStore.__memstore.clear();
+});
+
+/**
+ * Legal remediation E7b — mobile analytics are off by default; the
+ * stored opt-in is the source of truth the root layout reads at boot.
+ */
+describe('analytics-prefs', () => {
+  it('defaults to opted-out when nothing is stored', async () => {
+    expect(await getAnalyticsOptIn()).toBe(false);
+  });
+
+  it('persists an opt-in and reads it back', async () => {
+    await setAnalyticsOptIn(true);
+    expect(SecureStore.__memstore.get(OPT_IN_KEY)).toBe('1');
+    expect(await getAnalyticsOptIn()).toBe(true);
+  });
+
+  it('clears the opt-in when turned back off', async () => {
+    await setAnalyticsOptIn(true);
+    await setAnalyticsOptIn(false);
+    expect(SecureStore.__memstore.has(OPT_IN_KEY)).toBe(false);
+    expect(await getAnalyticsOptIn()).toBe(false);
+  });
+
+  it('returns false (default-off) when SecureStore throws', async () => {
+    SecureStore.getItemAsync.mockRejectedValueOnce(new Error('no keychain'));
+    expect(await getAnalyticsOptIn()).toBe(false);
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import PostHog from 'posthog-react-native';
@@ -6,6 +6,7 @@ import { noopTracker, type Tracker } from '@biteworthy/analytics';
 import { buildMobileTracker } from '../lib/track';
 import { createPostHogClient, registerExtension } from '../lib/posthog-client';
 import { TrackerContext } from '../lib/tracker-context';
+import { getAnalyticsOptIn } from '../lib/analytics-prefs';
 
 /**
  * Phase 5.8-wiring — root layout with PostHog provider.
@@ -15,56 +16,49 @@ import { TrackerContext } from '../lib/tracker-context';
  * launch funnel has a known first event. The tracker is exposed to
  * descendants via `TrackerContext` (mirrors the web pattern).
  *
- * Mobile is opt-in by default: the tracker stays `noopTracker` until
- * the user accepts in /settings/analytics. The opt-in flag lives in
- * `expo-secure-store` (added in a follow-up; v1 of this PR keeps it
- * always-noop pending that wiring).
+ * Legal remediation E7b — mobile is opt-in by default: the tracker
+ * stays `noopTracker` until the user enables analytics in
+ * Settings → Analytics. That choice is persisted in expo-secure-store
+ * and read here at boot. `EXPO_PUBLIC_POSTHOG_OPT_IN=1` still forces it
+ * on for local smoke testing.
  */
 export default function RootLayout() {
-  const trackerRef = useRef<Tracker | null>(null);
-  const appOpenFired = useRef(false);
-
-  if (trackerRef.current === null) {
-    const apiKey = process.env.EXPO_PUBLIC_POSTHOG_KEY;
-    // Phase 5.8-wiring v1: opt-in toggle wiring lands in a follow-up.
-    // Treat all real users as opted-out until then; this keeps the
-    // App Store privacy posture honest. Set EXPO_PUBLIC_POSTHOG_OPT_IN=1
-    // for local smoke testing.
-    const optedIn = process.env.EXPO_PUBLIC_POSTHOG_OPT_IN === '1';
-    if (apiKey && optedIn) {
-      const client = new PostHog(apiKey, {
-        host: 'https://us.i.posthog.com',
-      });
-      registerExtension(client);
-      trackerRef.current = buildMobileTracker({
-        apiKey,
-        optedIn: true,
-        client: createPostHogClient(client),
-      });
-    } else {
-      trackerRef.current = noopTracker;
-    }
-  }
-
-  const tracker = trackerRef.current;
+  const [tracker, setTracker] = useState<Tracker>(noopTracker);
+  const startedRef = useRef(false);
 
   useEffect(() => {
-    if (appOpenFired.current) return;
-    appOpenFired.current = true;
-    // Surface defaults to 'ios' on iOS, 'android' on Android. We
-    // don't import Platform here just to avoid the native-bridge
-    // boot for tests; the runtime require is fine because this
-    // file is already a screen.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { Platform } = require('react-native');
-    const surface = Platform.OS === 'android' ? 'android' : 'ios';
-    tracker.track('app_open', { surface });
-  }, [tracker]);
+    if (startedRef.current) return;
+    startedRef.current = true;
 
-  const value = useMemo(() => tracker, [tracker]);
+    let cancelled = false;
+    (async () => {
+      const apiKey = process.env.EXPO_PUBLIC_POSTHOG_KEY;
+      const optedIn = (await getAnalyticsOptIn()) || process.env.EXPO_PUBLIC_POSTHOG_OPT_IN === '1';
+
+      let next: Tracker = noopTracker;
+      if (apiKey && optedIn) {
+        const client = new PostHog(apiKey, { host: 'https://us.i.posthog.com' });
+        registerExtension(client);
+        next = buildMobileTracker({ apiKey, optedIn: true, client: createPostHogClient(client) });
+      }
+      if (cancelled) return;
+      setTracker(next);
+
+      // Fire app_open once, on whichever tracker we resolved (a no-op
+      // when opted out). The native-bridge require is fine — this is a
+      // screen — and avoids booting it for tests.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { Platform } = require('react-native');
+      next.track('app_open', { surface: Platform.OS === 'android' ? 'android' : 'ios' });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
-    <TrackerContext.Provider value={value}>
+    <TrackerContext.Provider value={tracker}>
       <StatusBar style="auto" />
       <Stack
         screenOptions={{

--- a/apps/mobile/app/onboarding/index.tsx
+++ b/apps/mobile/app/onboarding/index.tsx
@@ -144,11 +144,10 @@ export default function OnboardingScreen() {
       // Legal remediation E1 — the done step gates this save behind the
       // allergen-disclaimer toggle, so record the acknowledgment.
       await saveProfile({ ...payload, acknowledge_disclaimer: true }, jwt);
+      // Legal remediation E7 — funnel conversion only; the dietary
+      // profile (preset/strictness/avoid sizes) is health data and is
+      // never attached to this identified event.
       tracker.track('profile_set', {
-        preset_slug: draft.selectedPresetSlugs[0] ?? null,
-        avoid_ingredient_count: payload.avoid_ingredient_ids.length,
-        avoid_tag_count: payload.avoid_tag_ids.length,
-        strictness: payload.strictness,
         taste_signal_count: tasteSignalCount,
       });
       Alert.alert('Profile saved', 'Your dietary filter is ready.');

--- a/apps/mobile/app/settings/analytics.tsx
+++ b/apps/mobile/app/settings/analytics.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, Switch, Text, View } from 'react-native';
+import { colors, fontSize, space } from '@biteworthy/ui-tokens';
+import { getAnalyticsOptIn, setAnalyticsOptIn } from '../../lib/analytics-prefs';
+
+/**
+ * Legal remediation E7b — the Settings → Analytics screen the Privacy
+ * Policy promises ("On mobile, analytics are off by default and only
+ * fire if you enable them in Settings → Analytics").
+ *
+ * The toggle persists the opt-in to expo-secure-store; the root layout
+ * reads it at boot to decide whether to construct a real tracker, so
+ * the change takes effect on the next app launch. Analytics never carry
+ * the dietary profile (see packages/analytics).
+ */
+export default function AnalyticsSettingsScreen() {
+  const [optedIn, setOptedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAnalyticsOptIn().then((v) => {
+      if (!cancelled) setOptedIn(v);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onToggle = (next: boolean) => {
+    setOptedIn(next);
+    void setAnalyticsOptIn(next);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.headline}>Analytics</Text>
+      <Text style={styles.body}>
+        Analytics are off by default. Turn them on to share anonymous product usage that helps us
+        improve BiteWorthy. We never send your dietary profile — what you avoid, your presets, or
+        your strictness.
+      </Text>
+
+      <View style={styles.row}>
+        <Text style={styles.rowLabel}>Allow anonymous analytics</Text>
+        <Switch
+          accessibilityLabel="analytics-opt-in"
+          disabled={optedIn === null}
+          value={optedIn === true}
+          onValueChange={onToggle}
+          trackColor={{ true: colors.bite, false: colors.border }}
+        />
+      </View>
+
+      <Text style={styles.note} accessibilityLabel="analytics-state">
+        {optedIn === null
+          ? 'Loading…'
+          : optedIn
+            ? 'On. Takes effect the next time you open the app.'
+            : 'Off. No analytics are sent.'}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 80,
+    paddingHorizontal: space['6'],
+    backgroundColor: colors.bg,
+    gap: space['3'],
+  },
+  headline: {
+    fontSize: fontSize['2xl'],
+    fontWeight: '700',
+    color: colors.text,
+  },
+  body: {
+    fontSize: fontSize.base,
+    color: colors.textMuted,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: space['3'],
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.border,
+    marginTop: space['3'],
+  },
+  rowLabel: {
+    fontSize: fontSize.base,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  note: {
+    fontSize: fontSize.sm,
+    color: colors.textMuted,
+  },
+});

--- a/apps/mobile/lib/analytics-prefs.ts
+++ b/apps/mobile/lib/analytics-prefs.ts
@@ -1,0 +1,32 @@
+/**
+ * Legal remediation E7b — persisted analytics opt-in for mobile.
+ *
+ * Mobile analytics are OFF by default (App Store privacy posture); the
+ * user explicitly opts IN via Settings → Analytics. The choice lives in
+ * expo-secure-store so it survives restarts. `_layout` reads it at boot
+ * to decide whether to construct a real tracker.
+ */
+import * as SecureStore from 'expo-secure-store';
+
+const OPT_IN_KEY = 'bw_analytics_opt_in';
+
+/** True only if the user has explicitly opted in. Defaults to false. */
+export async function getAnalyticsOptIn(): Promise<boolean> {
+  try {
+    return (await SecureStore.getItemAsync(OPT_IN_KEY)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export async function setAnalyticsOptIn(value: boolean): Promise<void> {
+  try {
+    if (value) await SecureStore.setItemAsync(OPT_IN_KEY, '1');
+    else await SecureStore.deleteItemAsync(OPT_IN_KEY);
+  } catch {
+    // SecureStore unavailable (e.g. simulator without keychain) — the
+    // default-off posture still holds, so there's nothing to recover.
+  }
+}
+
+export { OPT_IN_KEY };

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -142,11 +142,10 @@ function OnboardingFlow() {
       // Legal remediation E1 — the review step gates this submit behind
       // the allergen-disclaimer checkbox, so record the acknowledgment.
       await saveProfile({ ...payload, acknowledge_disclaimer: true });
+      // Legal remediation E7 — funnel conversion only; the dietary
+      // profile (preset/strictness/avoid sizes) is health data and is
+      // never attached to this identified event.
       tracker.track('profile_set', {
-        preset_slug: draft.selectedPresetSlugs[0] ?? null,
-        avoid_ingredient_count: payload.avoid_ingredient_ids.length,
-        avoid_tag_count: payload.avoid_tag_ids.length,
-        strictness: payload.strictness,
         taste_signal_count: tasteSignalCount,
       });
       router.replace('/');

--- a/apps/web/src/app/profile/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/profile/settings/__tests__/page.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ProfileSettingsPage from '../page';
+import { OPT_OUT_KEY } from '../../../../lib/track';
+
+/**
+ * Legal remediation E7a — the analytics opt-out toggle the Privacy
+ * Policy promises lives at /profile/settings. It must read + write the
+ * same localStorage flag buildWebTracker honors.
+ */
+describe('ProfileSettingsPage — analytics toggle', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('defaults to analytics-on (no opt-out flag set)', async () => {
+    render(<ProfileSettingsPage />);
+    const toggle = (await screen.findByLabelText('analytics-opt-in')) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+    expect(localStorage.getItem(OPT_OUT_KEY)).toBeNull();
+  });
+
+  it('writes the opt-out flag when toggled off, and clears it when toggled back on', async () => {
+    render(<ProfileSettingsPage />);
+    const toggle = (await screen.findByLabelText('analytics-opt-in')) as HTMLInputElement;
+
+    fireEvent.click(toggle); // turn analytics OFF
+    await waitFor(() => expect(localStorage.getItem(OPT_OUT_KEY)).toBe('1'));
+    expect(screen.getByTestId('analytics-state')).toHaveTextContent(/opted out/i);
+
+    fireEvent.click(screen.getByLabelText('analytics-opt-in')); // back ON
+    await waitFor(() => expect(localStorage.getItem(OPT_OUT_KEY)).toBeNull());
+  });
+
+  it('reflects a pre-existing opt-out on load', async () => {
+    localStorage.setItem(OPT_OUT_KEY, '1');
+    render(<ProfileSettingsPage />);
+    const toggle = (await screen.findByLabelText('analytics-opt-in')) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+  });
+});

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { OPT_OUT_KEY } from '../../../lib/track';
+
+/**
+ * Legal remediation E7a — the analytics opt-out the Privacy Policy
+ * promises ("turn them off with the toggle in /profile/settings").
+ *
+ * Web analytics are on by default (the wrapper also honors the
+ * browser's Do-Not-Track). This toggle writes the same
+ * `localStorage.bw_analytics_opt_out` flag that `buildWebTracker`
+ * reads, so flipping it off makes the tracker a no-op on the next
+ * load. We never send the dietary profile on analytics events
+ * regardless (see packages/analytics — profile_set carries no health
+ * fields).
+ */
+export default function ProfileSettingsPage() {
+  // null until we've read localStorage (avoids an SSR/client mismatch).
+  const [optedOut, setOptedOut] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    try {
+      setOptedOut(localStorage.getItem(OPT_OUT_KEY) === '1');
+    } catch {
+      setOptedOut(false);
+    }
+  }, []);
+
+  const setOptOut = (next: boolean) => {
+    try {
+      if (next) localStorage.setItem(OPT_OUT_KEY, '1');
+      else localStorage.removeItem(OPT_OUT_KEY);
+    } catch {
+      // localStorage unavailable (private mode) — nothing to persist.
+    }
+    setOptedOut(next);
+  };
+
+  const analyticsOn = optedOut === false;
+
+  return (
+    <main className="mx-auto max-w-2xl px-bw-6 pt-bw-12 pb-bw-16">
+      <h1 className="text-bw-2xl font-bold text-zinc-900">Settings</h1>
+
+      <section className="mt-bw-8">
+        <h2 className="text-bw-lg font-bold text-zinc-900">Product analytics</h2>
+        <p className="mt-bw-2 text-bw-sm text-zinc-600">
+          We use privacy-respecting product analytics to understand the launch funnel. Events are
+          never tied to your dietary profile — we don’t send what you avoid, your presets, or your
+          strictness. We also honor your browser’s Do-Not-Track signal automatically.
+        </p>
+
+        <label className="mt-bw-4 flex items-center justify-between rounded-bw-md border border-zinc-200 p-bw-4">
+          <span className="text-bw-base font-semibold text-zinc-800">
+            Allow anonymous product analytics
+          </span>
+          <input
+            type="checkbox"
+            role="switch"
+            aria-label="analytics-opt-in"
+            disabled={optedOut === null}
+            checked={analyticsOn}
+            onChange={(e) => setOptOut(!e.target.checked)}
+            className="h-5 w-5"
+          />
+        </label>
+
+        <p className="mt-bw-2 text-bw-xs text-zinc-500" data-testid="analytics-state">
+          {optedOut === null
+            ? 'Loading…'
+            : analyticsOn
+              ? 'Analytics are on. Turning this off takes effect on your next page load.'
+              : 'Analytics are off. You’ve opted out on this device.'}
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -27,13 +27,15 @@ First event in every session. Fired by web on page load, by mobile on cold + war
 ### `profile_set`
 Fired when the user finishes the 6-tap onboarding (Phase 3.2 / 3.8) OR updates their profile.
 
+**Legal remediation E7:** this is a funnel-conversion marker only. The dietary
+profile is special-category health data, so `preset_slug`, `strictness`,
+`avoid_ingredient_count`, and `avoid_tag_count` were **removed** — a health
+condition must never be attached to an identified analytics event (memo Issue
+6). Only the (non-health) taste-signal count remains.
+
 | Field | Type | Notes |
 |---|---|---|
-| `preset_slug` | `string \| null` | One of the curated DietaryProfiles, or null when manual. |
-| `avoid_ingredient_count` | `number` | Final count after onboarding. |
-| `avoid_tag_count` | `number` | Final count after onboarding. |
-| `strictness` | `"relaxed" \| "balanced" \| "strict"` | The Phase 3.5 toggle value. |
-| `taste_signal_count` | `number?` | Phase 8.5 — liked + disliked tags + ingredients set in the "What do you love?" step. Optional; absent when the step was skipped or for pre-8.5 callers. |
+| `taste_signal_count` | `number?` | Phase 8.5 — liked + disliked tags + ingredients set in the "What do you love?" step. Optional; absent when the step was skipped or for pre-8.5 callers. Taste (cuisine/flavor) is not health data. |
 
 ### `menu_filtered`
 Fired when the user lands on a filtered restaurant page and the items endpoint returns. Once per page render, not per item.

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -72,14 +72,18 @@ export interface EventPropsMap {
     distinct_id?: string;
   };
   profile_set: {
-    preset_slug: string | null;
-    avoid_ingredient_count: number;
-    avoid_tag_count: number;
-    strictness: 'relaxed' | 'balanced' | 'strict';
     /**
-     * Phase 8.5 — total taste signals set during onboarding (liked +
-     * disliked tags + ingredients). Optional: pre-8.5 callers and the
-     * standalone "Improve my picks" save omit it.
+     * Legal remediation E7 — `profile_set` is a funnel conversion
+     * marker only. The dietary profile is special-category health data
+     * (a celiac/allergy preset, strictness, avoid-list sizes), so it is
+     * deliberately NOT sent on this identified event — associating a
+     * health condition with an account is the existential privacy risk
+     * (memo Issue 6). Fields removed: preset_slug, strictness,
+     * avoid_ingredient_count, avoid_tag_count.
+     *
+     * `taste_signal_count` stays — taste preferences (cuisine/flavor)
+     * are not health data. Optional: the standalone "Improve my picks"
+     * save omits it.
      */
     taste_signal_count?: number;
   };


### PR DESCRIPTION
## What

**Legal remediation E7** — closes alignment-matrix rows 6, 7, 8.

### E7c — strip health data from identified events
`profile_set` no longer carries `preset_slug`, `strictness`, `avoid_ingredient_count`, or `avoid_tag_count`. The dietary profile is **special-category health data**; associating a condition (celiac, allergy) with an account was the existential privacy risk (memo Issue 6). `profile_set` is now a pure funnel-conversion marker (only the non-health `taste_signal_count` remains). Both onboarding call sites + `docs/analytics.md` updated.

### E7a — web analytics toggle
`/profile/settings` page with a toggle that writes the `localStorage.bw_analytics_opt_out` flag `buildWebTracker` already honors (alongside Do-Not-Track).

### E7b — mobile analytics screen
`Settings → Analytics` screen. The opt-in is persisted to `expo-secure-store` (`analytics-prefs.ts`) and read by the **root layout at boot**, replacing the env-only flag — so the toggle actually controls whether a real tracker is constructed (default **off**).

## Deferred (noted, not skipped)
The privacy/ToS analytics copy reword to "anonymous" — those files are owned by the **unmerged Phase 1 PR (#327)**. The reword lands once both this and Phase 1 are on master, to avoid a copy conflict.

## Verification
- web 168, mobile 126, analytics 12 — all green.
- `pnpm typecheck` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)