### PR TITLE
fix(api): set ALLOWED_ORIGINS for CORS + point SMTP at Mailgun

### DIFF
--- a/apps/api/config/deploy.yml
+++ b/apps/api/config/deploy.yml
@@ -83,15 +83,20 @@ env:
     RAILS_LOG_TO_STDOUT: "true"
     RAILS_SERVE_STATIC_FILES: "true"
     PUBLIC_HOST: https://api.bite-worthy.com
+    # Browser (bite-worthy.com) reads public taxonomy from the Rails API
+    # directly (onboarding presets/tags/ingredient search), so rack-cors
+    # must allow the web origins. Space-separated; see initializers/cors.rb.
+    ALLOWED_ORIGINS: https://bite-worthy.com https://www.bite-worthy.com
     SOLID_QUEUE_IN_PUMA: "false"
     # libjemalloc trims puma RSS by ~30%; the Dockerfile installs
     # the lib but the loader has to be told to use it.
     LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
     # Mailer host is the WEB origin (Phase 5.4 Vercel), not the API.
     MAILER_HOST: https://bite-worthy.com
-    # SMTP defaults — Postmark per ADR 0003. Override via secrets if
-    # the human picks a different provider.
-    SMTP_ADDRESS: smtp.postmarkapp.com
+    # SMTP — the zone was already wired for Mailgun (MX/SPF/DKIM), so we
+    # use it instead of Postmark. SMTP_USERNAME/SMTP_PASSWORD are the
+    # Mailgun SMTP credentials (secrets).
+    SMTP_ADDRESS: smtp.mailgun.org
     SMTP_PORT: "587"
     SMTP_DOMAIN: bite-worthy.com
   secret:

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,24 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-14 (post-launch fixes 2) — CORS + email. Branch `fix/production-cors`.
+
+- **Onboarding was broken ("Could not load presets — Failed to fetch")** — the
+  page is a client component that reads public taxonomy from the Rails API
+  directly (`${NEXT_PUBLIC_API_BASE}/api/v1/...`), a cross-origin browser call.
+  `rack-cors` (`initializers/cors.rb`) defaults `ALLOWED_ORIGINS` to localhost
+  and it was never set in prod, so the API sent no `Access-Control-Allow-Origin`
+  for `https://bite-worthy.com`. Fixed: `ALLOWED_ORIGINS=https://bite-worthy.com
+  https://www.bite-worthy.com` in `deploy.yml` env.clear + `kamal deploy`.
+  Verified header present and all 10 presets load.
+- **Mailgun snag:** `SMTP_ADDRESS` switched to `smtp.mailgun.org` in deploy.yml,
+  BUT the WBW Mailgun account only has `whiteboardworks.com` + a sandbox —
+  **`bite-worthy.com` is NOT a domain there**, so the zone's Mailgun DNS records
+  don't map to a usable sending domain and there are no bite-worthy.com SMTP
+  creds. Email still unwired pending a decision (add bite-worthy.com to Mailgun /
+  send from whiteboardworks.com / different account). `kamal deploy` gotcha
+  recap: run `kamal` directly (not `bundle exec kamal` — it's not in the Gemfile).
+
 2026-07-14 (post-launch fixes) — content seeding + Durango SEO. Branch
 `fix/durango-diet-slugs`.
 


### PR DESCRIPTION
## Summary

- `/onboarding` (and any browser-side API read) failed with "Failed to fetch": `rack-cors` defaulted `ALLOWED_ORIGINS` to localhost and it was never set in production, so the API sent no `Access-Control-Allow-Origin` for `https://bite-worthy.com`. Set it to the web origins.
- Point `SMTP_ADDRESS` at `smtp.mailgun.org` (the zone was wired for Mailgun); the `SMTP_USERNAME`/`SMTP_PASSWORD` secrets are still pending a domain decision (bite-worthy.com isn't yet a Mailgun sending domain).

Already applied to production via `kamal deploy`; verified the CORS header is present and all 10 onboarding presets load.
