### PR TITLE
docs: add a one-way NDA template

### DIFF
--- a/docs/legal/nda-one-way.md
+++ b/docs/legal/nda-one-way.md
@@ -182,3 +182,8 @@ Date: ______________________________
    §8 reflects the founder's chosen default; adjust if counsel advises.
 4. For a counterparty that will also share sensitive information with you,
    ask counsel for a **mutual** version instead of this one-way form.
+5. **This NDA only covers confidentiality — it does not assign ownership.**
+   For anyone who *creates* work for BiteWorthy (a contractor writing
+   code, designs, or content), pair it with a separate IP-assignment /
+   work-for-hire agreement; otherwise the creator may retain rights in
+   what they produce.

--- a/docs/legal/nda-one-way.md
+++ b/docs/legal/nda-one-way.md
@@ -1,0 +1,184 @@
+# One-Way Non-Disclosure Agreement (template)
+
+> **DRAFT — not legal advice.** This is a fill-in-the-blanks template for
+> BiteWorthy to use with people who receive its confidential information
+> (an attorney, a contractor, an advisor, a beta tester, a prospective
+> investor). Have a licensed attorney review it before relying on it —
+> ideally the same counsel doing the Privacy/ToS review (legal-remediation
+> **L1**). Replace every `[BRACKETED]` field before sending.
+>
+> **Note on lawyers:** an attorney you retain is already bound by a
+> professional duty of confidentiality (e.g. ABA Model Rule 1.6), so an
+> NDA with your own counsel is often redundant — but it's common, harmless,
+> and usefully binds the firm's staff. Some lawyers will decline to sign
+> one or will mark it "for the firm's personnel."
+>
+> **Shape:** one-way (the Recipient protects BiteWorthy's information).
+> If the other party will also share sensitive material with you, use a
+> mutual NDA instead.
+
+---
+
+## Non-Disclosure Agreement
+
+This Non-Disclosure Agreement (the **"Agreement"**) is entered into as of
+**[EFFECTIVE DATE]** (the **"Effective Date"**) by and between:
+
+- **Disclosing Party:** [DISCLOSING PARTY LEGAL NAME], a
+  [STATE] [entity type, e.g. limited liability company / sole proprietor]
+  with an address at [ADDRESS] (**"BiteWorthy"** or the **"Disclosing
+  Party"**); and
+- **Recipient:** [RECIPIENT LEGAL NAME], a
+  [individual / entity type & state] with an address at [ADDRESS] (the
+  **"Recipient"**).
+
+BiteWorthy and the Recipient are each a **"Party"** and together the
+**"Parties."**
+
+### 1. Purpose
+The Recipient will receive confidential information from BiteWorthy in
+connection with **[PURPOSE — e.g. "providing legal services," "evaluating
+a potential engagement," "performing contract development work,"
+"evaluating a potential investment"]** (the **"Purpose"**). This Agreement
+governs how the Recipient may use and protect that information.
+
+### 2. Confidential Information
+**"Confidential Information"** means any non-public information that
+BiteWorthy discloses to the Recipient, in any form (oral, written,
+electronic, or visual), whether or not marked "confidential," that a
+reasonable person would understand to be confidential given its nature or
+the circumstances of disclosure. It includes, without limitation:
+
+- source code, software, schemas, and technical architecture;
+- the structured, dietary-annotated menu dataset and taxonomy (the "menu
+  graph") and any data derived from it;
+- product plans, roadmaps, designs, and unreleased features;
+- business, financial, marketing, pricing, and user/customer information;
+- vendor, partner, and personnel information; and
+- the existence and contents of any discussions between the Parties.
+
+### 3. Exclusions
+Confidential Information does **not** include information that the
+Recipient can show:
+
+(a) was publicly available at the time of disclosure, or later became
+   public through no act or omission of the Recipient;
+(b) was rightfully in the Recipient's possession, without a duty of
+   confidentiality, before BiteWorthy disclosed it;
+(c) was rightfully received by the Recipient from a third party without a
+   duty of confidentiality; or
+(d) was independently developed by the Recipient without use of or
+   reference to the Confidential Information.
+
+### 4. Obligations of the Recipient
+The Recipient shall:
+
+(a) use the Confidential Information solely for the Purpose;
+(b) protect it using at least the same degree of care it uses for its own
+   confidential information, and no less than a reasonable degree of care;
+(c) not disclose it to any third party except to the Recipient's
+   employees, contractors, or professional advisors who need it for the
+   Purpose and are bound by confidentiality obligations at least as
+   protective as this Agreement (the Recipient remains responsible for
+   their compliance); and
+(d) not copy, reverse engineer, or create derivative works from the
+   Confidential Information except as necessary for the Purpose.
+
+### 5. Compelled Disclosure
+If the Recipient is required by law, regulation, or valid legal process to
+disclose Confidential Information, it may do so, provided that — to the
+extent legally permitted — it gives BiteWorthy prompt written notice and
+reasonable cooperation so BiteWorthy can seek a protective order, and
+discloses only the portion legally required.
+
+### 6. No License; No Warranty
+All Confidential Information remains the property of BiteWorthy. No license
+or other right is granted to the Recipient except the limited right to use
+it for the Purpose. Confidential Information is provided **"AS IS,"**
+without warranty of any kind; BiteWorthy is not liable for the Recipient's
+reliance on it.
+
+### 7. No Obligation
+Nothing in this Agreement obligates either Party to disclose any
+information, to proceed with any transaction or engagement, or to enter
+into any further agreement.
+
+### 8. Term and Survival
+This Agreement begins on the Effective Date and continues until terminated
+by either Party on written notice. The Recipient's confidentiality
+obligations survive for **three (3) years** after the relevant
+Confidential Information is disclosed; provided that, for any Confidential
+Information that constitutes a **trade secret** under applicable law, the
+obligations continue for as long as the information remains a trade secret.
+
+### 9. Return or Destruction
+Upon BiteWorthy's written request or termination of this Agreement, the
+Recipient shall promptly return or destroy all Confidential Information in
+its possession or control (and certify destruction if asked), except for
+copies retained automatically by routine backup systems or as required by
+law, which remain subject to this Agreement.
+
+### 10. Remedies
+The Recipient agrees that unauthorized use or disclosure of Confidential
+Information may cause irreparable harm for which monetary damages are
+inadequate, and that BiteWorthy is entitled to seek injunctive relief in
+addition to any other remedies available at law or in equity, without the
+need to post a bond.
+
+### 11. Governing Law and Venue
+This Agreement is governed by the laws of the State of Colorado, without
+regard to its conflict-of-laws rules. The Parties consent to the exclusive
+jurisdiction and venue of the state and federal courts located in La Plata
+County, Colorado.
+
+### 12. Miscellaneous
+- **Entire agreement.** This Agreement is the entire understanding between
+  the Parties regarding its subject matter and supersedes prior
+  discussions.
+- **Amendments.** Any amendment must be in writing and signed by both
+  Parties.
+- **Assignment.** The Recipient may not assign this Agreement without
+  BiteWorthy's prior written consent.
+- **Severability.** If any provision is held unenforceable, the rest
+  remains in effect.
+- **No waiver.** A failure to enforce any provision is not a waiver of it.
+- **Counterparts / e-signature.** This Agreement may be signed in
+  counterparts and by electronic signature, each of which is an original.
+
+---
+
+**IN WITNESS WHEREOF,** the Parties have executed this Agreement as of the
+Effective Date.
+
+**Disclosing Party — [DISCLOSING PARTY LEGAL NAME]**
+
+Signature: ______________________________
+
+Name: [NAME]
+
+Title: [TITLE]
+
+Date: ______________________________
+
+**Recipient — [RECIPIENT LEGAL NAME]**
+
+Signature: ______________________________
+
+Name: [NAME]
+
+Title: [TITLE, if applicable]
+
+Date: ______________________________
+
+---
+
+## How to use this template
+1. Fill in every `[BRACKETED]` field (parties, address, Effective Date,
+   Purpose). If BiteWorthy has no formal legal entity yet, use the
+   founder's legal name and note that.
+2. Decide the Purpose wording per signer (legal services vs contract work
+   vs investment evaluation).
+3. Have counsel review (L1). The 3-year term + trade-secret carve-out in
+   §8 reflects the founder's chosen default; adjust if counsel advises.
+4. For a counterparty that will also share sensitive information with you,
+   ask counsel for a **mutual** version instead of this one-way form.


### PR DESCRIPTION
## What

A fill-in-the-blanks **one-way NDA** so BiteWorthy can bind anyone who receives its confidential info — the L1 attorney, contractors, advisors, beta testers, prospective investors — before sharing the codebase, the menu-graph dataset, or business plans. Lives at `docs/legal/nda-one-way.md`.

- **One-way** (Recipient protects BiteWorthy's info).
- **3-year** confidentiality survival with an **indefinite trade-secret** carve-out (the chosen defaults).
- Governing law **Colorado / La Plata County** to match the ToS.
- Standard clauses: definition + exclusions, use/protect obligations, compelled-disclosure notice, no-license/AS-IS, no-obligation, return/destroy, injunctive-relief remedy, miscellaneous, signature blocks.
- Bracketed fields for parties + Purpose, a "how to use" section, and a clear **DRAFT / not-legal-advice** banner (incl. the note that your own attorney is already bound by professional confidentiality, so an NDA with counsel is often redundant).

Docs-only; real Unicode glyphs.

> Needs attorney review before use — same gate as the Privacy/ToS (L1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)