### PR TITLE
refactor: consume @biteworthy/api-types — single-source the wire enums + auth types

### DIFF
--- a/apps/mobile/lib/api/onboarding.ts
+++ b/apps/mobile/lib/api/onboarding.ts
@@ -7,7 +7,7 @@
  * taps Done (Phase 1.3 endpoint, wholesale-replace semantics).
  */
 
-import type { DietaryPreset } from '@biteworthy/filter-engine';
+import type { DietaryPreset, Strictness } from '@biteworthy/filter-engine';
 
 import { API_BASE } from '../api-base';
 
@@ -75,7 +75,7 @@ export interface SaveProfilePayload {
   avoid_ingredient_ids: string[];
   avoid_tag_ids: string[];
   prefer_tag_ids: string[];
-  strictness: 'relaxed' | 'balanced' | 'strict';
+  strictness: Strictness;
   liked_tag_ids?: string[];
   disliked_tag_ids?: string[];
   liked_ingredient_ids?: string[];

--- a/apps/mobile/lib/api/restaurants.ts
+++ b/apps/mobile/lib/api/restaurants.ts
@@ -112,7 +112,7 @@ export async function fetchRestaurant(
 export interface FetchItemsOptions extends FetchOptions {
   jwt?: string;
   presetSlug?: string;
-  strictness?: 'relaxed' | 'balanced' | 'strict';
+  strictness?: Strictness;
 }
 
 export async function fetchRestaurantItems(

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -14,15 +14,14 @@
  */
 import * as SecureStore from 'expo-secure-store';
 
+// The auth user shape is the codegen'd contract — import it from
+// @biteworthy/api-types rather than re-declaring.
+import type { UserPayload } from '@biteworthy/api-types';
+
 import { API_BASE } from './api-base';
 const TOKEN_KEY = 'bw_jwt';
 
-export interface UserPayload {
-  id: string;
-  email: string;
-  handle: string | null;
-  display_name: string | null;
-}
+export type { UserPayload };
 
 export class AuthError extends Error {
   constructor(

--- a/apps/mobile/lib/share-url.ts
+++ b/apps/mobile/lib/share-url.ts
@@ -6,12 +6,12 @@
  * without needing an account. The token is the same base64url
  * encoding the Rails controller decodes via `?profile_token=`.
  */
-import { encodeProfileToken } from '@biteworthy/filter-engine';
+import { encodeProfileToken, type Strictness } from '@biteworthy/filter-engine';
 
 export interface FilterForSharing {
   avoid_ingredient_ids: string[];
   avoid_tag_ids: string[];
-  strictness: 'relaxed' | 'balanced' | 'strict';
+  strictness: Strictness;
 }
 
 export function buildShareUrl(

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -13,16 +13,11 @@
  */
 'use client';
 
-export interface UserPayload {
-  id: string;
-  email: string;
-  handle: string | null;
-  display_name: string | null;
-}
-
-export interface AuthResponse {
-  user: UserPayload;
-}
+// The auth response shapes are the codegen'd contract — import them
+// from @biteworthy/api-types rather than re-declaring (the generated
+// UserPayload also carries the OAuth `provider` field).
+import type { UserPayload, AuthResponse } from '@biteworthy/api-types';
+export type { UserPayload, AuthResponse };
 
 export class AuthError extends Error {
   constructor(

--- a/apps/web/src/lib/onboarding.ts
+++ b/apps/web/src/lib/onboarding.ts
@@ -6,7 +6,7 @@
  * fetcher shapes have to line up too.
  */
 
-import type { DietaryPreset } from '@biteworthy/filter-engine';
+import type { DietaryPreset, Strictness } from '@biteworthy/filter-engine';
 import { api, type ApiOptions } from './api';
 
 export interface IngredientSearchResult {
@@ -28,7 +28,7 @@ export interface SaveProfilePayload {
   avoid_ingredient_ids: string[];
   avoid_tag_ids: string[];
   prefer_tag_ids: string[];
-  strictness: 'relaxed' | 'balanced' | 'strict';
+  strictness: Strictness;
   liked_tag_ids?: string[];
   disliked_tag_ids?: string[];
   liked_ingredient_ids?: string[];

--- a/packages/filter-engine/src/index.ts
+++ b/packages/filter-engine/src/index.ts
@@ -16,10 +16,15 @@
  * camelCase happens at UI boundaries if needed.
  */
 
+import type { Strictness, Confidence } from '@biteworthy/api-types';
+
 // ─── Wire-format types ──────────────────────────────────────────────
 
-export type Strictness = 'relaxed' | 'balanced' | 'strict';
-export type Confidence = 'confirmed' | 'suggested' | 'inferred';
+// Strictness + Confidence are the canonical wire enums — declared once
+// in @biteworthy/api-types (codegen-anchored) and re-exported here so
+// every consumer keeps importing the filter contract from one place.
+export type { Strictness, Confidence };
+
 export type ItemStatus = 'visible' | 'hidden';
 
 /**


### PR DESCRIPTION
## Why

`@biteworthy/api-types` was a declared dependency of web/mobile/filter-engine but **nothing imported it** — the apps re-declared the same wire shapes locally (the orphaned-package finding from the cleanup audit). This wires the clean, unambiguous slice onto the package. **No behavior change** — typecheck/lint/test all green.

This also makes the CLAUDE.md claim *"`@biteworthy/filter-engine` consumes `@biteworthy/api-types`"* true (it was false before).

## What changed

- **`Strictness` + `Confidence` now have one declaration** (api-types). `filter-engine` imports + re-exports them, so every consumer keeps its existing `@biteworthy/filter-engine` import path. Removed the duplicate unions in filter-engine and the **four** inlined `'relaxed' | 'balanced' | 'strict'` literals (web/mobile onboarding, mobile share-url + restaurants).
- **web + mobile `UserPayload` / web `AuthResponse`** import from api-types instead of re-declaring. The generated `UserPayload` is also *more correct*: `handle` is non-null (DB `null: false` + `presence` + auto-assigned default) where the local copy said `string | null`, and it carries the OAuth `provider` field.

## Deliberately deferred (scope)

- **`ProfilePayload` (GET `/profile`)** — no typed consumer in either app; nothing to wire.
- **`SaveProfilePayload`** stays local — it intentionally makes the avoid-lists **required** so a save can't silently wipe the safety filter, while the generated PATCH body makes them optional. Only its inline strictness literal was converged.
- **Items endpoint** — the runtime `reasons[]` is *enriched* (`*_name`/`*_family`) but the generated type is ids-only; wiring it needs an rswag-spec change first. Tracked as a follow-up PR.
- **reviews/history/users/suggestions/ingestion** — no rswag spec exists, so there's no generated type to point at (out of scope).

## Verification

`pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test` ✓ (filter-engine 182 · web 180 · mobile 129 · analytics 12). `generated.ts` + `docs/openapi.json` untouched → codegen drift check stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)