### PR TITLE
feat(web): conspicuous ToS disclaimers + at-your-own-risk footer

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -17,7 +17,34 @@ export default function RootLayout({ children }: { children: ReactNode }): React
     <html lang="en">
       <body className="bg-white text-zinc-900 antialiased">
         <PostHogProvider>{children}</PostHogProvider>
+        <SiteDisclaimer />
       </body>
     </html>
+  );
+}
+
+/**
+ * Slim, site-wide legal disclaimer shown on every page. A plain-language
+ * "at your own risk" line keeps the AS-IS / not-a-guarantee message in
+ * front of users everywhere, not only on the Terms page.
+ */
+function SiteDisclaimer(): ReactElement {
+  return (
+    <footer
+      role="contentinfo"
+      data-testid="site-disclaimer"
+      className="border-t border-zinc-200 px-6 py-4 text-center text-xs text-zinc-500"
+    >
+      BiteWorthy is a planning aid, not a guarantee — dietary info can be wrong or out of date, so
+      always confirm with the restaurant. Use at your own risk. See our{' '}
+      <a href="/terms" className="underline hover:text-zinc-700">
+        Terms
+      </a>{' '}
+      and{' '}
+      <a href="/privacy" className="underline hover:text-zinc-700">
+        Privacy Policy
+      </a>
+      .
+    </footer>
   );
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -29,9 +29,12 @@ export default function RootLayout({ children }: { children: ReactNode }): React
  * front of users everywhere, not only on the Terms page.
  */
 function SiteDisclaimer(): ReactElement {
+  // role="note", not a <footer>/contentinfo landmark — pages like the
+  // marketing landing already have their own footer, and a second
+  // contentinfo landmark is an accessibility smell.
   return (
-    <footer
-      role="contentinfo"
+    <div
+      role="note"
       data-testid="site-disclaimer"
       className="border-t border-zinc-200 px-6 py-4 text-center text-xs text-zinc-500"
     >
@@ -45,6 +48,6 @@ function SiteDisclaimer(): ReactElement {
         Privacy Policy
       </a>
       .
-    </footer>
+    </div>
   );
 }

--- a/apps/web/src/app/terms/__tests__/page.test.tsx
+++ b/apps/web/src/app/terms/__tests__/page.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TermsPage from '../page';
+
+/**
+ * Risk-reduction follow-up — the protective disclaimers only help if
+ * they're conspicuous. These assert the prominent "use at your own
+ * risk" summary box and that the AS-IS warranty + liability language is
+ * present in its conspicuous (uppercase) form.
+ */
+describe('TermsPage — conspicuous disclaimers', () => {
+  it('shows the top-of-page "use at your own risk" summary box', () => {
+    render(<TermsPage />);
+    const box = screen.getByTestId('summary-disclaimer');
+    expect(box).toHaveTextContent(/use at your own risk/i);
+    expect(box).toHaveTextContent(/confirm with the restaurant/i);
+  });
+
+  it('renders the AS-IS warranty + liability disclaimers conspicuously (uppercase)', () => {
+    render(<TermsPage />);
+    // The operative clauses are capitalized so they're "conspicuous".
+    // ("AS IS"/"AS AVAILABLE" sit in their own <strong> nodes, so match
+    // a phrase that lives in a single text node.)
+    expect(screen.getByText(/WITHOUT WARRANTIES OF ANY KIND/)).toBeInTheDocument();
+    expect(screen.getByText(/TO THE MAXIMUM EXTENT PERMITTED BY LAW/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -42,6 +42,8 @@ export default function TermsPage(): ReactElement {
 
       <DraftBanner />
 
+      <SummaryDisclaimer />
+
       <article className="prose prose-zinc mt-bw-8 max-w-none text-zinc-800">
         <Section title="Acceptance of these terms">
           <p>
@@ -89,27 +91,41 @@ export default function TermsPage(): ReactElement {
         </Section>
 
         <Section title="Disclaimer of warranties">
-          <p>
-            BiteWorthy is provided <strong>“as is”</strong> and <strong>“as available,”</strong>{' '}
-            without warranties of any kind, whether express or implied — including implied
-            warranties of merchantability, fitness for a particular purpose, accuracy, and
-            non-infringement. We do not warrant that the dietary information is accurate, complete,
-            or current, or that the service will be uninterrupted or error-free. Some jurisdictions
-            don’t allow the exclusion of certain warranties, so parts of this may not apply to you.
-          </p>
+          {/*
+            Conspicuous per UCC §2-316 — a warranty disclaimer must stand
+            out to be enforceable, so the operative language is boxed and
+            partly capitalized rather than buried in prose.
+          */}
+          <Conspicuous>
+            <p>
+              BITEWORTHY IS PROVIDED <strong>“AS IS”</strong> AND{' '}
+              <strong>“AS AVAILABLE,”</strong> WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR
+              IMPLIED — INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+              PARTICULAR PURPOSE, ACCURACY, AND NON-INFRINGEMENT.
+            </p>
+            <p className="mt-bw-2">
+              We do not warrant that the dietary information is accurate, complete, or current, or
+              that the service will be uninterrupted or error-free. Some jurisdictions don’t allow
+              the exclusion of certain warranties, so parts of this may not apply to you.
+            </p>
+          </Conspicuous>
         </Section>
 
         <Section title="Limitation of liability">
-          <p>
-            To the maximum extent permitted by law, BiteWorthy and its operators will not be liable
-            for any indirect, incidental, special, consequential, or punitive damages, or for any
-            loss arising from your reliance on the dietary information — including any allergic
-            reaction, illness, or injury. Our total liability for any claim relating to the service
-            is limited to USD 100. Some jurisdictions don’t allow these limitations, and{' '}
-            <strong>
-              nothing in these Terms limits any liability that can’t be limited by law.
-            </strong>
-          </p>
+          <Conspicuous>
+            <p>
+              TO THE MAXIMUM EXTENT PERMITTED BY LAW, BITEWORTHY AND ITS OPERATORS WILL NOT BE
+              LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR
+              FOR ANY LOSS ARISING FROM YOUR RELIANCE ON THE DIETARY INFORMATION — INCLUDING ANY
+              ALLERGIC REACTION, ILLNESS, OR INJURY. OUR TOTAL LIABILITY FOR ANY CLAIM RELATING TO
+              THE SERVICE IS LIMITED TO USD 100.
+            </p>
+            <p className="mt-bw-2">
+              Some jurisdictions don’t allow these limitations, and{' '}
+              <strong>nothing in these Terms limits any liability that can’t be limited by law</strong>
+              .
+            </p>
+          </Conspicuous>
         </Section>
 
         <Section title="Indemnification">
@@ -251,6 +267,42 @@ function DraftBanner(): ReactElement {
     >
       <strong>Draft.</strong> Has not yet had final lawyer review; the launch checklist (Phase 5.9)
       requires that pass before App Store / Play Store submission.
+    </div>
+  );
+}
+
+/**
+ * A prominent, plain-language "read this first" disclaimer at the top of
+ * the Terms. Conspicuous on purpose — the protective clauses below only
+ * help if a user can't miss the gist.
+ */
+function SummaryDisclaimer(): ReactElement {
+  return (
+    <div
+      role="note"
+      data-testid="summary-disclaimer"
+      className="mt-bw-4 rounded-bw-md border-2 border-bite/50 bg-bite-light p-bw-4 text-bw-base text-bite-dark"
+    >
+      <p className="font-bold uppercase tracking-wide">Please read — use at your own risk</p>
+      <p className="mt-bw-2">
+        BiteWorthy is a planning aid, not a guarantee of safety. The dietary information can be
+        wrong, incomplete, out of date, or mislabeled, and a dish that isn’t safe for you can still
+        appear in your results. <strong>Always confirm with the restaurant before you order</strong>
+        , especially for a serious allergy. Your use of BiteWorthy is at your own risk; see the
+        allergen disclaimer and limitation of liability below.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Conspicuous callout for the warranty + liability disclaimers — boxed
+ * and set off so they're "conspicuous" (UCC §2-316) rather than buried.
+ */
+function Conspicuous({ children }: { children: ReactElement | ReactElement[] }): ReactElement {
+  return (
+    <div className="rounded-bw-md border border-zinc-300 bg-zinc-50 p-bw-4 text-bw-sm font-semibold text-zinc-900">
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## What

Risk-reduction follow-up (the "use at your own risk" hardening). The protective clauses from Phase 1 only help if users can't miss them and they're legally **conspicuous**.

- **Terms page**: a prominent top-of-page *"Please read — use at your own risk"* summary box; the **AS-IS warranty disclaimer** + **limitation of liability** are now boxed, set off, and partly uppercased so they're "conspicuous" under **UCC §2-316** (an inconspicuous warranty disclaimer can be struck) instead of buried in prose.
- **Site-wide footer** (root layout): a slim, every-page line — *"planning aid, not a guarantee — confirm with the restaurant; use at your own risk"* — with Terms/Privacy links.

DRAFT banners stay until L1 attorney review.

## Verification
- web **180** (+2 terms-page tests for the summary box + conspicuous clauses), `pnpm typecheck` + `pnpm lint` clean, no mojibake (real glyphs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)