### PR TITLE
docs: launch plan + reversed six-month winning plan

### DIFF
--- a/docs/launch-plan.md
+++ b/docs/launch-plan.md
@@ -1,0 +1,256 @@
+# Launch & Growth Plan
+
+> Consolidated, dependency-ordered execution plan for taking Biteworthy from
+> "code-complete, credential-gated" to launched — plus the loop-shippable growth
+> work (lower-the-gate + restaurant QR) that can run in parallel.
+>
+> **Created:** 2026-06-30 · Derived from `docs/launch-readiness.md`,
+> `docs/roadmap.md`, `docs/strategy-2026-h2.md`, the ADRs, and a code
+> investigation of `apps/web` / `apps/api` / `apps/mobile`. When this doc and the
+> live tracking docs disagree, the tracking docs win — reconcile, don't fork.
+
+## The one structural insight
+
+There are **two independent tracks**, and they have been mistaken for one — which
+is why the project stalled at "feature-complete" with nothing public shipped.
+
+- **Track A — Launch (all human-gated).** Provisioning, payments, a lawyer, DNS,
+  a real-device test. The autonomous delivery loop *cannot touch any of it*. This
+  is the real blocker.
+- **Track B — Lower-the-gate + QR (all loop-shippable code).** Friction removal,
+  SEO/visibility, and the restaurant QR program. The loop is allowed to build
+  every bit of this **today, in parallel**, while the human works Track A.
+
+They converge at launch. The move: **you take Track A; the loop takes Track B.**
+
+---
+
+## The three keystones (start these first)
+
+1. **First `kamal deploy`** — unblocks email, storage, web, seed, screenshots,
+   press. Nothing public exists until this runs.
+2. **L1 attorney sign-off** (Privacy + ToS) — long lead time (external party);
+   blocks DRAFT-banner removal *and* mobile store submission. Start day one even
+   though it finishes late.
+3. **Anthropic billing** — cheap, but unblocks both the AI cassette and the
+   30-restaurant seed.
+
+---
+
+# Track A — Launch sequence (all manual)
+
+Everything below requires **you, by hand**. Grouped into waves; within a wave,
+items run in parallel. HARD = legally/technically blocks public launch; SOFT =
+can launch without, or fast-follow.
+
+### Wave 0 — today, no prerequisites (all parallel)
+
+| Item | Cost | Gate |
+|---|---|---|
+| Create **Hetzner** account + API token + ed25519 SSH key | ~$6/mo all-in | HARD |
+| Create **Neon** `biteworthy-prod` (aws-us-east-1), copy pooled URL | free tier | HARD |
+| Create **GHCR PAT** (`write:packages` + `read:packages`) | free | HARD |
+| **Start L1** — engage Colorado attorney for Privacy + ToS ⏳ *long lead* | varies | HARD |
+| Register **DMCA designated agent (L2)** + repeat-infringer process | ~$6 | HARD (DMCA feature) |
+| Sign up **Postmark / Cloudflare R2 / Vercel / PostHog** accounts | free tiers | mixed |
+| **Apple Developer** ($99/yr) + **Google Play Console** ($25 one-time) | $124 | HARD (mobile) |
+| Turn on **Anthropic billing** | ~$15 total downstream | keystone |
+| Design **`icon-source.svg`** | — | HARD (mobile) |
+| L4 — trademark knockout search + `LICENSE` decision | — | SOFT |
+
+### Wave 1 — needs a box / keys to exist
+
+- [ ] **Point DNS `api.bite-worthy.com` A-record → Hetzner IP**
+- [ ] **Record the AI cassette** — replace the `skip` block in
+      `apps/api/spec/jobs/extract_menu_job_spec.rb` with `VCR.use_cassette`
+      (`record: :once` against `spec/fixtures/menus/sample.jpg`, commit it). ~$0.05.
+      This is also the *first end-to-end proof the ingestion moat works against a
+      real menu.* SOFT (test confidence), but do not skip it.
+
+### Wave 2 — the keystone deploy
+
+- [ ] **Run the first `kamal deploy`** — `kamal setup && kamal env push &&
+      kamal deploy && kamal smoke`; replace the two `<REPLACE_WITH_HETZNER_IP>`
+      placeholders. **HARD. Unlocks every API flow.**
+
+### Wave 3 — needs the API live
+
+- [ ] **Wire Postmark** — verify `bite-worthy.com` sender (DKIM + Return-Path
+      DNS), set Server API Token. SOFT, but needed for password reset / claims /
+      waitlist. (~$15/mo at 10k mails; free ≤100/mo.)
+- [ ] **Create R2 bucket `biteworthy-blobs` + API token.** SOFT, but review/dish
+      photos won't survive deploys without it. (~$1–3/mo.)
+- [ ] **Connect Vercel** (Hobby, free) — import repo, set 3 `NEXT_PUBLIC_*` vars,
+      add `bite-worthy.com` + `www` custom domains (DNS). **HARD for the public site.**
+
+### Wave 4 — needs API + Vercel live
+
+- [ ] **Seed 30 Durango restaurants** — populate `docs/seeds/durango.csv`, run
+      `bin/rails biteworthy:seed:durango` via `kamal app exec`, swipe-verify to the
+      80%-published threshold. ~$15. **HARD — coverage *is* the day-one product.**
+- [ ] **Set PostHog keys** — `NEXT_PUBLIC_POSTHOG_KEY` (Vercel) +
+      `EXPO_PUBLIC_POSTHOG_KEY` (EAS); verify `app_open` fires. SOFT.
+- [ ] **Remove DRAFT banners** from `apps/web/src/app/privacy/page.tsx` +
+      `terms/page.tsx` (+ source DRAFT comments) — **only after L1 sign-off.**
+- [ ] *(loop-shippable)* Phase 5.1.1-wiring — CI `kamal deploy` on master push
+      (roadmap "Next up" #2). Can only be validated after the manual deploy proves out.
+
+### Wave 5 — needs seeded data + icon + L1
+
+- [ ] **Render binary assets + wire `/screenshots/[id]` routes** against seeded
+      restaurants (`apps/mobile/assets/README.md`).
+- [ ] **Fill `eas.json` placeholders** — `REPLACE_WITH_APPLE_ID@bite-worthy.com`,
+      `REPLACE_WITH_ASC_APP_ID`, `REPLACE_WITH_TEAM_ID`; commit the gitignored
+      `play-service-account.json`.
+
+### Wave 6 — final
+
+- [ ] **`eas build` → `eas submit`** (Phase 5.9-wiring). Apple review 1–7 days,
+      Google minutes. HARD for mobile.
+- [ ] **Send press outreach** — customize `docs/outreach/` templates, send ~7 days
+      pre-launch, stage `launch-day.md`. SOFT.
+
+### Also gated on the lawyer (fast-follow, not launch-blocking for the web MVP)
+
+- [ ] **L3** — attorney call on auto-cropping third-party dish photos
+      (`dish_photo_cropper.rb` R2 rehosting). Opt-in-upload fallback exists.
+- [ ] **L5** — "BiteWorthy-safe" badge (flag only, deferred).
+
+### Dependency summary
+
+```
+Hetzner + Neon + GHCR + DNS ─┐
+                             ├─► first `kamal deploy` ─► Postmark / R2 / Vercel+domain
+Anthropic billing ─► cassette┘                        └─► seed 30 ─► screenshots ─► eas submit
+Anthropic billing ─► seed 30                                          │
+L1 attorney ─► remove DRAFT banners ─► (store requires signed docs) ──┘ ─► press
+Apple + Google accounts + icon.svg ─────────────────────────────────► eas submit
+```
+
+**Highest-unblock items:** (a) the first `kamal deploy`; (b) L1 lawyer sign-off;
+(c) Anthropic billing.
+
+---
+
+# Track B — Lower the gate for usage & visibility (loop-shippable now)
+
+The read path is **already fully anonymous**: the API skips auth on restaurant /
+item reads (`apps/api/app/controllers/api/v1/items_controller.rb:19`,
+`restaurants_controller.rb:24`) and already accepts `?profile=<preset>` and
+`?profile_token=<token>` for filtering without an account
+(`items_controller.rb:74-114`). The gate is **purely UI** — there is no logged-out
+filter picker, and the SEO/share plumbing is half-wired. All of the below are code
+fixes the loop can ship while the human does Track A.
+
+### Friction — first value without an account
+
+1. **Anonymous preset/filter picker on the restaurant page + persist to
+   `localStorage`.** *(M — plumbing exists.)* **The linchpin.** It's what makes
+   both the SEO funnel and the QR program deliver a *filtered* menu instead of an
+   unfiltered wall. Backend (`?profile=`, `encodeProfileToken`) is done; only the
+   logged-out UI is missing.
+2. **Let onboarding finish without login** — store the avoid-list as a
+   `profile_token` in `localStorage`, apply via `?p=` across restaurants, offer
+   "save to account" *afterward*. *(M.)* Today onboarding 401s straight to
+   `/login` (`apps/web/src/app/onboarding/page.tsx:144`), so building a filter
+   *requires* an account. Directly attacks the strict-mode-sparsity / activation
+   risk in `docs/strategy-2026-h2.md` §6.
+
+### Visibility — so people can find it at all
+
+3. **Populate `restaurantSlugs` (+ `/u` handles) in the sitemap.** *(S — the hook
+   at `apps/web/src/lib/sitemap.ts:40` exists but is never filled.)* Today **zero
+   restaurant pages are indexed** — only `/`, `/story`, `/login`, `/signup`,
+   `/durango/<diet>`.
+4. **Add `generateMetadata` + Restaurant/Menu JSON-LD to `/restaurants/[slug]`.**
+   *(S–M — copy the `durango/[diet]/page.tsx:42-57` pattern.)* Every restaurant
+   currently shares one generic `<title>`; no rich results, no social unfurls.
+5. **Forward diet context from the durango cards** — link
+   `/restaurants/<slug>?profile=<diet>` instead of bare `/restaurants/<slug>`
+   (`apps/web/src/app/durango/[diet]/page.tsx:180`). *(S — backend already accepts
+   `?profile=`.)* Today an SEO click from "Celiac restaurants in Durango" lands on
+   an **unfiltered** menu, dropping the whole point.
+6. **Write strictness + active filter into the URL** so every filtered view is
+   bookmarkable / shareable / crawlable, not just the clipboard token
+   (`RestaurantClient.tsx` strictness is React-state-only today). *(S.)*
+7. **`generateMetadata` + OG for `/u/[handle]`** (review count, recent reviews) so
+   shared reviewer cards unfurl. *(S — page is already SSR.)*
+8. **OG unfurl for `/r/<slug>?p=` share links** ("N safe dishes at <name>"),
+   building on #4. *(M.)*
+
+**Highest leverage:** #1 (anonymous picker) + #3/#5 (index + don't drop the
+filter). Small, exploit existing public endpoints, and they're the difference
+between "we shipped a page" and "the page is useful and findable."
+
+---
+
+# Track B (cont.) — Restaurant QR program
+
+**Verdict: ~80% already built.** A restaurant QR that goes scan → instant filtered
+menu → (optionally) into the app is mostly a config + image-generation job, not a
+new feature.
+
+### What already exists
+
+- **Stable public URL per restaurant:** `slug` on the model
+  (`apps/api/app/models/restaurant.rb:15`), and `/r/<slug>` re-exports the SSR
+  restaurant page (`apps/web/src/app/r/[slug]/page.tsx`). The fetch is explicitly
+  anonymous. **This is what the QR should encode.**
+- **No-login filtering** via `?p=<token>` on that page, plus a strictness toggle.
+- A custom scheme (`biteworthy`, `apps/mobile/app.json:5`) and a mobile restaurant
+  screen (`apps/mobile/app/restaurants/[id].tsx`).
+- The claim flow already composes per-restaurant URLs
+  (`restaurant_claims_controller.rb:64`) — a natural place to hand owners their QR.
+
+### Phase 1 — web-only (ships now, effort S)
+
+Add QR generation (e.g. the `rqrcode` gem) that encodes
+`https://<host>/r/<slug>`, exposed as an admin/Avo action or a download endpoint.
+That alone delivers "table-tent → scan → filtered web menu, no install."
+
+- **Depends on:** the restaurant being `status: "published"`
+  (`restaurants_controller.rb:53` 404s otherwise) → needs Track A deploy + seed.
+- **Best paired with** Track B lever #1 (anonymous picker) so the scanning diner
+  can actually pick their diet.
+
+### Phase 2 — deep-link into the app (effort M)
+
+- Add `ios.associatedDomains: ["applinks:<host>"]` + `android.intentFilters` for
+  `/r/*` and `/restaurants/*` to `apps/mobile/app.json`.
+- Ship `apple-app-site-association` + `.well-known/assetlinks.json` from
+  `apps/web/public` (+ `next.config.ts` headers for correct content-type).
+- Add the expo-router linking map so `/r/<slug>` resolves to `restaurants/[id]`
+  (server-side `find_by_id_or_slug!` handles slug-vs-UUID).
+- **None of this exists today** (no AASA, no assetlinks, no `associatedDomains`).
+- **Blocked on:** the **Apple Team ID + Android release signing SHA-256**, which
+  come from the Apple/Google accounts in Track A Wave 0 — the one piece of Track B
+  that waits on Track A.
+
+### Why it matters
+
+The QR is a direct answer to the **frequency / cold-start** risk in
+`docs/strategy-2026-h2.md`: a restaurant displaying "see what *you* can eat here"
+is owner-independent distribution that creates coverage and pulls users online
+without an app install — the HappyCow-style loop the strategy is betting on.
+
+---
+
+## Outstanding manual items (Track A checklist)
+
+- [ ] **Hetzner + Neon + GHCR provisioning** → **first `kamal deploy`** (keystone #1)
+- [ ] **Engage attorney for L1 Privacy/ToS sign-off** (keystone #2 — start now, long lead)
+- [ ] **Enable Anthropic billing** (keystone #3)
+- [ ] **Apple Developer ($99) + Google Play ($25) + DMCA agent ($6)**
+- [ ] **Postmark / R2 / Vercel + domain / PostHog** wiring
+- [ ] **Design `icon-source.svg`**
+- [ ] **Seed 30 Durango restaurants**
+- [ ] **Remove DRAFT banners** (post-L1)
+- [ ] **For QR Phase 2:** capture the **Apple Team ID + Android signing SHA-256**
+      when setting up the store accounts
+
+## Recommended first loop PR (Track B)
+
+Lead with the slice that makes everything else deliver value:
+**anonymous filter picker (#1)** + **sitemap / metadata / don't-drop-the-filter
+(#3, #4, #5)** + **QR Phase 1**. These are the keystone of Track B; the rest of the
+visibility work stacks on top.

--- a/docs/plans/six-month-plan.md
+++ b/docs/plans/six-month-plan.md
@@ -1,0 +1,179 @@
+# Six-month plan — reversed into tasks (manual + code)
+
+> The "how do we *win*, not just launch" companion to `docs/launch-plan.md`.
+> Reverses the launch plan + strategy (`docs/strategy-2026-h2.md`) into a
+> sequenced task breakdown, split **[MANUAL]** (human-only) vs **[CODE]**
+> (loop-shippable). Every non-obvious sequencing call is backed by a
+> steelman-both-ways decision (§1). Living doc — check items off as shipped.
+
+**Created:** 2026-07-14 · **Horizon:** July → December 2026 · **Status:** pre-launch (code-complete, credential-gated)
+
+---
+
+## The meta-conclusion
+
+The binding constraint is the **human launch timeline (~2–4 weeks of
+provisioning + attorney sign-off that cannot be compressed)**. Everything else
+is loop-shippable code that should run *inside* that window and then be gated on
+real canaries — not the 2026-06-18 strategy hunches.
+
+All three strategic debates below resolve to the same shape:
+**parallelize the human and code tracks, then gate every subsequent build on
+evidence.** Use the unavoidable launch-prep window to pre-build the retention
+hook + the safety guardrails + SEO; launch small; then let the three canaries
+(§4) drive discovery, gamification, monetization, and city #2.
+
+---
+
+## 1. The three decisions (steelman both ways → verdict)
+
+### A. Sequencing — launch thin now, or build the retention loop first?
+- **Steelman "launch now":** Frequency is unproven; the fastest way to learn is
+  real users. Every week pre-building a loop nobody has validated is a week of
+  guessing. Ship, measure, then build what the data demands.
+- **Steelman "loop first":** A high-value/low-frequency tool with no retention
+  hook churns its first cohort — and you only get one first impression with a
+  small Durango word-of-mouth base. Launching into an empty-menu, one-and-done
+  experience burns the scarce early audience.
+- **Verdict — overlap them.** The human launch path takes ~2–4 weeks regardless;
+  that window is free build time. Launch on the Track A timeline, but pre-build
+  *exactly one* retention hook (the confirm/dispute ✓/✗ micro-loop) + the
+  anonymous filter picker so day-one strict users never hit an empty page. Defer
+  the gamified contribution *identity* until the micro-loop shows engagement.
+
+### B. Positioning — discovery-led for everyone, or safety-first wedge?
+- **Steelman "discovery-led":** "What should I order?" fires for ~everyone at
+  every restaurant — 3–4× the TAM and the only mass-market answer to the
+  frequency problem. The scoring engine is already built (Phase 8); it's a
+  frontend reorder, not a new product.
+- **Steelman "safety-first wedge":** Honest disclosure is the *only* moat — the
+  one thing EveryBite/Olo and the grocery scanners structurally can't copy.
+  Leading with generic discovery throws away the defensible identity and invites
+  a Yummly-style "discovery without grounding wasn't defensible" death.
+- **Verdict — sequence, don't choose.** Keep the wedge-first identity (safety,
+  restricted diners) as the launch headline. Ship discovery only as a Top Picks
+  layer *inside* already-safe menus. Flip the headline to "what should I order?"
+  only if **rec-acceptance clears a bar (~30% tap/save) with the safety canaries
+  green**. Instrument rec-acceptance from day one so the pivot is a data call,
+  not a vibe.
+
+### C. Trust vs. scale — is honest disclosure enough, or harden before opening?
+- **Steelman "enough":** The confidence/source model + strict mode + "show why"
+  already encode safety in the schema. Over-hardening before you have users is
+  premature; ship and add guards when scale demands them.
+- **Steelman "harden first":** One cross-contamination incident is existential
+  (strategy §6). The false-negative — a hidden allergen rendered as safe — is
+  "the one unforgivable bug." At scale, community publishing invites vandalism
+  the 80%-threshold can't catch.
+- **Verdict — guard the fatal mechanism now, defer scale-gated hardening.** The
+  three guardrail tests (parity, array-sync, adversarial hidden-allergen) are
+  near-free and CI-blocking → **P0 before launch**. Anti-vandalism /
+  trusted-contributor weighting only matters at scale → **P1, gated on leaving
+  Durango**. Cross-contamination disclaimer copy reviewed at L1.
+
+---
+
+## 2. The reversed task plan
+
+Tags: **[MANUAL]** = human-only · **[CODE]** = loop-shippable · P0/P1/P2 = priority.
+
+### Phase 0 — The launch window (Weeks 0–4): two streams in parallel
+
+**Stream 1 — [MANUAL] Track A critical path** (the real gate; detail in `docs/launch-plan.md`)
+- [ ] **Provision Hetzner cx22 → Neon → GHCR PAT → first `kamal deploy`** (keystone)
+- [ ] **Engage the L1 attorney on `/privacy` + `/terms` — day one** (long lead; blocks DRAFT-banner removal + store submission). Also get the **L3 dish-photo auto-crop liability ruling**.
+- [ ] **Enable Anthropic billing**
+- [ ] **Apple Developer ($99) + Google Play ($25) + DMCA agent ($6)**; **design `icon-source.svg`**
+- [ ] **Postmark SMTP · Cloudflare R2 · Vercel (domain + SSR) · PostHog API key**
+- [ ] **Seed 30 Durango restaurants (~$15 ingestion)** — coverage *is* the day-one product
+- [ ] **Set up Neon snapshots** — ADR-0007 admits no self-snapshot today; one un-backed-up wipe during early word-of-mouth is a pre-mortem death. Don't launch without it.
+- [ ] **Gate: verify strict-mode `visible_count` is non-trivial on seeded data *before* inviting anyone** (the empty-menu check)
+
+**Stream 2 — [CODE] pre-launch, ships during the window**
+- [ ] **[P0] The three safety guardrails** — highest-value code in the plan:
+  - Parity test: `packages/filter-engine` output ≡ API SQL filter on a shared adversarial fixture set (allergen present/absent × strict on/off), **CI-blocking**
+  - Array-sync invariant + nightly reconciliation: `items.ingredient_ids/tag_ids` always equal the join rows; alert on drift
+  - Adversarial test: a `suggested`/self-accepted item with a hidden allergen must **never** render safe for a user avoiding it, in any mode
+- [ ] **[P0] Anonymous filter picker on `/r/<slug>` + `localStorage`** — kills the empty-first-impression risk (backend already supports `?profile=`/`?profile_token=`)
+- [ ] **[P0] Confirm/dispute "✓/✗" micro-loop** → writes a suggestion/verification. The *one* retention hook; also backfills strict-mode confirmations (fixes sparsity). Not the gamified identity yet.
+- [ ] **[P0] Instrumentation before first user:** week-2 return rate, strict-mode `visible_count`, coverage velocity, **rec-acceptance** (tap/save on a Top Pick)
+- [ ] **[P1] Visibility / SEO:** populate `restaurantSlugs` in the sitemap, add `generateMetadata` + Restaurant/Menu JSON-LD, forward diet context from durango cards (`?profile=<diet>`). SEO compounds — start early.
+- [ ] **[P1] QR Phase 1 (web-only)** — encode `https://<host>/r/<slug>`; owner-independent distribution, zero install
+- [ ] **[P1] Top Picks row *inside* safe menus only**, labeled provisional (discovery as a within-safety layer)
+- [ ] **[MANUAL] Copy review:** cross-contamination + "not a medical guarantee" disclaimers reviewed at L1 — never let marketing say "safe"
+
+### Phase 1 — Soft launch & learn (Month 1–2)
+- [ ] **[MANUAL] Soft-launch to Durango restricted diners**; watch the three canaries ~2–3 weeks before any wider push
+- [ ] **[MANUAL] Founder spot-audit** the first community-published restaurants
+- [ ] **[CODE]** Finish **anonymous onboarding** (avoid-list → `profile_token` in `localStorage`, "save to account" offered *after*) so building a filter no longer requires signup
+- [ ] **[CODE]** Keep onboarding **dietary-first**; taste is an optional/skippable step (not step 1 yet)
+- [ ] **[CODE] QR Phase 2 (deep-link)** — add `associatedDomains` + `intentFilters` + AASA/assetlinks, once the **Apple Team ID + Android signing SHA** exist from the store accounts
+- [ ] **[MANUAL]** Write the **pivot gate** into the strategy doc: widen the front door only if rec-acceptance ≥ threshold **AND** safety canaries green
+
+### Phase 2 — The retention loop (Month 3, highest-leverage build)
+- [ ] **[CODE]** Contribution identity on `/u/[handle]` (confirmation count, "menus you keep accurate," city rank) — **only if the ✓/✗ micro-loop showed engagement**
+- [ ] **[CODE]** Verify the loop raises strict-mode coverage *and* repeat visits
+- [ ] **Decision gate:** is week-2 return rate trending up? If not, this loop is the whole ballgame — iterate here before anything else.
+
+### Phase 3 — Frequency + the positioning decision (Month 4)
+- [ ] **[MANUAL] Month-4 review: decide the discovery-led repositioning on the rec-acceptance metric, not vibes**
+- [ ] **[CODE]** If the gate passed: forced-choice **taste quiz** (flagged, dark-launched first), starter taste profiles, discovery-led onboarding reorder
+- [ ] **[CODE]** "Safe near me" / "what should I order near me" (needs `expo-location`)
+- [ ] **[CODE][P1] Trusted-contributor weighting + spam/vandalism gate** — required **before** any city beyond Durango (≥2 independent verifiers or 1 trusted for auto-publish)
+
+### Phase 4 — Monetize + harden (Month 5)
+- [ ] **[CODE]** Freemium gate: free = N scans/mo + filtering; premium (~$20–30/yr) = unlimited scans, multi-profile, strict mode, offline, **table/group mode** (the last only after rec-acceptance is proven)
+- [ ] **[MANUAL] Set up billing** (App Store / Play IAP or Stripe) — new manual item for premium
+- [ ] **[CODE]** Fix the analytics/throttle **IP-bucketing race** (shared store, not per-process MemoryStore) before scaling
+- [ ] **[CODE]** Harden monitoring: alert on `visible_count` anomalies and on any post-publish edit that *removes* an allergen (tampering/error signal)
+
+### Phase 5 — Expand on evidence (Month 6)
+- [ ] **[MANUAL] Expand to city #2 only if the week-2 canary went green** after the Month-3 loop; pick it by where waitlist/organic interest clusters
+
+---
+
+## 3. Dependency shape
+
+```
+[MANUAL] provision ──► kamal deploy ──► seed Durango ──► visible_count gate ──► SOFT LAUNCH
+   │                                                          ▲
+   │  (runs in parallel, same 2–4 wk window)                  │
+[CODE] P0 guardrails ─► anon picker ─► ✓/✗ micro-loop ─► instrumentation ──┘
+[CODE] SEO + QR Ph1 ──────────────────────────────────────► (compounds post-launch)
+
+SOFT LAUNCH ──► week-2 canary ──► Month-3 retention loop ──► [gate] ──► discovery pivot / near-me
+                                                              │
+                                                              └─► [gate] ──► monetize ──► city #2
+```
+
+## 4. What "winner in 6 months" means (the scoreboard)
+
+Three numbers decide it (strategy §5); everything above is in service of them:
+1. **Week-2 return rate** ≥ ~15% (frequency canary) — the retention loop's job
+2. **Coverage velocity** positive and compounding (menus scanned/week via users) — the moat
+3. **Strict-mode `visible_count`** non-trivial (the safest users see real options) — the trust check
+
+Plus two pass/fail guards: **zero safety incidents** (P0 tests hold) and
+**rec-acceptance measured** before any discovery pivot.
+
+## 5. Decision gates (don't build ahead of these)
+
+| Gate | Unlocks | Metric |
+|---|---|---|
+| `visible_count` non-trivial on seed | Invite the first users | Strict-mode visible count > 0 across seeded venues |
+| ✓/✗ micro-loop shows engagement | Build the contribution *identity* (Ph 2) | Confirmations/user trending up |
+| Week-2 return rate green | Frequency surfaces + expansion | ≥ ~15% |
+| Rec-acceptance ≥ ~30% + safety green | Discovery-led repositioning (Ph 3) | Top-Pick tap/save rate |
+| Anti-vandalism gate shipped | Any city beyond Durango | Trusted-contributor weighting live |
+
+---
+
+## Outstanding manual items (still human-only — none loop-shippable)
+
+- [ ] **Provisioning → first `kamal deploy`** (keystone)
+- [ ] **Engage L1 attorney now** (keystone, long lead) + **L3 dish-photo ruling**
+- [ ] **Anthropic billing**; **Apple + Google + DMCA**; **design icon SVG**; **seed 30 Durango**
+- [ ] **Set up Neon snapshots** (no backup exists today — real data-loss risk)
+- [ ] **Verify strict-mode `visible_count` before inviting anyone**
+- [ ] **For QR Phase 2:** capture **Apple Team ID + Android signing SHA** at store-account setup
+- [ ] **Month-4:** make the discovery-pivot call on data; **Month-5:** set up billing; **Month-6:** city-#2 go/no-go on the canary

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,15 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-14 — planning (interactive, no tick). Added `docs/launch-plan.md`
+(two-track launch: manual Track A critical path + loop-shippable Track B
+lower-the-gate + QR program) and `docs/plans/six-month-plan.md` (the
+"how do we win, not just launch" reversal — three steelman-resolved
+decisions on sequencing/positioning/trust, tasks split [MANUAL]/[CODE]
+across 6 months, gated on the strategy §5 canaries). No code changed yet;
+recommended first build = the P0 safety guardrails (filter-engine↔SQL
+parity, array-sync invariant, adversarial hidden-allergen test).
+
 2026-06-14 — post-loop interactive work (no tick number; the cron loop
 stayed paused). Two workstreams landed on master after tick #147, neither
 of which had a status entry until now:


### PR DESCRIPTION
## Summary
- Adds `docs/launch-plan.md` — two-track launch: manual Track A critical path (provision → `kamal deploy` → seed) + loop-shippable Track B (lower-the-gate levers + QR program).
- Adds `docs/plans/six-month-plan.md` — reverses the plan into tasks split **[MANUAL]**/**[CODE]** across six months, backed by three steelman-resolved decisions (sequencing, positioning, trust-vs-scale) and gated on the strategy §5 canaries.
- Docs only; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8CabuYFTqo1dHKj9To5jY
