### PR TITLE
test(mobile): de-flake the onboarding render suite

### DIFF
--- a/apps/mobile/__tests__/screens/onboarding.render.test.tsx
+++ b/apps/mobile/__tests__/screens/onboarding.render.test.tsx
@@ -37,8 +37,17 @@ jest.mock('../../lib/auth', () => ({
   getJwt: jest.fn(() => Promise.resolve(null)),
 }));
 
-import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { act, configure, fireEvent, render, screen } from '@testing-library/react-native';
 import OnboardingScreen from '../../app/onboarding/index';
+
+// Flake fix: the screen fires two fire-and-forget mount fetches
+// (fetchDietaryProfiles + fetchTags); every test waits for the result
+// with a `findBy*`. On a loaded CI runner the default 1s async timeout
+// occasionally elapsed before React flushed those resolutions, failing
+// "renders a chip per preset…" intermittently. A generous timeout
+// removes the race without restructuring the tests (the queries still
+// resolve in milliseconds locally).
+configure({ asyncUtilTimeout: 10_000 });
 
 /**
  * Phase 3.2 deferred snapshot — finally landing.


### PR DESCRIPTION
## What

The mobile onboarding screen fires two fire-and-forget mount fetches (`fetchDietaryProfiles` + `fetchTags`); every test in `onboarding.render.test.tsx` waits on the result with a `findBy*`. On a loaded CI runner the default **1s** RNTL async-util timeout occasionally elapsed before React flushed those resolutions, intermittently failing *"renders a chip per preset once the fetch resolves"* (1 failed / ~128 passed).

This is the flake that blocked the E2/E7/E10 merges and passed on every re-run.

## Fix

Raise this file's RNTL async timeout to **10s** via `configure({ asyncUtilTimeout })` — one line, no test restructuring. The queries still resolve in milliseconds locally; the headroom removes the slow-runner race.

I first tried a `render` + `act()`-flush helper to settle the fetches deterministically, but making the first test `async` leaked into the next test and broke the full suite locally — so I backed that out in favor of this minimal, structure-preserving change.

## Verification
- Full mobile suite **129/129**, stable across repeated local runs.
- `pnpm --filter @biteworthy/mobile lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)