### PR TITLE
refactor(web,mobile): drop dead exports and correct stale analytics comments

### DIFF
--- a/apps/mobile/lib/posthog-client.ts
+++ b/apps/mobile/lib/posthog-client.ts
@@ -18,8 +18,6 @@ import type { AnalyticsClient } from '@biteworthy/analytics';
 
 export const EXTENSION_NAME = 'biteworthy';
 
-export type PostHogRNInstance = PostHog;
-
 /**
  * posthog-react-native 4.45+ narrowed event properties from
  * `Record<string, unknown>` to `{ [key: string]: JsonType }`, and the

--- a/apps/mobile/lib/track.ts
+++ b/apps/mobile/lib/track.ts
@@ -11,10 +11,10 @@
  * opt-in is explicit (default off until the user accepts in
  * `/settings/analytics`).
  *
- * Phase 5.8 ships the wrapper without `posthog-react-native` as a
- * hard dep — the follow-up wiring PR adds the package + replaces
- * `null` below with a real client. Same ship-the-abstraction
- * pattern as the web wrapper.
+ * The client is supplied by `_layout.tsx`, which constructs the
+ * `posthog-react-native` instance and passes `createPostHogClient(...)`
+ * in. When no client is injected (tests, or before init) the tracker
+ * stays `noopTracker`. Same shape as the web wrapper.
  */
 
 import {
@@ -30,8 +30,9 @@ interface BuildOptions {
   /** Test override for the analytics-opt-in flag. */
   optedIn?: boolean;
   /**
-   * Test override / Phase-5.8-wiring hook: inject a constructed
-   * AnalyticsClient (e.g. the posthog-react-native instance).
+   * The constructed AnalyticsClient — the posthog-react-native instance
+   * in production (injected by `_layout.tsx`), or a mock in tests. When
+   * absent the tracker no-ops.
    */
   client?: AnalyticsClient | null;
 }
@@ -46,7 +47,7 @@ export function buildMobileTracker(opts: BuildOptions = {}): Tracker {
   if (!optedIn) return noopTracker;
 
   if (!opts.client) {
-    // Same Phase 5.8 ship-abstraction-first guard as web.
+    // No client injected (tests, or before init) — same guard as web.
     return noopTracker;
   }
   return createTracker({ client: opts.client });

--- a/apps/web/src/lib/durango.ts
+++ b/apps/web/src/lib/durango.ts
@@ -18,8 +18,6 @@
 
 import { API_BASE } from './api-base';
 
-export const DURANGO_CITY_SLUG = 'durango';
-
 /**
  * Curated dietary-profile slugs Phase 3.1 seeded. Order is the
  * sitemap order (priority is the same for all, so order is just

--- a/apps/web/src/lib/track.ts
+++ b/apps/web/src/lib/track.ts
@@ -9,12 +9,12 @@
  *   * The user has opted out via the in-app analytics toggle
  *     (`localStorage.bw_analytics_opt_out === '1'`)
  *
- * Otherwise it constructs a tracker around an injected
- * `AnalyticsClient`. **Phase 5.8 ships the wrapper without
- * `posthog-js` as a hard dep** — the follow-up wiring PR adds the
- * package + replaces `null` below with the real client. Keeping
- * this file noop-by-default means we can ship + review the
- * abstraction without committing to a posthog-js install yet.
+ * Otherwise it constructs a tracker around the injected
+ * `AnalyticsClient`. The client is supplied by `_PostHogProvider`,
+ * which initializes `posthog-js` and passes
+ * `createPostHogClient(posthog)` in. When no client is injected (SSR,
+ * tests, or any caller outside the provider) the tracker stays
+ * `noopTracker` — an apiKey alone is not enough to make it live.
  */
 
 import {
@@ -34,11 +34,10 @@ interface BuildOptions {
   /** Test override for the localStorage opt-out flag. */
   optedOut?: boolean;
   /**
-   * Test override / Phase-5.8-wiring hook: inject a constructed
-   * AnalyticsClient (e.g. a configured posthog-js instance). When
-   * absent + `apiKey` is set, the tracker still no-ops because we
-   * haven't installed the SDK yet — Phase 5.8-wiring follow-up
-   * fills this in.
+   * The constructed AnalyticsClient — a configured posthog-js instance
+   * in production (injected by `_PostHogProvider`), or a mock in tests.
+   * When absent the tracker no-ops even if `apiKey` is set: a live
+   * tracker requires an injected client.
    */
   client?: AnalyticsClient | null;
 }
@@ -54,9 +53,8 @@ export function buildWebTracker(opts: BuildOptions = {}): Tracker {
   if (optedOut) return noopTracker;
 
   if (!opts.client) {
-    // Phase 5.8 ships without posthog-js installed. The presence of
-    // an apiKey alone isn't enough — a follow-up PR injects the
-    // real client here.
+    // No client injected (SSR, tests, or a caller outside
+    // _PostHogProvider) — an apiKey alone doesn't make a live tracker.
     return noopTracker;
   }
   return createTracker({ client: opts.client });

--- a/apps/web/src/lib/users.ts
+++ b/apps/web/src/lib/users.ts
@@ -30,13 +30,6 @@ export interface PublicUserProfile {
   recent_reviews: UserReview[];
 }
 
-export class UserProfileNotFoundError extends Error {
-  constructor(handle: string) {
-    super(`User profile not found: ${handle}`);
-    this.name = 'UserProfileNotFoundError';
-  }
-}
-
 export async function fetchPublicUserProfile(
   handle: string,
   opts: ApiOptions = {},

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -2,9 +2,9 @@
  * BiteWorthy analytics — typed Tracker abstraction shared by web +
  * mobile.
  *
- * Phase 5.8 ships the abstraction + the canonical event taxonomy;
- * the actual posthog-js / posthog-react-native install + the 9
- * call-site instrumentations are a follow-up PR (see
+ * Phase 5.8 shipped the abstraction + the canonical event taxonomy;
+ * the posthog-js / posthog-react-native install and the 9 call-site
+ * instrumentations are now wired in `apps/web` + `apps/mobile` (see
  * `docs/analytics.md` + `docs/adr/0006-analytics.md`).
  *
  * Design choices that matter:


### PR DESCRIPTION
## Why

Cleanup from the analytics/legal audit. **No behavior change** — dead-code removal + comment correction.

## What changed

**Dead exports removed** (each defined, imported nowhere — repo-wide grep confirmed):
- web `lib/users.ts` `UserProfileNotFoundError` — the fetcher returns `null` on 404, never throws it.
- web `lib/durango.ts` `DURANGO_CITY_SLUG` — the fetcher takes `citySlug` as a param; the const had no callers.
- mobile `lib/posthog-client.ts` `PostHogRNInstance` type alias — unused.

**Stale comments corrected.** web + mobile `track.ts` and `packages/analytics` still claimed PostHog *"ships without the SDK / a follow-up PR injects the real client / call-sites are a follow-up."* That shipped: `posthog-js` + `posthog-react-native` are hard deps, `_PostHogProvider` / `_layout.tsx` inject real clients, all 9 events fire. Comments now describe the actual behavior — the no-client branch is a deliberate SSR/test guard, not a not-yet-wired placeholder.

## Deliberately skipped

`filter-engine` `topPicks` was flagged as test-only, but it's a **documented, tested public export** of the package. Removing it is an API-surface decision, not a janitorial deletion — left in place and flagged instead.

## Verification

`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test` ✓ (web 180 + mobile/filter-engine/analytics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)