### PR TITLE
feat(api): user-facing report-a-review (E8)

### DIFF
--- a/apps/api/app/controllers/api/v1/reviews_controller.rb
+++ b/apps/api/app/controllers/api/v1/reviews_controller.rb
@@ -13,7 +13,7 @@ module Api
     class ReviewsController < BaseController
       skip_before_action :authenticate_user!, only: [:index]
       before_action :load_item,    only: [:index, :create]
-      before_action :load_review,  only: [:update, :destroy]
+      before_action :load_review,  only: [:update, :destroy, :report]
       before_action :gate_owner!,  only: [:update, :destroy]
 
       DEFAULT_LIMIT = 20
@@ -55,6 +55,15 @@ module Api
 
       def destroy
         @review.destroy!
+        head :no_content
+      end
+
+      # POST /api/v1/reviews/:id/report — legal remediation E8.
+      # Any signed-in reader can report a review; it routes into the
+      # existing admin moderation queue (sets flagged_at, doesn't hide).
+      # Idempotent, so a re-report is a harmless no-op.
+      def report
+        @review.report!
         head :no_content
       end
 

--- a/apps/api/app/models/review.rb
+++ b/apps/api/app/models/review.rb
@@ -58,6 +58,16 @@ class Review < ApplicationRecord
     update!(hidden_at: nil, hidden_reason: nil, flagged_at: nil)
   end
 
+  # Legal remediation E8 — a reader reported this review. Routes it
+  # into the same moderation queue the spam heuristic feeds (sets
+  # flagged_at without hiding — only a moderator hides). Idempotent: an
+  # already-flagged review keeps its original flag time, so repeated
+  # reports can't reset the queue ordering.
+  def report!
+    update!(flagged_at: Time.current) if flagged_at.blank?
+    self
+  end
+
   # Whether the body looks like spam under the lightweight heuristic.
   # Public so specs + the Avo "rerun heuristic" action can call it.
   def suspicious?

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -85,7 +85,11 @@ Rails.application.routes.draw do
         # Phase 4.10 — anyone can suggest a fix.
         resources :suggestions, only: [:create]
       end
-      resources :reviews, only: [:update, :destroy]
+      resources :reviews, only: [:update, :destroy] do
+        # Legal remediation E8 — readers report a review into the
+        # moderation queue.
+        member { post :report }
+      end
       # Phase 5.10 — soft-launch waitlist; public + unauthenticated.
       resources :waitlist_signups, only: [:create]
       # Phase 4.10 — owner accepts/rejects a suggestion.

--- a/apps/api/spec/requests/api/v1/reviews_spec.rb
+++ b/apps/api/spec/requests/api/v1/reviews_spec.rb
@@ -175,6 +175,36 @@ RSpec.describe "Reviews API", type: :request do
     end
   end
 
+  describe "POST /api/v1/reviews/:id/report (legal E8)" do
+    let!(:review) { create(:review, item: item, user: owner, rating: 5, body: "Great.") }
+
+    it "flags the review into the moderation queue for any signed-in reader" do
+      expect {
+        post "/api/v1/reviews/#{review.id}/report", headers: auth_headers_for(other_user)
+      }.to change { review.reload.flagged_at }.from(nil).to(be_present)
+
+      expect(response).to have_http_status(:no_content)
+      # The admin queue surfaces flagged-but-not-hidden reviews.
+      expect(Review.awaiting_moderation).to include(review)
+      # Reporting does not hide it — only a moderator does.
+      expect(review.reload).not_to be_hidden
+    end
+
+    it "is idempotent — a second report doesn't reset the flag time" do
+      post "/api/v1/reviews/#{review.id}/report", headers: auth_headers_for(other_user)
+      first_flagged = review.reload.flagged_at
+
+      post "/api/v1/reviews/#{review.id}/report", headers: auth_headers_for(owner)
+      expect(review.reload.flagged_at).to eq(first_flagged)
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "401s anonymously" do
+      post "/api/v1/reviews/#{review.id}/report"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
   # Synthesize a multipart upload from in-memory bytes — avoids
   # checking real binary fixtures into the repo.
   def upload_fixture(filename:, type:, size: 32)

--- a/apps/mobile/__tests__/lib/reviews.test.ts
+++ b/apps/mobile/__tests__/lib/reviews.test.ts
@@ -2,6 +2,7 @@ import {
   createReview,
   deleteReview,
   fetchReviews,
+  reportReview,
   ReviewError,
   updateReview,
   type ReviewPayload,
@@ -136,5 +137,22 @@ describe('deleteReview', () => {
   it('throws on non-2xx', async () => {
     const fetchImpl = fakeFetch(403, { error: 'forbidden' });
     await expect(deleteReview('rev-1', 'jwt', { fetchImpl })).rejects.toBeInstanceOf(ReviewError);
+  });
+});
+
+describe('reportReview (legal E8)', () => {
+  it('POSTs /api/v1/reviews/:id/report with the bearer token', async () => {
+    const fetchImpl = fakeFetch(204, {});
+    await reportReview('rev-1', 'jwt', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toContain('/api/v1/reviews/rev-1/report');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer jwt');
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'Not signed in' });
+    await expect(reportReview('rev-1', 'jwt', { fetchImpl })).rejects.toBeInstanceOf(ReviewError);
   });
 });

--- a/apps/mobile/app/items/[id].tsx
+++ b/apps/mobile/app/items/[id].tsx
@@ -17,6 +17,7 @@ import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
   createReview,
   fetchReviews,
+  reportReview,
   type ReviewPayload,
 } from '../../lib/api/reviews';
 import { getJwt } from '../../lib/auth';
@@ -134,6 +135,26 @@ export default function ItemDetailScreen() {
 }
 
 function ReviewCard({ review }: { review: ReviewPayload }) {
+  // Legal remediation E8 — report routes the review into the moderation
+  // queue. Signed-in only; a 401 prompts the reader to log in.
+  const [reportState, setReportState] = useState<'idle' | 'sending' | 'done'>('idle');
+
+  const onReport = async () => {
+    const jwt = await getJwt();
+    if (!jwt) {
+      Alert.alert('Sign in to report', 'You need an account to report a review.');
+      return;
+    }
+    setReportState('sending');
+    try {
+      await reportReview(review.id, jwt);
+      setReportState('done');
+    } catch (e) {
+      setReportState('idle');
+      Alert.alert('Could not report', (e as Error).message);
+    }
+  };
+
   return (
     <View style={styles.reviewCard} testID={`review-${review.id}`}>
       <Text style={styles.reviewAuthor}>
@@ -144,6 +165,20 @@ function ReviewCard({ review }: { review: ReviewPayload }) {
       {review.photo_url ? (
         <Image source={{ uri: review.photo_url }} style={styles.reviewPhoto} accessibilityLabel="review-photo" />
       ) : null}
+      {reportState === 'done' ? (
+        <Text style={styles.reportedNote} accessibilityLabel={`reported-${review.id}`}>
+          Reported — a moderator will take a look.
+        </Text>
+      ) : (
+        <Pressable
+          accessibilityLabel={`report-${review.id}`}
+          onPress={onReport}
+          disabled={reportState === 'sending'}
+          style={styles.reportButton}
+        >
+          <Text style={styles.reportText}>{reportState === 'sending' ? 'Reporting…' : 'Report'}</Text>
+        </Pressable>
+      )}
     </View>
   );
 }
@@ -362,6 +397,20 @@ const styles = StyleSheet.create({
     height: 200,
     borderRadius: 12,
     backgroundColor: colors.bgAlt,
+  },
+  reportButton: {
+    marginTop: space['2'],
+    alignSelf: 'flex-start',
+  },
+  reportText: {
+    fontSize: fontSize.xs,
+    fontWeight: '600',
+    color: colors.textMuted,
+  },
+  reportedNote: {
+    marginTop: space['2'],
+    fontSize: fontSize.xs,
+    color: colors.textMuted,
   },
   composerSheet: {
     position: 'absolute',

--- a/apps/mobile/lib/api/reviews.ts
+++ b/apps/mobile/lib/api/reviews.ts
@@ -150,6 +150,23 @@ export async function deleteReview(
   if (!res.ok) throw await reviewError(res, `deleteReview ${reviewId}`);
 }
 
+/**
+ * Legal remediation E8 — report a review into the moderation queue.
+ * Signed-in only; a 401 means the reader needs to log in first.
+ */
+export async function reportReview(
+  reviewId: string,
+  jwt: string,
+  opts: FetchOptions = {},
+): Promise<void> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`${API_BASE}/api/v1/reviews/${encodeURIComponent(reviewId)}/report`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  if (!res.ok) throw await reviewError(res, `reportReview ${reviewId}`);
+}
+
 function filenameFromUri(uri: string): string {
   const last = uri.split('/').pop();
   return last && last.length > 0 ? last : 'photo.jpg';

--- a/apps/web/src/app/api/reviews/[id]/report/route.ts
+++ b/apps/web/src/app/api/reviews/[id]/report/route.ts
@@ -1,0 +1,29 @@
+/**
+ * Legal remediation E8 — proxy POST /api/reviews/:id/report to Rails
+ * with the cookie's JWT. Routes the review into the moderation queue.
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getServerJwt } from '../../../../../lib/server-auth';
+
+import { API_BASE } from '../../../../../lib/api-base';
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  const jwt = await getServerJwt();
+  if (!jwt) {
+    return NextResponse.json({ error: 'Not signed in' }, { status: 401 });
+  }
+
+  const upstream = await fetch(
+    `${API_BASE}/api/v1/reviews/${encodeURIComponent(id)}/report`,
+    { method: 'POST', headers: { Authorization: `Bearer ${jwt}` } },
+  );
+  const text = await upstream.text();
+  return new NextResponse(text.length > 0 ? text : null, {
+    status: upstream.status,
+    headers: { 'Content-Type': upstream.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/ReviewsClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/ReviewsClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import {
   createReview,
   fetchReviews,
+  reportReview,
   ReviewError,
   type ReviewPayload,
   type ReviewsResponse,
@@ -136,7 +137,51 @@ function ReviewCard({ review }: { review: ReviewPayload }) {
           className="mt-bw-2 max-h-80 w-full rounded-bw-md object-cover"
         />
       )}
+      <ReportControl reviewId={review.id} />
     </li>
+  );
+}
+
+/**
+ * Legal remediation E8 — "Report" affordance. Routes the review into
+ * the moderation queue (the same queue the spam heuristic feeds).
+ * Signed-in only; a 401 nudges the reader to sign in.
+ */
+function ReportControl({ reviewId }: { reviewId: string }) {
+  const [state, setState] = useState<'idle' | 'sending' | 'done' | 'signin' | 'error'>('idle');
+
+  if (state === 'done') {
+    return <p className="mt-1 text-bw-xs text-zinc-500" data-testid={`reported-${reviewId}`}>Reported — thanks. A moderator will take a look.</p>;
+  }
+
+  const onReport = async () => {
+    setState('sending');
+    try {
+      await reportReview(reviewId);
+      setState('done');
+    } catch (e) {
+      setState(e instanceof ReviewError && e.status === 401 ? 'signin' : 'error');
+    }
+  };
+
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={onReport}
+        disabled={state === 'sending'}
+        data-testid={`report-${reviewId}`}
+        className="text-bw-xs font-semibold text-zinc-400 hover:text-zinc-600"
+      >
+        {state === 'sending' ? 'Reporting…' : 'Report'}
+      </button>
+      {state === 'signin' && (
+        <span className="ml-2 text-bw-xs text-zinc-500">Sign in to report.</span>
+      )}
+      {state === 'error' && (
+        <span className="ml-2 text-bw-xs text-bite-dark">Couldn’t report — try again.</span>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/lib/__tests__/reviews.test.ts
+++ b/apps/web/src/lib/__tests__/reviews.test.ts
@@ -3,6 +3,7 @@ import {
   createReview,
   deleteReview,
   fetchReviews,
+  reportReview,
   ReviewError,
   updateReview,
   type ReviewPayload,
@@ -138,5 +139,22 @@ describe('deleteReview', () => {
     const init = fetchImpl.mock.calls[0]![1] as RequestInit;
     expect(init.method).toBe('DELETE');
     expect(init.credentials).toBe('same-origin');
+  });
+});
+
+describe('reportReview (legal E8)', () => {
+  it('POSTs to the report proxy URL with credentials', async () => {
+    const fetchImpl = fakeFetch(204, {});
+    await reportReview('rev-1', { fetchImpl });
+    const url = String(fetchImpl.mock.calls[0]![0]);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect(url).toBe('/api/reviews/rev-1/report');
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('same-origin');
+  });
+
+  it('throws a 401 ReviewError so the UI can prompt sign-in', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'Not signed in' });
+    await expect(reportReview('rev-1', { fetchImpl })).rejects.toMatchObject({ status: 401 });
   });
 });

--- a/apps/web/src/lib/reviews.ts
+++ b/apps/web/src/lib/reviews.ts
@@ -151,6 +151,23 @@ export async function deleteReview(
   if (!res.ok) throw await reviewError(res, `deleteReview ${reviewId}`);
 }
 
+/**
+ * Legal remediation E8 — report a review into the moderation queue.
+ * Routes through the Next proxy so the cookie JWT is attached. 401
+ * means the reader isn't signed in.
+ */
+export async function reportReview(
+  reviewId: string,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<void> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`/api/reviews/${encodeURIComponent(reviewId)}/report`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  });
+  if (!res.ok) throw await reviewError(res, `reportReview ${reviewId}`);
+}
+
 async function reviewError(res: Response, label: string): Promise<ReviewError> {
   let body: { error?: string } | null = null;
   try {


### PR DESCRIPTION
## What

**Legal remediation E8** — gives readers a way to flag a review into the existing moderation queue (previously fed only by the spam heuristic + admins). Memo Issue 6.

- `POST /api/v1/reviews/:id/report` — signed-in only; `Review#report!` sets `flagged_at` (**without hiding** — only a moderator hides), so the review surfaces in the admin `awaiting_moderation` queue. **Idempotent**: a re-report keeps the original flag time.
- **Web**: a "Report" affordance on each review (`ReviewsClient`) + a Next proxy route + `reportReview()` client fn. 401 prompts sign-in.
- **Mobile**: a "Report" control on each review card (`items/[id]`) + `reportReview()`; no JWT → "sign in to report" alert.

Reviews aren't in the rswag/openapi set (hand-written read types per CLAUDE.md), so this follows the existing request-spec convention rather than adding codegen.

## Verification
- API `bundle exec rspec` → 474 (report: flags into queue, idempotent, 401 anon).
- web 167, mobile 124 — all green. `pnpm typecheck` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)