### PR TITLE
chore(ci): add deploy-api workflow (kamal deploy on merge to master)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,88 @@
+name: Deploy API
+
+# Ships apps/api to the Hetzner box (87.99.137.181) via Kamal on every merge to
+# master that touches the API. ci-api (rspec + brakeman) is a required PR check,
+# so master is already green by the time this runs. Trigger it by hand from the
+# Actions tab (workflow_dispatch) to redeploy the current master.
+#
+# ── Required repo secrets (Settings → Secrets and variables → Actions) ──
+#   KAMAL_SECRETS_B64   base64 of apps/api/.kamal/secrets — the same file Kamal
+#                       reads locally, holding every app secret AND
+#                       KAMAL_REGISTRY_PASSWORD. Regenerate after rotating any
+#                       value with:  base64 -i apps/api/.kamal/secrets | pbcopy
+#   SSH_PRIVATE_KEY     private key with root@87.99.137.181 access (the box's
+#                       provisioning key), full text including the BEGIN/END lines.
+#
+# Kamal builds the amd64 image on the runner and pushes it to GHCR itself (it
+# logs in with KAMAL_REGISTRY_PASSWORD from the secrets file), then SSHes to the
+# box to pull + boot. The entrypoint runs db:prepare on boot, so migrations ride
+# along; kamal-proxy keeps traffic on the old release until /up passes.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/deploy-api.yml'
+  workflow_dispatch:
+
+concurrency:
+  # Serialize deploys; never cancel one mid-flight (would leave a half cutover).
+  group: deploy-api
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.6'
+          bundler-cache: false
+
+      - name: Install Kamal
+        run: gem install kamal -v 2.12.0 --no-document
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Preflight — required secrets present
+        env:
+          KAMAL_SECRETS_B64: ${{ secrets.KAMAL_SECRETS_B64 }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          : "${KAMAL_SECRETS_B64:?Set the KAMAL_SECRETS_B64 repo secret (base64 of apps/api/.kamal/secrets)}"
+          : "${SSH_PRIVATE_KEY:?Set the SSH_PRIVATE_KEY repo secret (key with root@87.99.137.181 access)}"
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -H 87.99.137.181 >> ~/.ssh/known_hosts 2>/dev/null
+          cat > ~/.ssh/config <<'CFG'
+          Host 87.99.137.181
+            User root
+            IdentityFile ~/.ssh/id_deploy
+            IdentitiesOnly yes
+          CFG
+          chmod 600 ~/.ssh/config
+
+      - name: Materialize Kamal secrets
+        env:
+          KAMAL_SECRETS_B64: ${{ secrets.KAMAL_SECRETS_B64 }}
+        run: |
+          printf '%s' "$KAMAL_SECRETS_B64" | base64 -d > apps/api/.kamal/secrets
+          test -s apps/api/.kamal/secrets
+
+      - name: Kamal deploy
+        working-directory: apps/api
+        run: kamal deploy
+
+      - name: Scrub secrets from the runner
+        if: always()
+        run: rm -f apps/api/.kamal/secrets ~/.ssh/id_deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,4 +192,4 @@ Two workflows gate PRs:
 
 Both are required for auto-merge. Don't request human review on red.
 
-Other workflows run but don't gate auto-merge: `migration-guard.yml` (blocks edits to previously-shipped migrations under `apps/api/db/migrate/`), `ci-nightly.yml` (nightly full suite), `codeql.yml` (security scan), `expo-align.yml` (mobile Expo-SDK dependency alignment), `labeler.yml` (auto-labels PRs, feeds the auto-merge opt-in), `pr-title.yml` (conventional-commit title check), `auto-merge.yml` (the merge driver).
+Other workflows run but don't gate auto-merge: `migration-guard.yml` (blocks edits to previously-shipped migrations under `apps/api/db/migrate/`), `ci-nightly.yml` (nightly full suite), `codeql.yml` (security scan), `expo-align.yml` (mobile Expo-SDK dependency alignment), `labeler.yml` (auto-labels PRs, feeds the auto-merge opt-in), `pr-title.yml` (conventional-commit title check), `auto-merge.yml` (the merge driver), `deploy-api.yml` (runs `kamal deploy` to Hetzner on merge to master touching `apps/api/**`, or on manual `workflow_dispatch`; needs the `KAMAL_SECRETS_B64` + `SSH_PRIVATE_KEY` repo secrets).

--- a/apps/api/config/deploy.yml
+++ b/apps/api/config/deploy.yml
@@ -22,8 +22,10 @@
 #   kamal env push         # uploads secrets
 #   kamal deploy           # full deploy with db:prepare release
 #
-# Subsequent deploys: `kamal deploy` from the laptop. CI automation
-# is a separate small follow-up after manual deploys are proven.
+# Subsequent deploys: automatic. `.github/workflows/deploy-api.yml` runs
+# `kamal deploy` on every merge to master touching apps/api (or on manual
+# workflow_dispatch). Run `kamal deploy` from the laptop for out-of-band
+# ships; it needs .kamal/secrets + SSH access to the box + Docker.
 
 service: biteworthy-api
 image: whiteboard-works/biteworthy-api

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,19 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-15 — API auto-deploy. Branch `chore/api-auto-deploy`.
+
+- Added `.github/workflows/deploy-api.yml`: runs `kamal deploy` on merge to
+  master touching `apps/api/**` (or manual `workflow_dispatch`). Builds the
+  amd64 image on the runner, pushes to GHCR, SSHes root@87.99.137.181 to boot;
+  `concurrency: deploy-api` serializes, `cancel-in-progress: false`. Web already
+  auto-deploys via Vercel; this closes the API gap (was manual `kamal deploy`).
+- **Secrets model:** one blob instead of ~17 keys — `KAMAL_SECRETS_B64` =
+  base64 of `apps/api/.kamal/secrets` (decoded to the file in CI, holds every
+  app secret + KAMAL_REGISTRY_PASSWORD), plus `SSH_PRIVATE_KEY` (root@box key).
+  **MANUAL, user: add both repo secrets before the first run**, else the
+  preflight step fails loudly.
+
 2026-07-14 (post-launch fixes 2) — CORS + email. Branch `fix/production-cors`.
 
 - **Onboarding was broken ("Could not load presets — Failed to fetch")** — the


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-api.yml` — runs `kamal deploy` to Hetzner on every merge to `master` touching `apps/api/**` (or manual `workflow_dispatch`), closing the API auto-deploy gap (web already ships via Vercel).
- Builds the amd64 image on the runner → GHCR → SSHes `root@87.99.137.181` to boot; `concurrency` serializes deploys and never cancels one mid-flight.

**Requires two repo secrets before the first run** (Settings → Secrets and variables → Actions): `KAMAL_SECRETS_B64` (base64 of `apps/api/.kamal/secrets`) and `SSH_PRIVATE_KEY` (root@box key). A preflight step fails loudly if either is missing.
