### PR TITLE
feat(web): add DMCA takedown intake page + endpoint (E10)

### DIFF
--- a/apps/api/app/controllers/api/v1/dmca_notices_controller.rb
+++ b/apps/api/app/controllers/api/v1/dmca_notices_controller.rb
@@ -1,0 +1,35 @@
+module Api
+  module V1
+    # POST /api/v1/dmca_notices — legal remediation E10.
+    #
+    # Public + unauthenticated: a copyright holder (who, by definition,
+    # isn't a BiteWorthy user) files a takedown notice from /dmca. The
+    # notice is stored for admin review (the repeat-infringer process)
+    # and backs the ToS § Copyright clause + the §512 safe harbor.
+    #
+    # 201 on a valid notice; 422 when a required field or one of the two
+    # sworn statements is missing.
+    class DmcaNoticesController < BaseController
+      skip_before_action :authenticate_user!, only: [:create]
+
+      def create
+        notice = DmcaNotice.new(notice_params)
+        if notice.save
+          render json: { ok: true, id: notice.id }, status: :created
+        else
+          render json: { ok: false, errors: notice.errors.full_messages },
+                 status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def notice_params
+        params.require(:dmca_notice).permit(
+          :complainant_name, :complainant_email, :infringing_url,
+          :work_description, :good_faith, :accuracy_sworn, :signature
+        )
+      end
+    end
+  end
+end

--- a/apps/api/app/models/dmca_notice.rb
+++ b/apps/api/app/models/dmca_notice.rb
@@ -1,0 +1,34 @@
+class DmcaNotice < ApplicationRecord
+  # Legal remediation E10 — a copyright takedown notice filed at /dmca.
+  #
+  # The §512(c)(3) notice requires, among other things, a good-faith
+  # statement and a statement (under penalty of perjury) that the
+  # notice is accurate — both captured as required checkboxes. We store
+  # every notice so there's an auditable trail and the data behind the
+  # repeat-infringer process (an admin review over these rows, plus L2:
+  # registering the designated agent).
+  EMAIL_REGEX = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+  STATUSES = %w[received actioned rejected].freeze
+
+  validates :complainant_name,  presence: true
+  validates :complainant_email, presence: true, format: { with: EMAIL_REGEX }
+  validates :infringing_url,    presence: true
+  validates :work_description,  presence: true
+  validates :signature,         presence: true
+  validates :status, inclusion: { in: STATUSES }
+  # Both §512(c)(3) sworn statements must be affirmed for a valid notice.
+  validate :statements_affirmed
+
+  before_validation :normalize_email
+
+  private
+
+  def normalize_email
+    self.complainant_email = complainant_email.to_s.strip.downcase if complainant_email.present?
+  end
+
+  def statements_affirmed
+    errors.add(:good_faith, "must be affirmed") unless good_faith
+    errors.add(:accuracy_sworn, "must be affirmed") unless accuracy_sworn
+  end
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -95,6 +95,8 @@ Rails.application.routes.draw do
       end
       # Phase 5.10 — soft-launch waitlist; public + unauthenticated.
       resources :waitlist_signups, only: [:create]
+      # Legal remediation E10 — DMCA takedown intake; public.
+      resources :dmca_notices, only: [:create]
       # Phase 4.10 — owner accepts/rejects a suggestion.
       resources :suggestions, only: [:update]
       # Phase 4.7 — public profile by handle. Constraint allows

--- a/apps/api/db/migrate/20260614140000_create_dmca_notices.rb
+++ b/apps/api/db/migrate/20260614140000_create_dmca_notices.rb
@@ -1,0 +1,25 @@
+# Legal remediation E10 — stores DMCA takedown notices submitted via
+# /dmca, backing the ToS § Copyright clause + the §512 safe harbor
+# (the designated agent gets registered separately in L2). Persisting
+# each notice gives an auditable record and the data behind the
+# repeat-infringer process (an admin/ops review over these rows).
+class CreateDmcaNotices < ActiveRecord::Migration[8.1]
+  def change
+    create_table :dmca_notices, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.string   :complainant_name,  null: false
+      t.string   :complainant_email, null: false
+      t.text     :infringing_url,    null: false
+      t.text     :work_description,  null: false
+      # The two §512(c)(3) sworn statements, captured as checkboxes.
+      t.boolean  :good_faith,        null: false, default: false
+      t.boolean  :accuracy_sworn,    null: false, default: false
+      t.string   :signature,         null: false
+      # received | actioned | rejected — admins move it through review.
+      t.string   :status,            null: false, default: "received"
+      t.timestamps
+    end
+
+    add_index :dmca_notices, :status
+    add_index :dmca_notices, :created_at
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_14_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -98,6 +98,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_130000) do
     t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_dietary_profiles_on_slug", unique: true
+  end
+
+  create_table "dmca_notices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "accuracy_sworn", default: false, null: false
+    t.string "complainant_email", null: false
+    t.string "complainant_name", null: false
+    t.datetime "created_at", null: false
+    t.boolean "good_faith", default: false, null: false
+    t.text "infringing_url", null: false
+    t.string "signature", null: false
+    t.string "status", default: "received", null: false
+    t.datetime "updated_at", null: false
+    t.text "work_description", null: false
+    t.index ["created_at"], name: "index_dmca_notices_on_created_at"
+    t.index ["status"], name: "index_dmca_notices_on_status"
   end
 
   create_table "hours", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/apps/api/spec/requests/api/v1/dmca_notices_spec.rb
+++ b/apps/api/spec/requests/api/v1/dmca_notices_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "POST /api/v1/dmca_notices (legal E10)", type: :request do
+  let(:url) { "/api/v1/dmca_notices" }
+
+  let(:valid) do
+    {
+      dmca_notice: {
+        complainant_name:  "Ansel Adams Estate",
+        complainant_email: "Legal@Example.com",
+        infringing_url:    "https://bite-worthy.com/restaurants/foo/items/bar",
+        work_description:  "My copyrighted dish photograph, used without a license.",
+        good_faith:        true,
+        accuracy_sworn:    true,
+        signature:         "Jane Counsel"
+      }
+    }
+  end
+
+  it "stores a valid takedown notice anonymously and normalizes the email" do
+    expect {
+      post url, params: valid, as: :json
+    }.to change(DmcaNotice, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    expect(response.parsed_body["ok"]).to be true
+
+    notice = DmcaNotice.last
+    expect(notice.status).to eq("received")
+    expect(notice.complainant_email).to eq("legal@example.com")
+  end
+
+  it "422s when a sworn statement is not affirmed" do
+    post url, params: valid.deep_merge(dmca_notice: { good_faith: false }), as: :json
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body["errors"].join).to match(/affirmed/i)
+  end
+
+  it "422s on a malformed complainant email" do
+    post url, params: valid.deep_merge(dmca_notice: { complainant_email: "nope" }), as: :json
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  it "422s when the work description is missing" do
+    post url, params: valid.deep_merge(dmca_notice: { work_description: "" }), as: :json
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+end

--- a/apps/web/src/app/api/dmca/route.ts
+++ b/apps/web/src/app/api/dmca/route.ts
@@ -1,0 +1,33 @@
+/**
+ * Legal remediation E10 — Next proxy for the DMCA takedown form.
+ *
+ * `POST /api/dmca` from the /dmca page forwards to the Rails
+ * `POST /api/v1/dmca_notices`. Keeps the API base server-side so the
+ * browser makes a same-origin request (no CORS preflight).
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { API_BASE } from '../../../lib/api-base';
+
+interface DmcaBody {
+  complainant_name?: string;
+  complainant_email?: string;
+  infringing_url?: string;
+  work_description?: string;
+  good_faith?: boolean;
+  accuracy_sworn?: boolean;
+  signature?: string;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = (await request.json().catch(() => ({}))) as DmcaBody;
+
+  const upstream = await fetch(`${API_BASE}/api/v1/dmca_notices`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ dmca_notice: body }),
+  });
+
+  const responseBody = await upstream.json().catch(() => ({}));
+  return NextResponse.json(responseBody, { status: upstream.status });
+}

--- a/apps/web/src/app/dmca/DmcaForm.tsx
+++ b/apps/web/src/app/dmca/DmcaForm.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+
+/**
+ * Legal remediation E10 — DMCA notice form. Posts to the Next proxy at
+ * /api/dmca (→ Rails POST /api/v1/dmca_notices). Both §512(c)(3) sworn
+ * statements are required checkboxes; the server rejects a notice that
+ * omits either.
+ */
+export function DmcaForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [url, setUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [goodFaith, setGoodFaith] = useState(false);
+  const [accuracySworn, setAccuracySworn] = useState(false);
+  const [signature, setSignature] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const ready =
+    name && email && url && description && signature && goodFaith && accuracySworn && !submitting;
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/dmca', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          complainant_name: name,
+          complainant_email: email,
+          infringing_url: url,
+          work_description: description,
+          good_faith: goodFaith,
+          accuracy_sworn: accuracySworn,
+          signature,
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { errors?: string[] };
+        throw new Error(body.errors?.join(', ') || `Submission failed (${res.status})`);
+      }
+      setDone(true);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <div
+        role="status"
+        data-testid="dmca-done"
+        className="mt-bw-8 rounded-bw-md border border-ok/40 bg-ok/10 p-bw-4 text-bw-sm text-zinc-800"
+      >
+        <strong>Notice received.</strong> Thank you — our team will review it and follow up at the
+        email you provided.
+      </div>
+    );
+  }
+
+  const field = 'mt-1 w-full rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base';
+  const labelText = 'text-bw-sm font-semibold text-zinc-700';
+
+  return (
+    <form onSubmit={onSubmit} className="mt-bw-8 flex flex-col gap-bw-4" data-testid="dmca-form">
+      <h2 className="text-bw-xl font-bold text-zinc-900">File a notice</h2>
+
+      <label>
+        <span className={labelText}>Your name</span>
+        <input value={name} onChange={(e) => setName(e.target.value)} required aria-label="dmca-name" className={field} />
+      </label>
+      <label>
+        <span className={labelText}>Your email</span>
+        <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required aria-label="dmca-email" className={field} />
+      </label>
+      <label>
+        <span className={labelText}>URL of the infringing material</span>
+        <input value={url} onChange={(e) => setUrl(e.target.value)} required aria-label="dmca-url" className={field} />
+      </label>
+      <label>
+        <span className={labelText}>Describe the copyrighted work</span>
+        <textarea value={description} onChange={(e) => setDescription(e.target.value)} required aria-label="dmca-description" rows={3} className={field} />
+      </label>
+
+      <label className="flex items-start gap-bw-2 text-bw-sm text-zinc-700">
+        <input type="checkbox" checked={goodFaith} onChange={(e) => setGoodFaith(e.target.checked)} aria-label="dmca-good-faith" className="mt-bw-1 h-4 w-4 shrink-0" />
+        <span>I have a good-faith belief that the use isn’t authorized by the owner, its agent, or the law.</span>
+      </label>
+      <label className="flex items-start gap-bw-2 text-bw-sm text-zinc-700">
+        <input type="checkbox" checked={accuracySworn} onChange={(e) => setAccuracySworn(e.target.checked)} aria-label="dmca-accuracy" className="mt-bw-1 h-4 w-4 shrink-0" />
+        <span>Under penalty of perjury, this notice is accurate and I am the owner or authorized to act for them.</span>
+      </label>
+
+      <label>
+        <span className={labelText}>Signature (type your full name)</span>
+        <input value={signature} onChange={(e) => setSignature(e.target.value)} required aria-label="dmca-signature" className={field} />
+      </label>
+
+      {error && (
+        <p className="rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">{error}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={!ready}
+        data-testid="dmca-submit"
+        className={[
+          'rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
+          ready ? 'hover:bg-bite-dark' : 'opacity-60',
+        ].join(' ')}
+      >
+        {submitting ? 'Submitting…' : 'Submit notice'}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/app/dmca/__tests__/DmcaForm.test.tsx
+++ b/apps/web/src/app/dmca/__tests__/DmcaForm.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { DmcaForm } from '../DmcaForm';
+
+/**
+ * Legal remediation E10 — the DMCA form must require both §512(c)(3)
+ * sworn statements before it will submit, and post the structured
+ * notice to the proxy.
+ */
+describe('DmcaForm', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const fill = () => {
+    fireEvent.change(screen.getByLabelText('dmca-name'), { target: { value: 'Jane' } });
+    fireEvent.change(screen.getByLabelText('dmca-email'), { target: { value: 'jane@example.com' } });
+    fireEvent.change(screen.getByLabelText('dmca-url'), { target: { value: 'https://x/y' } });
+    fireEvent.change(screen.getByLabelText('dmca-description'), { target: { value: 'My photo.' } });
+    fireEvent.change(screen.getByLabelText('dmca-signature'), { target: { value: 'Jane Counsel' } });
+  };
+
+  it('keeps submit disabled until both sworn statements are checked', () => {
+    render(<DmcaForm />);
+    fill();
+    expect(screen.getByTestId('dmca-submit')).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('dmca-good-faith'));
+    expect(screen.getByTestId('dmca-submit')).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('dmca-accuracy'));
+    expect(screen.getByTestId('dmca-submit')).not.toBeDisabled();
+  });
+
+  it('posts the notice and shows a confirmation on success', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true, json: async () => ({ ok: true }) } as Response);
+
+    render(<DmcaForm />);
+    fill();
+    fireEvent.click(screen.getByLabelText('dmca-good-faith'));
+    fireEvent.click(screen.getByLabelText('dmca-accuracy'));
+    fireEvent.click(screen.getByTestId('dmca-submit'));
+
+    await waitFor(() => expect(screen.getByTestId('dmca-done')).toBeInTheDocument());
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/dmca');
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+      complainant_email: 'jane@example.com',
+      good_faith: true,
+      accuracy_sworn: true,
+    });
+  });
+});

--- a/apps/web/src/app/dmca/page.tsx
+++ b/apps/web/src/app/dmca/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import { buildLegalMetadata } from '../../lib/legal-meta';
+import { DmcaForm } from './DmcaForm';
+
+/**
+ * Legal remediation E10 — the DMCA takedown page.
+ *
+ * Backs the ToS § Copyright clause: it lays out the §512(c)(3) notice
+ * procedure and provides a structured form that files a notice into the
+ * intake (POST /api/v1/dmca_notices). The designated-agent registration
+ * itself is an external step (L2).
+ */
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://bite-worthy.com';
+
+export const metadata: Metadata = buildLegalMetadata({
+  pageTitle: 'Copyright & DMCA',
+  description:
+    'How to report content on BiteWorthy that infringes your copyright, and how to file a counter-notice.',
+  path: '/dmca',
+  siteUrl: SITE_URL,
+});
+
+export default function DmcaPage(): ReactElement {
+  return (
+    <main className="mx-auto max-w-3xl px-bw-6 pt-bw-12 pb-bw-16">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">Legal</p>
+      <h1 className="mt-bw-3 text-bw-3xl font-bold text-zinc-900 md:text-bw-4xl">Copyright & DMCA</h1>
+
+      <article className="prose prose-zinc mt-bw-8 max-w-none text-zinc-800">
+        <p>
+          BiteWorthy respects intellectual property. If you believe content here — a menu image or
+          a dish photo — infringes your copyright, send us a notice using the form below or by
+          email to <a href="mailto:legal@bite-worthy.com">legal@bite-worthy.com</a>. We remove
+          infringing material and terminate repeat infringers. See also the{' '}
+          <a href="/terms#copyright">Terms § Copyright & DMCA</a>.
+        </p>
+
+        <h2 className="text-bw-xl font-bold text-zinc-900">What a notice needs</h2>
+        <ul>
+          <li>Identification of the copyrighted work.</li>
+          <li>The URL or location of the material on BiteWorthy.</li>
+          <li>Your contact information.</li>
+          <li>A statement that you have a good-faith belief the use isn’t authorized.</li>
+          <li>A statement, under penalty of perjury, that the notice is accurate and that you’re the owner or authorized to act for them.</li>
+          <li>Your signature.</li>
+        </ul>
+
+        <h2 className="text-bw-xl font-bold text-zinc-900">Counter-notice</h2>
+        <p>
+          If you believe your content was removed in error, you may send a counter-notice to{' '}
+          <a href="mailto:legal@bite-worthy.com">legal@bite-worthy.com</a>.
+        </p>
+      </article>
+
+      <DmcaForm />
+    </main>
+  );
+}


### PR DESCRIPTION
## What

**Legal remediation E10** — backs the ToS § Copyright clause + the §512 safe harbor (alignment-matrix row 15). Pairs with **L2** (register the designated agent — external).

- **`/dmca` page**: lays out the §512(c)(3) notice + counter-notice procedure and a structured form. Both sworn statements (good-faith + accuracy under penalty of perjury) are **required checkboxes**; submit stays disabled until both are checked.
- **`POST /api/v1/dmca_notices`** (public) stores each notice in a new `dmca_notices` table — an auditable record + the data behind the **repeat-infringer process** (admin review over these rows). The model rejects a notice missing either sworn statement.
- Next proxy at `/api/dmca` keeps the request same-origin.

Follows the waitlist convention (request spec, not rswag — neither is in the openapi read-model set), so no codegen.

## Verification
- API `bundle exec rspec` → 475 (stores valid notice, normalizes email, 422 on missing sworn statement / bad email / missing description).
- web → 167 (form gates on both checkboxes, posts structured body). `pnpm typecheck` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)