### PR TITLE
fix(api): neutral default handle, no email leak (E9)

### DIFF
--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
                      format: { with: /\A[a-z0-9_]{3,30}\z/i }
 
   before_validation :ensure_jti, on: :create
-  before_validation :default_handle_from_email, on: :create
+  before_validation :assign_default_handle, on: :create
   after_create_commit :ensure_profile
 
   # Find or create a user from an OmniAuth auth hash. Used by both the
@@ -72,13 +72,18 @@ class User < ApplicationRecord
     self.jti ||= SecureRandom.uuid
   end
 
-  def default_handle_from_email
-    return if handle.present? || email.blank?
-    base = email.split("@", 2).first.gsub(/[^a-z0-9_]/i, "_").downcase
-    candidate = base
-    suffix = 1
-    candidate = "#{base}_#{suffix += 1}" while User.exists?(handle: candidate)
-    self.handle = candidate
+  # Legal remediation E9 — give accounts that didn't choose a handle a
+  # NEUTRAL default. The handle is shown publicly (on reviews and at
+  # /u/:handle), so it must not leak the email local-part the way the
+  # old `default_handle_from_email` did ("jane.doe@…" → "jane_doe").
+  # `diner_<random>` carries no PII; a user can still set a custom
+  # handle at signup.
+  def assign_default_handle
+    return if handle.present?
+    self.handle = loop do
+      candidate = "diner_#{SecureRandom.hex(4)}"
+      break candidate unless User.exists?(handle: candidate)
+    end
   end
 
   def ensure_profile

--- a/apps/api/spec/models/user_spec.rb
+++ b/apps/api/spec/models/user_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe User do
+  describe "#assign_default_handle (legal E9)" do
+    it "keeps a handle the user chose" do
+      user = User.create!(
+        email: "chooser@example.com", password: "password123",
+        password_confirmation: "password123", handle: "picky_eater"
+      )
+      expect(user.handle).to eq("picky_eater")
+    end
+
+    it "assigns a neutral default that does NOT leak the email local-part" do
+      user = User.create!(
+        email: "jane.doe.celiac@example.com", password: "password123",
+        password_confirmation: "password123"
+      )
+      expect(user.handle).to match(/\Adiner_[0-9a-f]{8}\z/)
+      # The old behavior derived the handle from the email — make sure
+      # nothing of the local-part survives in the public handle.
+      expect(user.handle).not_to include("jane")
+      expect(user.handle).not_to include("doe")
+      expect(user.handle).not_to include("celiac")
+    end
+
+    it "produces distinct defaults for different accounts" do
+      a = User.create!(email: "a@example.com", password: "password123", password_confirmation: "password123")
+      b = User.create!(email: "b@example.com", password: "password123", password_confirmation: "password123")
+      expect(a.handle).not_to eq(b.handle)
+    end
+  end
+end


### PR DESCRIPTION
## What

**Legal remediation E9** — closes alignment-matrix row 19.

The public handle (shown on reviews and at `/u/:handle`) was derived from the **email local-part** (`default_handle_from_email`: `jane.doe@…` → `jane_doe`), leaking PII.

Replaced with `assign_default_handle`, which assigns a neutral `diner_<8 hex>` handle that carries no email info. Users who choose a handle at signup keep it; only accounts without one (including OAuth) get the default.

**No backfill** — existing handles are left unchanged (altering established public identities/links would be worse than the leak for accounts that already exist; pre-launch there are no real users anyway).

## Verification
- `bundle exec rspec` → 474; new `user_spec` asserts the default is `diner_…` and contains none of the email local-part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)