### PR TITLE
feat(api): rack-attack request throttling (E12)

### DIFF
--- a/apps/api/Gemfile
+++ b/apps/api/Gemfile
@@ -15,6 +15,9 @@ gem "solid_cable"
 # --- API ---------------------------------------------------------------------
 gem "jbuilder"
 gem "rack-cors"
+# Legal remediation E12 — request throttling so "don't scrape the API"
+# (ToS Acceptable use) is enforced, not just stated.
+gem "rack-attack"
 gem "rswag-api"
 gem "rswag-ui"
 

--- a/apps/api/Gemfile.lock
+++ b/apps/api/Gemfile.lock
@@ -328,6 +328,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
@@ -538,6 +540,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   pg (~> 1.5)
   puma (~> 8.0)
+  rack-attack
   rack-cors
   rails (~> 8.1.3)
   rspec-rails (~> 8.0)
@@ -679,6 +682,7 @@ CHECKSUMS
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
   rack-cors (3.0.0) sha256=7b95be61db39606906b61b83bd7203fa802b0ceaaad8fcb2fef39e097bf53f68
   rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8

--- a/apps/api/config/initializers/rack_attack.rb
+++ b/apps/api/config/initializers/rack_attack.rb
@@ -8,6 +8,17 @@
 # Disabled in the test env by default so the request specs (which fire
 # many requests from 127.0.0.1) don't trip a throttle — the dedicated
 # throttle spec flips `Rack::Attack.enabled` on with its own cache.
+#
+# OPERATIONAL CAVEAT (per-IP attribution): throttling keys on `req.ip`,
+# which is the real client only for traffic that reaches Rails directly
+# (mobile) or through a proxy that sets `X-Forwarded-For` and that Rails
+# trusts. The web app proxies some calls server-side (auth, profile,
+# dmca, review mutations), so those arrive from the Next server's IP —
+# meaning web users would share one bucket and could trip the tight auth
+# throttle together. Before relying on per-client auth throttling in
+# production, forward the client IP from the Next proxy (X-Forwarded-For)
+# and trust it in Rails; otherwise treat the auth limit as a per-edge
+# guard, not per-user.
 class Rack::Attack
   # In-memory counter store. Single-process is fine for the launch
   # footprint; swap to a shared store (Solid Cache / Redis) when the API

--- a/apps/api/config/initializers/rack_attack.rb
+++ b/apps/api/config/initializers/rack_attack.rb
@@ -1,0 +1,42 @@
+# Legal remediation E12 — API request throttling (rack-attack).
+#
+# Backs the ToS "don't scrape the API at a rate that affects other
+# users" rule with actual enforcement, and gives brute-force protection
+# on the auth endpoints. rack-attack inserts its middleware via its
+# Railtie; this file only defines the rules.
+#
+# Disabled in the test env by default so the request specs (which fire
+# many requests from 127.0.0.1) don't trip a throttle — the dedicated
+# throttle spec flips `Rack::Attack.enabled` on with its own cache.
+class Rack::Attack
+  # In-memory counter store. Single-process is fine for the launch
+  # footprint; swap to a shared store (Solid Cache / Redis) when the API
+  # runs multiple processes and per-process buckets stop being accurate.
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  # General per-IP ceiling across the whole API surface. Generous enough
+  # that a normal session never notices; low enough that a scraper does.
+  throttle("api/ip", limit: 300, period: 5.minutes) do |req|
+    req.ip if req.path.start_with?("/api/")
+  end
+
+  # Tighter ceiling on the auth endpoints (login + signup) to blunt
+  # credential-stuffing / account-enumeration bursts.
+  throttle("auth/ip", limit: 10, period: 20.seconds) do |req|
+    req.ip if req.post? && req.path.start_with?("/api/v1/auth/")
+  end
+
+  # JSON 429 with a Retry-After so clients can back off politely.
+  self.throttled_responder = lambda do |request|
+    match_data = request.env["rack.attack.match_data"] || {}
+    retry_after = (match_data[:period] || 60).to_i
+    [
+      429,
+      { "Content-Type" => "application/json", "Retry-After" => retry_after.to_s },
+      [{ error: "Too many requests. Please slow down and try again shortly." }.to_json]
+    ]
+  end
+end
+
+# Off in test unless a spec explicitly enables it (see the throttle spec).
+Rack::Attack.enabled = false if Rails.env.test?

--- a/apps/api/spec/requests/api/v1/rate_limiting_spec.rb
+++ b/apps/api/spec/requests/api/v1/rate_limiting_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+# Legal remediation E12 — rack-attack throttling. It's disabled in the
+# test env by default (so the rest of the request specs aren't throttled
+# from 127.0.0.1); this spec turns it on with a fresh in-memory counter.
+RSpec.describe "API rate limiting (legal E12)", type: :request do
+  around do |example|
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    example.run
+  ensure
+    Rack::Attack.enabled = false
+    Rack::Attack.reset!
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  it "throttles a burst of auth requests from one IP with 429 + Retry-After" do
+    # auth/ip rule: 10 per 20s. The 11th from the same IP is throttled
+    # before it reaches the controller (the bad creds never matter).
+    11.times do
+      post "/api/v1/auth/login",
+           params: { user: { email: "x@example.com", password: "wrong-password" } },
+           as: :json
+    end
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(response.headers["Retry-After"]).to be_present
+    expect(response.parsed_body["error"]).to match(/too many requests/i)
+  end
+
+  it "lets traffic under the limit through" do
+    post "/api/v1/auth/login",
+         params: { user: { email: "x@example.com", password: "wrong-password" } },
+         as: :json
+    expect(response).not_to have_http_status(:too_many_requests)
+  end
+end


### PR DESCRIPTION
## What

**Legal remediation E12** (optional/low-priority) — enforces the ToS *"don't scrape the API at a rate that affects other users"* rule instead of only stating it, and adds brute-force protection on auth (alignment-matrix row 17).

- **rack-attack** with two throttles:
  - general **300 req / 5 min** per IP across `/api/`
  - tighter **10 req / 20s** per IP on `POST /api/v1/auth/*` (login + signup)
  - throttled responses are **429 + Retry-After** + a JSON error body.
- **Disabled in the test env by default** so the existing request specs (many requests from 127.0.0.1) aren't throttled; the dedicated throttle spec flips it on with its own in-memory counter and asserts the 11th auth request in a burst returns 429.

Single-process `MemoryStore` counter for the launch footprint — noted in the initializer to move to a shared store (Solid Cache / Redis) once the API runs multiple processes.

## Verification
- `bundle exec rspec` → 495 examples, 0 failures (rack-attack off in test doesn't affect other specs; throttle spec proves the 429 path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)