### PR TITLE
docs: taste-quiz onboarding flow + recover strategy §7

### DIFF
--- a/docs/plans/taste-quiz.md
+++ b/docs/plans/taste-quiz.md
@@ -1,0 +1,143 @@
+# Taste-Profile Quiz — onboarding flow spec
+
+> Discovery-led onboarding (see `docs/strategy-2026-h2.md` §7). Goal: in ~6 taps,
+> build a taste profile good enough to power Top Picks for a brand-new user with
+> **no dietary restrictions** — restrictions become an optional setting, not the
+> identity. Writes only to the existing `liked/disliked_{tag,ingredient}_ids`
+> arrays; no new persistence model.
+
+**Status:** draft · **Created:** 2026-06-19
+
+---
+
+## Reality check — what we have to build with
+
+The taste engine is fully built (`taste_scoring.rb`, `packages/filter-engine/src/taste.ts`,
+Top Picks UI). The constraint is **vocabulary**, from `apps/api/db/seeds/tags.yml:92`:
+
+| Family | Real tags today | Count |
+|---|---|---|
+| `cuisine` | Italian, Mexican, Thai, Japanese, Indian, American | 6 |
+| `prep` | Fried, Grilled, Raw, Smoked | 4 |
+| `flavor` | **Spicy, Sweet** | 2 |
+
+**12 taste tags total.** Hero ingredients exist for love/hate cards
+(`apps/api/db/seeds/ingredients.yml`): `herb-cilantro`, `herb-basil`,
+`herb-garlic`, `fruit-lemon`, `fruit-olive`, mushroom, etc. — plus on-demand
+`searchIngredients(q)` (≤20 results).
+
+### Three implementation realities (do not skip)
+
+1. **Flavor vocabulary is too thin for a "rich" quiz** (only Spicy + Sweet).
+   Cuisine + hero-ingredients carry v1. **Prerequisite for a genuinely good
+   quiz:** expand the `flavor` family (e.g. Savory/Umami, Sour/Tangy, Smoky,
+   Creamy, Herby, Cheesy) and optionally add a `texture`/`format` family. Adding
+   taxonomy nodes is admin-gated ltree work — small, but it gates quiz quality.
+2. **`fetchTags` defaults to `['cuisine','flavor']`** (`apps/web/src/lib/onboarding.ts:69`)
+   — the quiz must call `fetchTags(['cuisine','prep','flavor'])` to load prep.
+3. **The reducer only exposes `CYCLE_TASTE_TAG` / `CYCLE_TASTE_INGREDIENT`**
+   (neutral → liked → disliked → neutral; `onboarding-reducer.ts:119`). That
+   3-state cycle is wrong for quiz buttons (a multi-select "pick what you like"
+   that deselects to *disliked* is a bug; a love/pass card needs to land on a
+   specific state). **Add explicit actions** `SET_TASTE_TAG {id, state}` and
+   `SET_TASTE_INGREDIENT {id, state}` (state ∈ `liked|disliked|neutral`), keep
+   the cycle for the existing chip UI, and keep the filter-engine parity tests
+   green. Small, clean addition.
+
+---
+
+## The flow — 6 screens, skippable after screen 3
+
+Each screen writes concrete signals. A persistent **"Skip → see my picks"**
+appears from screen 3 on; the minimum viable profile is a couple of cuisine taps.
+
+### Screen 1 — Cuisines *(multi-select)*
+**"Which cuisines make you hungry?"** — 6 chips (Italian, Mexican, Thai,
+Japanese, Indian, American). Tap = love.
+→ `SET_TASTE_TAG {cuisineTagId, 'liked'}`; tap again → `'neutral'`.
+
+### Screen 2 — Heat *(single tap, 4-point)*
+**"How much heat do you like?"** — None · Mild · Medium · Bring the fire.
+→ None/Mild → `SET_TASTE_TAG {spicyId, 'disliked'}` · Medium → `'neutral'` ·
+Fire → `'liked'`. Maps to the real `flavor:Spicy` tag.
+
+### Screen 3 — Sweet tooth *(single tap)*
+**"Do you go for something sweet?"** — Always / Sometimes / Rarely.
+→ Always → `SET_TASTE_TAG {sweetId, 'liked'}` · Rarely → `'disliked'` ·
+Sometimes → `'neutral'`. *(This is the last of the two real flavor tags — when
+the flavor family is expanded (prereq #1), insert a "pick the flavors you love"
+multi-select here instead.)*
+— **"See my picks" unlocks here.** —
+
+### Screen 4 — Cooking style *(multi-select)*
+**"How do you like it cooked?"** — Grilled · Fried · Raw (sushi/ceviche) ·
+Smoked. → `SET_TASTE_TAG {prepTagId, 'liked'}` per pick. *(Requires fetching the
+`prep` family — reality #2.)*
+
+### Screen 5 — Hero ingredients *(forced love/pass cards)*
+A small deck of polarizing ingredients: **Cilantro, Olives, Mushroom, Garlic,
+Basil, Lemon** (curated preset of seed slugs, no typing — fast). Each card:
+**♥ Love** / **✕ Pass** / *skip*.
+→ Love → `SET_TASTE_INGREDIENT {id, 'liked'}` · Pass → `'disliked'`.
+This is the highest-signal, most-fun screen (the classic "cilantro: love or
+hate"). Keep it to ~5–7 cards.
+
+### Screen 6 — Restrictions *(optional, gentle link — NOT a step)*
+**"Anything you avoid? Allergies or diets — optional."** A skippable link into
+the existing dietary preset/avoid-list flow. This is the discovery-led demotion:
+restrictions are a setting underneath, not a gate in front. Restricted users who
+tap through get the full honest-disclosure filter; everyone else never sees it.
+
+### Done
+Build the payload with `toProfilePayload(state, presets)` (full onboarding) or
+`toTastePayload(state)` (taste-only) → `PATCH /api/v1/profile` (web proxy
+`/api/profile`). Server validates liked/disliked are disjoint (422 otherwise);
+"filter wins" means avoided IDs are ignored by scoring, never shown.
+
+---
+
+## Signal → array mapping
+
+| Screen | Dimension | Reducer action | Lands in |
+|---|---|---|---|
+| 1 | Cuisines | `SET_TASTE_TAG …'liked'` | `liked_tag_ids` |
+| 2 | Spice | `SET_TASTE_TAG spicy …` | `liked_` / `disliked_tag_ids` |
+| 3 | Sweet | `SET_TASTE_TAG sweet …` | `liked_` / `disliked_tag_ids` |
+| 4 | Cooking style | `SET_TASTE_TAG prep …'liked'` | `liked_tag_ids` |
+| 5 | Hero ingredients | `SET_TASTE_INGREDIENT …` | `liked_` / `disliked_ingredient_ids` |
+| 6 | Restrictions | (existing preset/avoid flow) | `avoid_*`, `selectedPresetSlugs` |
+
+---
+
+## Analytics
+
+- Keep firing `profile_set { taste_signal_count }` on submit (web + mobile, as today).
+- **Add quiz funnel instrumentation** (the activation canary): furthest screen
+  reached + completed-vs-skipped. Onboarding fatigue is the #1 risk; we must see
+  where people drop.
+- **Instrument `rec_acceptance`** downstream (tap/save on a Top Pick) — the
+  discovery-quality metric from §7. A pretty quiz that yields bad picks is worse
+  than no quiz.
+- Taste prefs (cuisine/flavor) are **not** health data, so per-family counts
+  (`liked_cuisine_count`, etc.) are safe to add if we want finer funnels — unlike
+  the dietary profile, which stays off identified events.
+
+---
+
+## Build checklist
+
+- [ ] Expand `flavor` taxonomy (+ optional `texture`/`format` family) — *quality prereq*
+- [ ] Add `SET_TASTE_TAG` / `SET_TASTE_INGREDIENT` reducer actions + parity tests
+- [ ] `fetchTags(['cuisine','prep','flavor'])` in the quiz path
+- [ ] Curate the hero-ingredient preset deck (seed-backed slugs)
+- [ ] Build the 6 screens (web `apps/web/src/app/onboarding`, mirror in mobile)
+- [ ] **Reorder onboarding so the quiz is step 1**; dietary → optional setting (§7)
+- [ ] Quiz-funnel + `rec_acceptance` analytics
+- [ ] Skip-after-screen-3 logic + minimum-viable-profile save
+
+## v2 (fast-follow, not v1) — "this or that" dish swipe
+
+Show two real dish photos: **"Which would you order?"** Infer taste tags from the
+chosen `item.tag_ids`. More delightful and higher-signal, but needs a **curated,
+representative dish set per tag** (cold-start), so it ships after v1's
+chip/scale quiz proves the engine converts.

--- a/docs/strategy-2026-h2.md
+++ b/docs/strategy-2026-h2.md
@@ -176,6 +176,9 @@ product.
 | Top Picks UI + "Because you like X & Y" reasons (web + mobile), hides for zero-signal | `apps/web/.../TopPicksRow.tsx`, `items_controller.rb:154` |
 | Taste tags separable from dietary via `families` param (`cuisine`/`prep`/`flavor` vs `diet`/`allergen`) | `apps/api/app/models/tag.rb:2` |
 
+**Quiz flow spec:** see `docs/plans/taste-quiz.md` (screen-by-screen, reducer
+actions, the thin-flavor-taxonomy prerequisite).
+
 **The gap (UX + positioning only):**
 - Taste is buried — onboarding is dietary-first; taste is **skippable step 4**
   (`apps/web/src/app/onboarding/page.tsx:224`). Discovery-led → **taste becomes

--- a/docs/strategy-2026-h2.md
+++ b/docs/strategy-2026-h2.md
@@ -57,7 +57,17 @@ Nov 2025. They will own the B2B/ordering-integrated side. Our defensible ground 
 
 ## 3. The core strategic bet
 
-**Make the contribution loop the product's heartbeat, and freemium the business model.**
+**Make the contribution loop the product's heartbeat, freemium the business
+model — and open the front door to *everyone*, not just restricted diners.**
+
+**Positioning (decided 2026-06-18 — discovery-led, safety underneath):**
+
+> Biteworthy tells you what to order at any restaurant — and if you have
+> restrictions, it never shows you what you can't eat.
+
+The headline question becomes **"what should I order here?"** (universal),
+with dietary restrictions demoted to an optional *setting*. Restrictions are no
+longer the product's identity; they're a guarantee underneath it. See §7.
 
 1. **Coverage via crowdsourcing (the moat).** Anyone-can-scan already shipped
    (Phase 6). Every user who scans a new menu *creates* coverage — HappyCow's
@@ -65,10 +75,14 @@ Nov 2025. They will own the B2B/ordering-integrated side. Our defensible ground 
 2. **Frequency via a contribution identity (the retention fix).** Turn
    `suggestion_submitted` + self-verify into "I'm the person who keeps my city's
    menus accurate." Public profiles (`/u/[handle]`) already exist.
-3. **Revenue via consumer freemium (the proven model).** Yuka: ~98% of revenue
+3. **Reach via taste discovery (the TAM unlock).** "What should I order?" fires
+   for ~everyone at every new restaurant — the mass-market answer to the
+   frequency problem the restricted-only loop can't reach. The scoring engine is
+   already built (§7).
+4. **Revenue via consumer freemium (the proven model).** Yuka: ~98% of revenue
    from subs, ad-free. **Avoid the restaurant-ad trap** (Find Me Gluten Free's
    founder: "almost impossible"). Premium = unlimited scans, multi-profile
-   (family), strict mode, offline.
+   (family), strict mode, offline, and **table/group mode** (§7).
 
 ---
 
@@ -92,6 +106,10 @@ Nov 2025. They will own the B2B/ordering-integrated side. Our defensible ground 
 - [ ] Ship to one zip code. Do not scale — *learn*.
 - [ ] Add the one derived metric the 9-event funnel is missing: **week-2 return rate** (the frequency canary)
 - [ ] Watch `menu_filtered.visible_count` in strict mode — near-zero confirms the sparsity risk
+- [ ] **Discovery-led onboarding (§7)** — frontend-only, can build during Month-1 provisioning (no credential dependency): reorder so the **taste quiz is step 1**, dietary becomes an optional setting
+- [ ] Build the **forced-choice taste quiz** (~6–10 taps) writing to existing `liked_tag_ids`; keep skippable after ~3 taps
+- [ ] Add **starter taste profiles** (taste analog of dietary presets)
+- [ ] Instrument **rec acceptance** (tap/save on a Top Pick) — the discovery-quality metric
 
 ### Month 3 (Aug) — The contribution loop *(highest-leverage build)*.
 
@@ -102,7 +120,8 @@ Nov 2025. They will own the B2B/ordering-integrated side. Our defensible ground 
 ### Month 4 (Sep) — Frequency surface beyond the venue lookup.
 
 - [ ] **"Safe near me"** — given avoid lists + location, what can I eat *right now* across nearby venues
-- [ ] **Household/multi-profile** filtering (also the first premium hook)
+- [ ] **"What should I order?" near me** — taste-ranked picks across nearby venues (discovery analog)
+- [ ] **Household/multi-profile + table/group mode (§7)** — combine taste profiles → "what should we all get?" (first premium hook)
 
 ### Month 5 (Oct) — Monetize + harden.
 
@@ -136,6 +155,55 @@ Nov 2025. They will own the B2B/ordering-integrated side. Our defensible ground 
 
 ---
 
+## 7. Expansion bet — the taste recommender for everyone (discovery-led)
+
+**The idea:** serve the ~70% of diners with *no* dietary restrictions by
+answering "what's the best thing to order at this new restaurant?" via a fast
+taste-profile quiz. This is the mass-market frequency answer (§1) and roughly
+3–4× the addressable audience.
+
+**Why it's cheap: the engine already exists (Phase 8).** This is a frontend
+reorder + a better onboarding UX on top of finished infrastructure — not a new
+product.
+
+| Already built | File |
+|---|---|
+| Taste model — `liked/disliked_{tag,ingredient}_ids` arrays, disjoint-set validated | `apps/api/app/models/user_profile.rb:8` |
+| `PATCH /api/v1/profile` already accepts taste arrays (no schema/API change) | `apps/api/app/controllers/api/v1/profiles_controller.rb:62` |
+| Scoring engine: `+2/liked tag, +1/liked ing, −2/−1 disliked` + popularity + rating | `apps/api/app/services/taste_scoring.rb` |
+| **"Filter wins"** — avoid lists subtracted *before* scoring (safety guaranteed) | `taste_scoring.rb:37` |
+| TS mirror w/ parity tests | `packages/filter-engine/src/taste.ts` |
+| Top Picks UI + "Because you like X & Y" reasons (web + mobile), hides for zero-signal | `apps/web/.../TopPicksRow.tsx`, `items_controller.rb:154` |
+| Taste tags separable from dietary via `families` param (`cuisine`/`prep`/`flavor` vs `diet`/`allergen`) | `apps/api/app/models/tag.rb:2` |
+
+**The gap (UX + positioning only):**
+- Taste is buried — onboarding is dietary-first; taste is **skippable step 4**
+  (`apps/web/src/app/onboarding/page.tsx:224`). Discovery-led → **taste becomes
+  step 1, dietary becomes an optional setting.**
+- Capture is a cold chip/search picker, not a quiz. Build a **forced-choice
+  visual wizard** (~6–10 taps: "which would you order?") that writes the *same*
+  `liked_tag_ids`. Keep it skippable/progressive — let users in after ~3 taps.
+- No profile-edit UI, append-only, no **starter taste profiles** (the taste
+  analog of dietary presets) — add these.
+
+**Killer premium feature — table/group mode:** combine several taste profiles →
+"order these 4 dishes the whole table will love." Group-ordering paralysis is
+universal (MFP: 80%+ find restaurant choices hard).
+
+**The two guardrails:**
+1. **Don't let discovery erode safety trust.** Strict-mode / honest-disclosure
+   must stay rock-solid for restricted users even as marketing goes wide. Safety
+   is the moat; discovery is the funnel.
+2. **Higher rec-quality bar.** Foodies just want the pick to be *good*;
+   tag-overlap scoring is a fine v1 but thin. **Instrument rec acceptance** (did
+   they tap/save the pick?) from day one; plan collaborative filtering once there
+   is data. Remember Yummly ($100M, shut down Dec 2024) — discovery without
+   per-venue grounding wasn't defensible. Our grounding (real item data for the
+   actual menu) is the defense; never lose it.
+
+---
+
 ## Log
 
 - **2026-06-18** — Doc created from strategic review (internal product brief + competitive landscape research). Direction confirmed with Skylar: pure utility filter tool, **not** a game. Core bet = contribution loop + consumer freemium.
+- **2026-06-18** — Added §7 taste-recommender expansion. Decision: **discovery-led, safety underneath** — open the app to non-restricted diners via a taste quiz; restrictions become an optional setting. Key finding: the Phase 8 scoring engine is already built; the gap is UX + positioning (reorder onboarding, build a forced-choice quiz, add starter profiles). Premium unlock = table/group mode.


### PR DESCRIPTION
Two things, both docs-only:

1. **Recovers strategy §7** — the taste-recommender section was lost when #360 auto-merged at its first commit before the §7 edit landed. Restored here.
2. **Adds `docs/plans/taste-quiz.md`** — a screen-by-screen spec for the discovery-led taste-profile quiz (onboarding step 1 for non-restricted diners).

## Quiz spec highlights
- **6 screens, skippable after 3**, writing only to the existing `liked/disliked_{tag,ingredient}_ids` arrays — no new persistence model.
- Cuisines → spice → sweet → cooking style → **hero-ingredient love/pass cards** (cilantro!) → optional restrictions link.
- Full signal→array mapping table and analytics plan (quiz funnel + `rec_acceptance`).

## Honest constraints called out
- **Thin flavor taxonomy** — only 12 taste tags exist (flavor = just Spicy + Sweet). Expanding the `flavor` family is a quality prerequisite for a rich quiz.
- **Reducer only has 3-state `CYCLE_*`** — quiz love/pass buttons need explicit `SET_TASTE_*` actions.
- **`fetchTags` excludes `prep` by default** — quiz must request it.
- v2 fast-follow: the "this or that" dish-pair swipe (needs a curated dish set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRdLcz37pH76gfaHMhd5rX