### PR TITLE
feat(web): in-app review edit + delete for the author (E11)

### DIFF
--- a/apps/mobile/app/items/[id].tsx
+++ b/apps/mobile/app/items/[id].tsx
@@ -16,11 +16,13 @@ import * as ImagePicker from 'expo-image-picker';
 import { colors, fontSize, space } from '@biteworthy/ui-tokens';
 import {
   createReview,
+  deleteReview,
   fetchReviews,
   reportReview,
+  updateReview,
   type ReviewPayload,
 } from '../../lib/api/reviews';
-import { getJwt } from '../../lib/auth';
+import { getJwt, getUserId } from '../../lib/auth';
 import { useTracker } from '../../lib/tracker-context';
 
 /**
@@ -52,6 +54,18 @@ export default function ItemDetailScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
+  // Legal remediation E11 — drives the owner-only edit/delete controls.
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getUserId().then((id) => {
+      if (!cancelled) setCurrentUserId(id);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const reload = async () => {
     if (!itemId) return;
@@ -111,7 +125,19 @@ export default function ItemDetailScreen() {
           data={reviews}
           scrollEnabled={false}
           keyExtractor={(r) => r.id}
-          renderItem={({ item }) => <ReviewCard review={item} />}
+          renderItem={({ item }) => (
+            <ReviewCard
+              review={item}
+              isOwner={currentUserId != null && item.user.id === currentUserId}
+              onUpdated={(saved) =>
+                setReviews((prev) => prev.map((r) => (r.id === saved.id ? saved : r)))
+              }
+              onDeleted={(id) => {
+                setReviews((prev) => prev.filter((r) => r.id !== id));
+                setTotal((n) => Math.max(0, n - 1));
+              }}
+            />
+          )}
           ListEmptyComponent={
             <Text style={styles.empty}>No reviews yet — be the first.</Text>
           }
@@ -134,10 +160,25 @@ export default function ItemDetailScreen() {
   );
 }
 
-function ReviewCard({ review }: { review: ReviewPayload }) {
+function ReviewCard({
+  review,
+  isOwner,
+  onUpdated,
+  onDeleted,
+}: {
+  review: ReviewPayload;
+  isOwner: boolean;
+  onUpdated: (saved: ReviewPayload) => void;
+  onDeleted: (id: string) => void;
+}) {
   // Legal remediation E8 — report routes the review into the moderation
   // queue. Signed-in only; a 401 prompts the reader to log in.
   const [reportState, setReportState] = useState<'idle' | 'sending' | 'done'>('idle');
+  // Legal remediation E11 — the author edits/deletes their own review.
+  const [editing, setEditing] = useState(false);
+  const [draftBody, setDraftBody] = useState(review.body ?? '');
+  const [draftRating, setDraftRating] = useState(review.rating);
+  const [busy, setBusy] = useState(false);
 
   const onReport = async () => {
     const jwt = await getJwt();
@@ -155,6 +196,82 @@ function ReviewCard({ review }: { review: ReviewPayload }) {
     }
   };
 
+  const onSaveEdit = async () => {
+    const jwt = await getJwt();
+    if (!jwt) return;
+    setBusy(true);
+    try {
+      const saved = await updateReview(review.id, jwt, {
+        rating: draftRating,
+        body: draftBody.trim() || null,
+      });
+      onUpdated(saved);
+      setEditing(false);
+    } catch (e) {
+      Alert.alert('Could not save', (e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDelete = () => {
+    Alert.alert('Delete review?', 'This permanently removes your review.', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          const jwt = await getJwt();
+          if (!jwt) return;
+          try {
+            await deleteReview(review.id, jwt);
+            onDeleted(review.id);
+          } catch (e) {
+            Alert.alert('Could not delete', (e as Error).message);
+          }
+        },
+      },
+    ]);
+  };
+
+  if (editing) {
+    return (
+      <View style={styles.reviewCard} testID={`review-${review.id}`}>
+        <View style={styles.editStars}>
+          {[1, 2, 3, 4, 5].map((n) => (
+            <Pressable
+              key={n}
+              accessibilityLabel={`edit-star-${review.id}-${n}`}
+              onPress={() => setDraftRating(n)}
+            >
+              <Text style={styles.editStar}>{draftRating >= n ? '★' : '☆'}</Text>
+            </Pressable>
+          ))}
+        </View>
+        <TextInput
+          accessibilityLabel={`edit-body-${review.id}`}
+          value={draftBody}
+          onChangeText={setDraftBody}
+          multiline
+          style={styles.input}
+        />
+        <View style={styles.editActions}>
+          <Pressable accessibilityLabel={`cancel-edit-${review.id}`} onPress={() => setEditing(false)}>
+            <Text style={styles.reportText}>Cancel</Text>
+          </Pressable>
+          <Pressable
+            accessibilityLabel={`save-edit-${review.id}`}
+            onPress={onSaveEdit}
+            disabled={busy}
+            style={[styles.editSave, busy && { opacity: 0.5 }]}
+          >
+            <Text style={styles.editSaveText}>{busy ? 'Saving…' : 'Save'}</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.reviewCard} testID={`review-${review.id}`}>
       <Text style={styles.reviewAuthor}>
@@ -165,7 +282,16 @@ function ReviewCard({ review }: { review: ReviewPayload }) {
       {review.photo_url ? (
         <Image source={{ uri: review.photo_url }} style={styles.reviewPhoto} accessibilityLabel="review-photo" />
       ) : null}
-      {reportState === 'done' ? (
+      {isOwner ? (
+        <View style={styles.editActions}>
+          <Pressable accessibilityLabel={`edit-${review.id}`} onPress={() => setEditing(true)}>
+            <Text style={styles.editText}>Edit</Text>
+          </Pressable>
+          <Pressable accessibilityLabel={`delete-${review.id}`} onPress={onDelete}>
+            <Text style={styles.reportText}>Delete</Text>
+          </Pressable>
+        </View>
+      ) : reportState === 'done' ? (
         <Text style={styles.reportedNote} accessibilityLabel={`reported-${review.id}`}>
           Reported — a moderator will take a look.
         </Text>
@@ -411,6 +537,37 @@ const styles = StyleSheet.create({
     marginTop: space['2'],
     fontSize: fontSize.xs,
     color: colors.textMuted,
+  },
+  // Legal remediation E11 — owner edit/delete controls.
+  editActions: {
+    marginTop: space['2'],
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space['4'],
+  },
+  editText: {
+    fontSize: fontSize.xs,
+    fontWeight: '700',
+    color: colors.bite,
+  },
+  editStars: {
+    flexDirection: 'row',
+    gap: space['1'],
+  },
+  editStar: {
+    fontSize: fontSize.xl,
+    color: colors.bite,
+  },
+  editSave: {
+    backgroundColor: colors.bite,
+    paddingHorizontal: space['3'],
+    paddingVertical: space['1'],
+    borderRadius: 8,
+  },
+  editSaveText: {
+    color: colors.bg,
+    fontWeight: '700',
+    fontSize: fontSize.sm,
   },
   composerSheet: {
     position: 'absolute',

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -42,6 +42,26 @@ export async function getJwt(): Promise<string | null> {
   }
 }
 
+/**
+ * The signed-in user's id, decoded from the stored JWT's `sub` claim
+ * (devise-jwt). Legal remediation E11 uses it to show the owner-only
+ * edit/delete controls on a review. Display-only — the API still gates
+ * every mutation by ownership — so we don't verify the signature.
+ */
+export async function getUserId(): Promise<string | null> {
+  const token = await getJwt();
+  if (!token) return null;
+  const payload = token.split('.')[1];
+  if (!payload) return null;
+  try {
+    const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+    const sub = (JSON.parse(json) as { sub?: unknown }).sub;
+    return typeof sub === 'string' && sub.length > 0 ? sub : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function setJwt(token: string): Promise<void> {
   await SecureStore.setItemAsync(TOKEN_KEY, token);
 }

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/ReviewsClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/ReviewsClient.tsx
@@ -4,8 +4,10 @@ import { useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   createReview,
+  deleteReview,
   fetchReviews,
   reportReview,
+  updateReview,
   ReviewError,
   type ReviewPayload,
   type ReviewsResponse,
@@ -27,10 +29,13 @@ export function ReviewsClient({
   itemId,
   restaurantSlug,
   initial,
+  currentUserId = null,
 }: {
   itemId: string;
   restaurantSlug: string;
   initial: ReviewsResponse;
+  /** Legal remediation E11 — drives the owner-only edit/delete controls. */
+  currentUserId?: string | null;
 }) {
   const router = useRouter();
 
@@ -38,6 +43,14 @@ export function ReviewsClient({
   const [total, setTotal] = useState(initial.total);
   const [loadingMore, setLoadingMore] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
+
+  // E11 — keep the local list in sync after an in-place edit / delete.
+  const onUpdated = (saved: ReviewPayload) =>
+    setReviews((prev) => prev.map((r) => (r.id === saved.id ? saved : r)));
+  const onDeleted = (id: string) => {
+    setReviews((prev) => prev.filter((r) => r.id !== id));
+    setTotal((n) => Math.max(0, n - 1));
+  };
 
   const loadMore = async () => {
     try {
@@ -92,7 +105,13 @@ export function ReviewsClient({
 
       <ul className="mt-bw-4 divide-y divide-zinc-100">
         {reviews.map((r) => (
-          <ReviewCard key={r.id} review={r} />
+          <ReviewCard
+            key={r.id}
+            review={r}
+            isOwner={currentUserId != null && r.user.id === currentUserId}
+            onUpdated={onUpdated}
+            onDeleted={onDeleted}
+          />
         ))}
         {reviews.length === 0 && (
           <li className="py-bw-6 text-center text-bw-sm text-zinc-500">
@@ -116,7 +135,35 @@ export function ReviewsClient({
   );
 }
 
-function ReviewCard({ review }: { review: ReviewPayload }) {
+function ReviewCard({
+  review,
+  isOwner,
+  onUpdated,
+  onDeleted,
+}: {
+  review: ReviewPayload;
+  isOwner: boolean;
+  onUpdated: (saved: ReviewPayload) => void;
+  onDeleted: (id: string) => void;
+}) {
+  // E11 — the author can edit their own review inline or delete it.
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <li className="py-bw-3" data-testid={`review-${review.id}`}>
+        <EditReviewForm
+          review={review}
+          onCancel={() => setEditing(false)}
+          onSaved={(saved) => {
+            onUpdated(saved);
+            setEditing(false);
+          }}
+        />
+      </li>
+    );
+  }
+
   return (
     <li className="py-bw-3" data-testid={`review-${review.id}`}>
       <p className="text-bw-sm font-semibold text-zinc-900">
@@ -137,8 +184,172 @@ function ReviewCard({ review }: { review: ReviewPayload }) {
           className="mt-bw-2 max-h-80 w-full rounded-bw-md object-cover"
         />
       )}
-      <ReportControl reviewId={review.id} />
+      {isOwner ? (
+        <OwnerControls
+          reviewId={review.id}
+          onEdit={() => setEditing(true)}
+          onDeleted={() => onDeleted(review.id)}
+        />
+      ) : (
+        <ReportControl reviewId={review.id} />
+      )}
     </li>
+  );
+}
+
+/**
+ * Legal remediation E11 — owner-only edit/delete. The author can
+ * correct or remove their own review (the Privacy Policy "correct your
+ * data" right, in-app rather than by email). The API still gates by
+ * ownership; these controls only render for the author.
+ */
+function OwnerControls({
+  reviewId,
+  onEdit,
+  onDeleted,
+}: {
+  reviewId: string;
+  onEdit: () => void;
+  onDeleted: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const remove = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await deleteReview(reviewId);
+      onDeleted();
+    } catch (e) {
+      setError((e as Error).message);
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-1 flex items-center gap-bw-3">
+      <button
+        type="button"
+        onClick={onEdit}
+        data-testid={`edit-${reviewId}`}
+        className="text-bw-xs font-semibold text-bite hover:text-bite-dark"
+      >
+        Edit
+      </button>
+      {confirming ? (
+        <>
+          <span className="text-bw-xs text-zinc-500">Delete this review?</span>
+          <button
+            type="button"
+            onClick={remove}
+            disabled={busy}
+            data-testid={`confirm-delete-${reviewId}`}
+            className="text-bw-xs font-semibold text-bite-dark hover:underline"
+          >
+            {busy ? 'Deleting…' : 'Yes, delete'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="text-bw-xs font-semibold text-zinc-400 hover:text-zinc-600"
+          >
+            Cancel
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          data-testid={`delete-${reviewId}`}
+          className="text-bw-xs font-semibold text-zinc-400 hover:text-zinc-600"
+        >
+          Delete
+        </button>
+      )}
+      {error && <span className="text-bw-xs text-bite-dark">{error}</span>}
+    </div>
+  );
+}
+
+/** E11 — inline edit form for the author's own review (rating + body). */
+function EditReviewForm({
+  review,
+  onCancel,
+  onSaved,
+}: {
+  review: ReviewPayload;
+  onCancel: () => void;
+  onSaved: (saved: ReviewPayload) => void;
+}) {
+  const [rating, setRating] = useState(review.rating);
+  const [body, setBody] = useState(review.body ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const saved = await updateReview(review.id, { rating, body: body.trim() || null });
+      onSaved(saved);
+    } catch (e) {
+      setError((e as Error).message);
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} data-testid={`edit-form-${review.id}`}>
+      <div className="flex items-center gap-1">
+        {[1, 2, 3, 4, 5].map((n) => (
+          <button
+            type="button"
+            key={n}
+            onClick={() => setRating(n)}
+            data-testid={`edit-star-${review.id}-${n}`}
+            aria-pressed={rating >= n}
+            className={['text-2xl', rating >= n ? 'text-bite' : 'text-zinc-300'].join(' ')}
+          >
+            ★
+          </button>
+        ))}
+      </div>
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        aria-label={`edit-body-${review.id}`}
+        rows={3}
+        className="mt-bw-2 w-full rounded-bw-md border border-zinc-300 p-bw-2 text-bw-base"
+      />
+      {error && (
+        <p className="mt-bw-2 rounded-bw-md bg-bite-light px-bw-2 py-bw-1 text-bw-xs text-bite-dark">
+          {error}
+        </p>
+      )}
+      <div className="mt-bw-2 flex items-center justify-end gap-bw-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-bw-sm font-semibold text-zinc-500 hover:text-zinc-700"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          data-testid={`save-edit-${review.id}`}
+          className={[
+            'rounded-bw-md bg-bite px-bw-3 py-bw-1 text-bw-sm font-bold text-white',
+            saving ? 'opacity-60' : 'hover:bg-bite-dark',
+          ].join(' ')}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </form>
   );
 }
 

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/__tests__/ReviewsClient.test.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/__tests__/ReviewsClient.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Legal remediation E11 — the review author gets in-app edit + delete
+ * controls; everyone else gets "Report". The API still enforces
+ * ownership, so these tests assert the UI gating + that the wired
+ * update/delete calls fire.
+ */
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+const mockReport = vi.fn();
+vi.mock('../../../../../../lib/reviews', () => ({
+  createReview: vi.fn(),
+  fetchReviews: vi.fn(),
+  reportReview: (...a: unknown[]) => mockReport(...a),
+  updateReview: (...a: unknown[]) => mockUpdate(...a),
+  deleteReview: (...a: unknown[]) => mockDelete(...a),
+  ReviewError: class extends Error {},
+}));
+vi.mock('../../../../_PostHogProvider', () => ({ useTracker: () => ({ track: vi.fn() }) }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ replace: vi.fn() }) }));
+
+import { ReviewsClient } from '../ReviewsClient';
+
+const review = (over = {}) => ({
+  id: 'rev-1',
+  item_id: 'item-1',
+  user: { id: 'user-1', handle: 'mine', display_name: 'Mine' },
+  rating: 3,
+  body: 'Decent.',
+  photo_url: null,
+  created_at: '2026-06-14T00:00:00Z',
+  updated_at: '2026-06-14T00:00:00Z',
+  ...over,
+});
+
+const initial = (reviews: ReturnType<typeof review>[]) => ({
+  item_id: 'item-1',
+  reviews,
+  total: reviews.length,
+});
+
+beforeEach(() => {
+  mockUpdate.mockReset();
+  mockDelete.mockReset();
+  mockReport.mockReset();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('ReviewsClient — owner edit/delete (E11)', () => {
+  it('shows Edit/Delete on the owner’s review and Report on others’', () => {
+    render(
+      <ReviewsClient
+        itemId="item-1"
+        restaurantSlug="r"
+        currentUserId="user-1"
+        initial={initial([review(), review({ id: 'rev-2', user: { id: 'user-2', handle: 'x', display_name: 'X' } })])}
+      />,
+    );
+    expect(screen.getByTestId('edit-rev-1')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-rev-1')).toBeInTheDocument();
+    // The other user's review is reportable, not editable.
+    expect(screen.getByTestId('report-rev-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('edit-rev-2')).toBeNull();
+  });
+
+  it('signed-out users get Report, never owner controls', () => {
+    render(
+      <ReviewsClient itemId="item-1" restaurantSlug="r" currentUserId={null} initial={initial([review()])} />,
+    );
+    expect(screen.getByTestId('report-rev-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('edit-rev-1')).toBeNull();
+  });
+
+  it('edits in place via updateReview and reflects the saved review', async () => {
+    mockUpdate.mockResolvedValue(review({ rating: 5, body: 'Amazing now.' }));
+    render(
+      <ReviewsClient itemId="item-1" restaurantSlug="r" currentUserId="user-1" initial={initial([review()])} />,
+    );
+
+    fireEvent.click(screen.getByTestId('edit-rev-1'));
+    fireEvent.click(screen.getByTestId('edit-star-rev-1-5'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('save-edit-rev-1'));
+    });
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate.mock.calls[0]![0]).toBe('rev-1');
+    expect(mockUpdate.mock.calls[0]![1]).toMatchObject({ rating: 5 });
+    expect(await screen.findByText('Amazing now.')).toBeInTheDocument();
+  });
+
+  it('deletes via deleteReview after confirming and removes the card', async () => {
+    mockDelete.mockResolvedValue(undefined);
+    render(
+      <ReviewsClient itemId="item-1" restaurantSlug="r" currentUserId="user-1" initial={initial([review()])} />,
+    );
+
+    fireEvent.click(screen.getByTestId('delete-rev-1'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('confirm-delete-rev-1'));
+    });
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('rev-1'));
+    expect(screen.queryByTestId('review-rev-1')).toBeNull();
+  });
+});

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   type RestaurantItem,
 } from '../../../../../lib/restaurants';
 import { fetchReviewsServer, type ReviewsResponse } from '../../../../../lib/reviews';
+import { getServerUserId } from '../../../../../lib/server-auth';
 import { ReviewsClient } from './ReviewsClient';
 import { SuggestFixClient } from './SuggestFixClient';
 
@@ -28,16 +29,22 @@ export default async function ItemDetailPage({
 }) {
   const { slug, id } = await params;
 
-  const [restaurant, item, initialReviews] = await Promise.all([
+  const [restaurant, item, initialReviews, currentUserId] = await Promise.all([
     fetchRestaurant(slug).catch(() => null),
     fetchItem(slug, id).catch(() => null),
     fetchReviewsServer(id).catch(() => null),
+    getServerUserId(),
   ]);
 
   if (!restaurant || !item) notFound();
 
   return (
-    <Page restaurant={restaurant} item={item} initialReviews={initialReviews ?? emptyReviews(id)} />
+    <Page
+      restaurant={restaurant}
+      item={item}
+      initialReviews={initialReviews ?? emptyReviews(id)}
+      currentUserId={currentUserId}
+    />
   );
 }
 
@@ -45,10 +52,12 @@ function Page({
   restaurant,
   item,
   initialReviews,
+  currentUserId,
 }: {
   restaurant: Restaurant;
   item: RestaurantItem;
   initialReviews: ReviewsResponse;
+  currentUserId: string | null;
 }) {
   return (
     <main className="mx-auto max-w-3xl px-bw-6 py-bw-12">
@@ -62,7 +71,12 @@ function Page({
         <p className="mt-bw-2 text-bw-base text-zinc-700">{item.description}</p>
       )}
 
-      <ReviewsClient itemId={item.id} restaurantSlug={restaurant.slug} initial={initialReviews} />
+      <ReviewsClient
+        itemId={item.id}
+        restaurantSlug={restaurant.slug}
+        initial={initialReviews}
+        currentUserId={currentUserId}
+      />
       <SuggestFixClient itemId={item.id} restaurantSlug={restaurant.slug} />
     </main>
   );

--- a/apps/web/src/lib/server-auth.ts
+++ b/apps/web/src/lib/server-auth.ts
@@ -21,3 +21,27 @@ export async function getServerJwt(): Promise<string | null> {
   const value = jar.get(SESSION_COOKIE)?.value;
   return value && value.length > 0 ? value : null;
 }
+
+/**
+ * The signed-in user's id, read from the JWT's `sub` claim (devise-jwt
+ * puts the user id there). Used only to decide which UI to show — e.g.
+ * the owner-only edit/delete controls on a review (E11). We do NOT
+ * verify the signature here: the server still gates every mutation by
+ * ownership (403), so a forged id only changes which buttons render,
+ * never what the API allows. Returns null when signed out or malformed.
+ */
+export async function getServerUserId(): Promise<string | null> {
+  const jwt = await getServerJwt();
+  if (!jwt) return null;
+  const payload = jwt.split('.')[1];
+  if (!payload) return null;
+  try {
+    const json = Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString(
+      'utf8',
+    );
+    const sub = (JSON.parse(json) as { sub?: unknown }).sub;
+    return typeof sub === 'string' && sub.length > 0 ? sub : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

**Legal remediation E11** — wires the existing review `PATCH`/`DELETE` API into the UI so a user can correct or remove **their own** review in-app (the Privacy Policy *"correct your data"* right), not just by email (alignment-matrix row 5).

- **Web** (`ReviewsClient`): the author sees inline **Edit** (rating + body) and **Delete** (with a confirm step); everyone else still sees **Report** (E8). The list updates in place on save/delete.
- **Mobile** (`items/[id]`): the same Edit/Delete on the author's own cards.
- **Owner detection** uses the JWT `sub` claim — `getServerUserId()` (web SSR) / `getUserId()` (mobile). It's **display-only**: the API still gates every mutation by ownership (403), so a forged id only changes which buttons render, never what the server allows — so no signature verification is needed.

No API change — `updateReview`/`deleteReview` already existed.

## Verification
- web **178** (+4 `ReviewsClient` tests: owner-vs-other gating, signed-out → Report only, edit-in-place, delete-removes-card)
- mobile **129**; `pnpm typecheck` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)