### PR TITLE
feat(api): clickwrap Terms acceptance at signup

### DIFF
--- a/apps/api/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/apps/api/app/controllers/api/v1/auth/registrations_controller.rb
@@ -23,8 +23,19 @@ module Api
             }, status: :unprocessable_entity
           end
 
+          # Clickwrap assent — the client must affirmatively agree to the
+          # Terms + Privacy Policy. Recorded as terms_accepted_at, which
+          # is what makes the ToS (incl. arbitration + class waiver)
+          # enforceable rather than weak browsewrap.
+          unless ActiveModel::Type::Boolean.new.cast(params.dig(:user, :terms_acceptance))
+            return render json: {
+              errors: { terms_acceptance: ["You must agree to the Terms of Service and Privacy Policy."] }
+            }, status: :unprocessable_entity
+          end
+
           build_resource(sign_up_params)
           resource.age_confirmed_at = Time.current
+          resource.terms_accepted_at = Time.current
 
           if resource.save
             sign_in(resource_name, resource, store: false)

--- a/apps/api/db/migrate/20260614150000_add_terms_accepted_at_to_users.rb
+++ b/apps/api/db/migrate/20260614150000_add_terms_accepted_at_to_users.rb
@@ -1,0 +1,11 @@
+# Risk-reduction follow-up — records that the user affirmatively agreed
+# to the Terms of Service + Privacy Policy at signup (clickwrap). An
+# explicit, recorded acceptance is what makes the ToS — including the
+# arbitration clause + class-action waiver — enforceable, versus weak
+# "by using the site you agree" browsewrap. Nullable: accounts created
+# before the clickwrap (and OAuth accounts) have no stamp.
+class AddTermsAcceptedAtToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :terms_accepted_at, :datetime, null: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_14_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -411,6 +411,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_140000) do
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.integer "sign_in_count", default: 0, null: false
+    t.datetime "terms_accepted_at"
     t.string "uid"
     t.string "unconfirmed_email"
     t.datetime "updated_at", null: false

--- a/apps/api/spec/integration/api/v1/auth/signup_spec.rb
+++ b/apps/api/spec/integration/api/v1/auth/signup_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "auth/signup", type: :request do
         properties: {
           user: {
             type: :object,
-            required: %w[email password password_confirmation handle age_confirmation],
+            required: %w[email password password_confirmation handle age_confirmation terms_acceptance],
             properties: {
               email:                 { type: :string, format: :email },
               password:              { type: :string, minLength: 8 },
@@ -21,7 +21,10 @@ RSpec.describe "auth/signup", type: :request do
               display_name:          { type: :string, nullable: true },
               # Legal remediation E4 — must be true; the user affirms the
               # 13+ minimum. The server stamps users.age_confirmed_at.
-              age_confirmation:      { type: :boolean }
+              age_confirmation:      { type: :boolean },
+              # Clickwrap — must be true; the user agrees to the Terms +
+              # Privacy Policy. The server stamps users.terms_accepted_at.
+              terms_acceptance:      { type: :boolean }
             }
           }
         }
@@ -32,10 +35,12 @@ RSpec.describe "auth/signup", type: :request do
         let(:user) do
           { user: { email: "fresh@example.com", password: "password123",
                     password_confirmation: "password123", handle: "fresh_user",
-                    display_name: "Fresh User", age_confirmation: true } }
+                    display_name: "Fresh User", age_confirmation: true, terms_acceptance: true } }
         end
         run_test! do
-          expect(User.find_by(email: "fresh@example.com").age_confirmed_at).to be_present
+          created = User.find_by(email: "fresh@example.com")
+          expect(created.age_confirmed_at).to be_present
+          expect(created.terms_accepted_at).to be_present
         end
       end
 
@@ -45,7 +50,7 @@ RSpec.describe "auth/signup", type: :request do
           create(:user, email: "taken@example.com")
           { user: { email: "taken@example.com", password: "password123",
                     password_confirmation: "password123", handle: "taken_user",
-                    age_confirmation: true } }
+                    age_confirmation: true, terms_acceptance: true } }
         end
         run_test!
       end
@@ -54,10 +59,23 @@ RSpec.describe "auth/signup", type: :request do
         schema "$ref" => "#/components/schemas/ValidationErrors"
         let(:user) do
           { user: { email: "minor@example.com", password: "password123",
-                    password_confirmation: "password123", handle: "young_user" } }
+                    password_confirmation: "password123", handle: "young_user",
+                    terms_acceptance: true } }
         end
         run_test! do
           expect(User.find_by(email: "minor@example.com")).to be_nil
+        end
+      end
+
+      response(422, "terms not accepted — clickwrap gate") do
+        schema "$ref" => "#/components/schemas/ValidationErrors"
+        let(:user) do
+          { user: { email: "noterms@example.com", password: "password123",
+                    password_confirmation: "password123", handle: "no_terms",
+                    age_confirmation: true } }
+        end
+        run_test! do
+          expect(User.find_by(email: "noterms@example.com")).to be_nil
         end
       end
     end

--- a/apps/api/spec/requests/api/v1/auth/signup_spec.rb
+++ b/apps/api/spec/requests/api/v1/auth/signup_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe "POST /api/v1/auth/signup", type: :request do
         handle: "new_user",
         display_name: "New User",
         # Legal remediation E4 — the 13+ affirmation is required.
-        age_confirmation: true
+        age_confirmation: true,
+        # Clickwrap — agreeing to the Terms + Privacy Policy is required.
+        terms_acceptance: true
       }
     }
   end
@@ -29,8 +31,9 @@ RSpec.describe "POST /api/v1/auth/signup", type: :request do
     user = User.find_by(email: "new@example.com")
     expect(user.profile).to be_present
     expect(user.profile.strictness).to eq("balanced")
-    # Legal remediation E4 — the affirmation is recorded server-side.
+    # Affirmations are recorded server-side.
     expect(user.age_confirmed_at).to be_present
+    expect(user.terms_accepted_at).to be_present
   end
 
   it "rejects signup without the 13+ age confirmation (legal E4)" do
@@ -42,6 +45,17 @@ RSpec.describe "POST /api/v1/auth/signup", type: :request do
 
     expect(response).to have_http_status(:unprocessable_entity)
     expect(response.parsed_body["errors"]).to have_key("age_confirmation")
+  end
+
+  it "rejects signup without agreeing to the Terms (clickwrap)" do
+    expect {
+      post "/api/v1/auth/signup",
+           params: valid_params.tap { |p| p[:user].delete(:terms_acceptance) },
+           as: :json
+    }.not_to change(User, :count)
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.parsed_body["errors"]).to have_key("terms_acceptance")
   end
 
   it "rejects a duplicate email with 422" do

--- a/apps/mobile/__tests__/lib/auth.test.ts
+++ b/apps/mobile/__tests__/lib/auth.test.ts
@@ -106,13 +106,16 @@ describe('signup', () => {
       { user: { id: 'u2', email: 'b@c.com', handle: null, display_name: null } },
       { Authorization: 'Bearer fresh.token.here' },
     );
-    await signup('b@c.com', 'longerpw1', true, { fetchImpl });
+    await signup('b@c.com', 'longerpw1', true, true, { fetchImpl });
     const url = String(fetchImpl.mock.calls[0]![0]);
     expect(url).toContain('/api/v1/auth/signup');
     expect(await getJwt()).toBe('fresh.token.here');
-    // Legal remediation E4 — the affirmation rides in the body.
+    // The affirmations ride in the body.
     const init = fetchImpl.mock.calls[0]![1] as RequestInit;
-    expect(JSON.parse(init.body as string).user).toMatchObject({ age_confirmation: true });
+    expect(JSON.parse(init.body as string).user).toMatchObject({
+      age_confirmation: true,
+      terms_acceptance: true,
+    });
   });
 });
 

--- a/apps/mobile/app/signup.tsx
+++ b/apps/mobile/app/signup.tsx
@@ -16,6 +16,7 @@ export default function SignupScreen() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [ageConfirmed, setAgeConfirmed] = useState(false);
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
   const onSubmit = async () => {
@@ -31,9 +32,13 @@ export default function SignupScreen() {
       Alert.alert('Age confirmation required', 'You must confirm you are at least 13 years old.');
       return;
     }
+    if (!termsAccepted) {
+      Alert.alert('Agreement required', 'You must agree to the Terms of Service and Privacy Policy.');
+      return;
+    }
     try {
       setSubmitting(true);
-      await signup(email, password, ageConfirmed);
+      await signup(email, password, ageConfirmed, termsAccepted);
       router.replace(next);
     } catch (err) {
       const status = err instanceof AuthError ? err.status : 0;
@@ -84,10 +89,33 @@ export default function SignupScreen() {
       </Pressable>
 
       <Pressable
+        accessibilityLabel="terms-accept"
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: termsAccepted }}
+        onPress={() => setTermsAccepted((v) => !v)}
+        style={styles.ageRow}
+      >
+        <View style={[styles.ageBox, termsAccepted && styles.ageBoxChecked]}>
+          {termsAccepted && <Text style={styles.ageCheck}>✓</Text>}
+        </View>
+        <Text style={styles.ageText}>
+          I agree to the{' '}
+          <Link href="/terms" style={styles.linkInline}>
+            Terms of Service
+          </Link>{' '}
+          and{' '}
+          <Link href="/privacy" style={styles.linkInline}>
+            Privacy Policy
+          </Link>
+          .
+        </Text>
+      </Pressable>
+
+      <Pressable
         accessibilityLabel="signup-submit"
         onPress={onSubmit}
-        disabled={submitting || !ageConfirmed}
-        style={[styles.primary, (submitting || !ageConfirmed) && { opacity: 0.5 }]}
+        disabled={submitting || !ageConfirmed || !termsAccepted}
+        style={[styles.primary, (submitting || !ageConfirmed || !termsAccepted) && { opacity: 0.5 }]}
       >
         {submitting ? (
           <ActivityIndicator color={colors.bg} />
@@ -164,6 +192,10 @@ const styles = StyleSheet.create({
   ageText: {
     fontSize: fontSize.sm,
     color: colors.text,
+  },
+  linkInline: {
+    color: colors.bite,
+    fontWeight: '600',
   },
   primary: {
     backgroundColor: colors.bite,

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -87,10 +87,14 @@ export async function signup(
   password: string,
   // Legal remediation E4 — the 13+ affirmation, sent as age_confirmation.
   ageConfirmation: boolean,
+  // Clickwrap — agreement to the Terms + Privacy Policy, sent as
+  // terms_acceptance.
+  termsAcceptance: boolean,
   opts: AuthOptions = {},
 ): Promise<UserPayload> {
   return await postCredentials('/api/v1/auth/signup', email, password, opts, {
     age_confirmation: ageConfirmation,
+    terms_acceptance: termsAcceptance,
   });
 }
 

--- a/apps/web/src/app/api/auth/[action]/route.ts
+++ b/apps/web/src/app/api/auth/[action]/route.ts
@@ -27,6 +27,8 @@ interface CredentialsBody {
   password?: string;
   // Legal remediation E4 — present on signup only; the 13+ affirmation.
   age_confirmation?: boolean;
+  // Clickwrap — present on signup only; agreement to Terms + Privacy.
+  terms_acceptance?: boolean;
 }
 
 export async function POST(
@@ -52,10 +54,16 @@ async function handleLoginOrSignup(action: string, body: CredentialsBody) {
   }
 
   const path = action === 'login' ? '/api/v1/auth/login' : '/api/v1/auth/signup';
-  // Forward the 13+ affirmation on signup only (login ignores it).
+  // Forward the signup affirmations (13+ + Terms agreement) on signup
+  // only; login ignores them.
   const user =
     action === 'signup'
-      ? { email: body.email, password: body.password, age_confirmation: body.age_confirmation }
+      ? {
+          email: body.email,
+          password: body.password,
+          age_confirmation: body.age_confirmation,
+          terms_acceptance: body.terms_acceptance,
+        }
       : { email: body.email, password: body.password };
   const upstream = await fetch(`${API_BASE}${path}`, {
     method: 'POST',

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -19,6 +19,7 @@ export default function SignupPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [ageConfirmed, setAgeConfirmed] = useState(false);
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,9 +38,13 @@ export default function SignupPage() {
       setError('You must confirm you are at least 13 years old.');
       return;
     }
+    if (!termsAccepted) {
+      setError('You must agree to the Terms of Service and Privacy Policy.');
+      return;
+    }
     try {
       setSubmitting(true);
-      await signup(email, password, ageConfirmed);
+      await signup(email, password, ageConfirmed, termsAccepted);
       // `next` is a runtime query value — typedRoutes can't prove it.
       router.replace(next as Route);
     } catch (err) {
@@ -96,6 +101,27 @@ export default function SignupPage() {
           <span>I am at least 13 years old.</span>
         </label>
 
+        <label className="flex items-start gap-bw-2 text-bw-sm text-zinc-700">
+          <input
+            type="checkbox"
+            checked={termsAccepted}
+            onChange={(e) => setTermsAccepted(e.target.checked)}
+            data-testid="terms-accept"
+            className="mt-bw-1 h-4 w-4 shrink-0"
+          />
+          <span>
+            I agree to the{' '}
+            <Link href="/terms" className="font-semibold text-bite hover:text-bite-dark">
+              Terms of Service
+            </Link>{' '}
+            and{' '}
+            <Link href="/privacy" className="font-semibold text-bite hover:text-bite-dark">
+              Privacy Policy
+            </Link>
+            .
+          </span>
+        </label>
+
         {error && (
           <p className="rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
             {error}
@@ -104,11 +130,11 @@ export default function SignupPage() {
 
         <button
           type="submit"
-          disabled={submitting || !ageConfirmed}
+          disabled={submitting || !ageConfirmed || !termsAccepted}
           data-testid="signup-submit"
           className={[
             'mt-bw-2 rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
-            submitting || !ageConfirmed ? 'opacity-60' : 'hover:bg-bite-dark',
+            submitting || !ageConfirmed || !termsAccepted ? 'opacity-60' : 'hover:bg-bite-dark',
           ].join(' ')}
         >
           {submitting ? 'Creating…' : 'Create account'}

--- a/apps/web/src/lib/__tests__/auth.test.ts
+++ b/apps/web/src/lib/__tests__/auth.test.ts
@@ -41,16 +41,19 @@ describe('login', () => {
 describe('signup', () => {
   it('POSTs to /api/auth/signup', async () => {
     const fetchImpl = fakeFetch(200, { user: { id: 'u2', email: 'b@c.com', handle: null, display_name: null } });
-    await signup('b@c.com', 'longerpw1', true, { fetchImpl });
+    await signup('b@c.com', 'longerpw1', true, true, { fetchImpl });
     expect(String(fetchImpl.mock.calls[0]![0])).toBe('/api/auth/signup');
-    // Legal remediation E4 — the affirmation rides in the body.
+    // The affirmations ride in the body.
     const init = fetchImpl.mock.calls[0]![1] as RequestInit;
-    expect(JSON.parse(init.body as string)).toMatchObject({ age_confirmation: true });
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      age_confirmation: true,
+      terms_acceptance: true,
+    });
   });
 
   it('throws AuthError on duplicate email', async () => {
     const fetchImpl = fakeFetch(422, { error: 'taken' });
-    await expect(signup('b@c.com', 'longerpw1', true, { fetchImpl })).rejects.toBeInstanceOf(AuthError);
+    await expect(signup('b@c.com', 'longerpw1', true, true, { fetchImpl })).rejects.toBeInstanceOf(AuthError);
   });
 });
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -77,11 +77,14 @@ export function signup(
   // Legal remediation E4 — the 13+ affirmation, forwarded to Rails as
   // age_confirmation. The form gates submit on it being true.
   ageConfirmation: boolean,
+  // Clickwrap — agreement to the Terms + Privacy Policy, forwarded as
+  // terms_acceptance. Also gated by the form.
+  termsAcceptance: boolean,
   opts: FetchOptions = {},
 ): Promise<AuthResponse> {
   return authPost<AuthResponse>(
     '/api/auth/signup',
-    { email, password, age_confirmation: ageConfirmation },
+    { email, password, age_confirmation: ageConfirmation, terms_acceptance: termsAcceptance },
     opts,
   );
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -258,7 +258,7 @@
             }
           },
           "422": {
-            "description": "age not confirmed — under-13 gate (legal E4)",
+            "description": "terms not accepted — clickwrap gate",
             "content": {
               "application/json": {
                 "schema": {
@@ -284,7 +284,8 @@
                       "password",
                       "password_confirmation",
                       "handle",
-                      "age_confirmation"
+                      "age_confirmation",
+                      "terms_acceptance"
                     ],
                     "properties": {
                       "email": {
@@ -308,6 +309,9 @@
                         "nullable": true
                       },
                       "age_confirmation": {
+                        "type": "boolean"
+                      },
+                      "terms_acceptance": {
                         "type": "boolean"
                       }
                     }

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -231,6 +231,7 @@ export interface paths {
                             handle: string;
                             display_name?: string | null;
                             age_confirmation: boolean;
+                            terms_acceptance: boolean;
                         };
                     };
                 };
@@ -245,7 +246,7 @@ export interface paths {
                         "application/json": components["schemas"]["AuthResponse"];
                     };
                 };
-                /** @description age not confirmed — under-13 gate (legal E4) */
+                /** @description terms not accepted — clickwrap gate */
                 422: {
                     headers: {
                         [name: string]: unknown;


### PR DESCRIPTION
## What

Risk-reduction follow-up (the highest-enforceability item). Agreement to the Terms was implied ("by using the service…") — weak **browsewrap**. Signup now requires an explicit, recorded **clickwrap** assent, which is what makes the ToS (including the **arbitration clause + class-action waiver**) actually enforceable.

- Email/password signup requires `terms_acceptance: true`; the server gates account creation on it (**422** otherwise) and stamps a new `users.terms_accepted_at` alongside the E4 age affirmation.
- **Web + mobile** signup forms add a required *"I agree to the Terms of Service and Privacy Policy"* checkbox (with inline links) that gates submit and threads the flag to Rails.

## Scope
Email/password signup. OAuth (Google/Apple) assent is a separate follow-up (noted in the followups doc).

## Verification
- rswag + request specs: **201** (both stamps recorded), **missing-terms 422**, existing paths.
- API **498**, web **178**, mobile **129** — all green. `docs/openapi.json` + `api-types` regenerated; `pnpm typecheck` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)