### PR TITLE
chore(api): switch SMTP to Resend (mail.bite-worthy.com)

### DIFF
--- a/apps/api/config/deploy.yml
+++ b/apps/api/config/deploy.yml
@@ -93,12 +93,14 @@ env:
     LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
     # Mailer host is the WEB origin (Phase 5.4 Vercel), not the API.
     MAILER_HOST: https://bite-worthy.com
-    # SMTP — the zone was already wired for Mailgun (MX/SPF/DKIM), so we
-    # use it instead of Postmark. SMTP_USERNAME/SMTP_PASSWORD are the
-    # Mailgun SMTP credentials (secrets).
-    SMTP_ADDRESS: smtp.mailgun.org
+    # SMTP — Resend (mail.bite-worthy.com is the verified sending domain).
+    # Username is the literal "resend"; the API key is SMTP_PASSWORD (secret).
+    # From-address must live under the verified domain, hence @mail.
+    SMTP_ADDRESS: smtp.resend.com
     SMTP_PORT: "587"
-    SMTP_DOMAIN: bite-worthy.com
+    SMTP_DOMAIN: mail.bite-worthy.com
+    SMTP_USERNAME: resend
+    DEVISE_MAILER_FROM: no-reply@mail.bite-worthy.com
   secret:
     # Rails core
     - RAILS_MASTER_KEY
@@ -109,8 +111,7 @@ env:
     # Avo admin (Phase 1.5)
     - ADMIN_USERNAME
     - ADMIN_PASSWORD
-    # SMTP (Phase 5.2 — Postmark token in both fields)
-    - SMTP_USERNAME
+    # SMTP — Resend API key (username "resend" is non-secret, in env.clear)
     - SMTP_PASSWORD
     # ActiveStorage on Cloudflare R2 (Phase 5.3)
     - R2_ACCESS_KEY_ID


### PR DESCRIPTION
## Summary

- Mailgun's free plan rejected adding `bite-worthy.com` as a second sending domain (403), so switch transactional email to Resend (already used by other WBW projects).
- Verified Resend domain is the subdomain `mail.bite-worthy.com`, so from-address moves to `no-reply@mail.bite-worthy.com` and `SMTP_ADDRESS=smtp.resend.com`, `SMTP_USERNAME=resend`.

Draft until the Resend DNS records verify and the API key is wired as `SMTP_PASSWORD`; then deploy + email smoke test.
