### PR TITLE
fix(api): document the enriched items reasons[] fields in the OpenAPI spec

### DIFF
--- a/apps/api/spec/integration/api/v1/restaurants/items_spec.rb
+++ b/apps/api/spec/integration/api/v1/restaurants/items_spec.rb
@@ -51,10 +51,14 @@ RSpec.describe "restaurants/items", type: :request do
                            type: :object,
                            required: %w[kind],
                            properties: {
-                             kind:          { type: :string, enum: %w[avoid_ingredient avoid_tag unconfirmed_strict] },
-                             ingredient_id: { type: :string, format: :uuid },
-                             tag_id:        { type: :string, format: :uuid },
-                             confidence:    { type: :string, enum: %w[confirmed suggested inferred] }
+                             kind:              { type: :string, enum: %w[avoid_ingredient avoid_tag unconfirmed_strict] },
+                             ingredient_id:     { type: :string, format: :uuid },
+                             ingredient_name:   { type: :string, nullable: true },
+                             ingredient_family: { type: :string, nullable: true },
+                             tag_id:            { type: :string, format: :uuid },
+                             tag_name:          { type: :string, nullable: true },
+                             tag_family:        { type: :string, nullable: true },
+                             confidence:        { type: :string, enum: %w[confirmed suggested inferred] }
                            }
                          }
                        },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -710,9 +710,25 @@
                                   "type": "string",
                                   "format": "uuid"
                                 },
+                                "ingredient_name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "ingredient_family": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
                                 "tag_id": {
                                   "type": "string",
                                   "format": "uuid"
+                                },
+                                "tag_name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "tag_family": {
+                                  "type": "string",
+                                  "nullable": true
                                 },
                                 "confidence": {
                                   "type": "string",

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -471,8 +471,12 @@ export interface paths {
                                     kind: "avoid_ingredient" | "avoid_tag" | "unconfirmed_strict";
                                     /** Format: uuid */
                                     ingredient_id?: string;
+                                    ingredient_name?: string | null;
+                                    ingredient_family?: string | null;
                                     /** Format: uuid */
                                     tag_id?: string;
+                                    tag_name?: string | null;
+                                    tag_family?: string | null;
                                     /** @enum {string} */
                                     confidence?: "confirmed" | "suggested" | "inferred";
                                 }[];


### PR DESCRIPTION
## Why

`GET /api/v1/restaurants/:id/items` enriches each hide reason with display strings — `ingredient_name`/`ingredient_family` for `avoid_ingredient`, `tag_name`/`tag_family` for `avoid_tag` (see `ItemsController#hide_reasons`) — so the hidden-reason chip renders without a second lookup. The rswag schema only documented the `*_id` + `confidence` fields, so `docs/openapi.json` (a cross-package contract) **understated the actual response**.

This came out of the api-types wiring work (#350): the generated `reasons[]` type was ids-only while the runtime payload is enriched.

## What changed

- Added the four nullable enrichment fields (`ingredient_name`, `ingredient_family`, `tag_name`, `tag_family`) to the `reasons[]` item schema in the items rswag spec — same flat-object + optional-fields pattern the adjacent `taste_reasons` block already uses.
- Regenerated `docs/openapi.json` + `packages/api-types/src/generated.ts` (diffs are *only* the four fields — no incidental regen churn).

## Why not also rewire the TS consumers?

Deliberately not. TS consumers keep filter-engine's hand-written `HideReason` **discriminated union**, which is strictly more precise than the flat generated type (exhaustive `switch` on `kind`, no impossible field combos). Pointing them at the generated flat type would be a type-safety downgrade. This PR only makes the *published spec* honest.

## Verification

- `bundle exec rspec spec/integration/.../items_spec.rb` ✓ (rswag validates the live response against the updated schema)
- `pnpm --filter @biteworthy/api-types codegen:check` ✓ (drift check, exit 0)
- `pnpm typecheck` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)