### PR TITLE
chore(api): add kamal-secrets-push helper for CI secret rotation

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -8,8 +8,9 @@ name: Deploy API
 # ── Required repo secrets (Settings → Secrets and variables → Actions) ──
 #   KAMAL_SECRETS_B64   base64 of apps/api/.kamal/secrets — the same file Kamal
 #                       reads locally, holding every app secret AND
-#                       KAMAL_REGISTRY_PASSWORD. Regenerate after rotating any
-#                       value with:  base64 -i apps/api/.kamal/secrets | pbcopy
+#                       KAMAL_REGISTRY_PASSWORD. After changing any value in
+#                       .kamal/secrets, resync it with:
+#                         apps/api/bin/kamal-secrets-push   (add --deploy to ship)
 #   SSH_PRIVATE_KEY     private key with root@87.99.137.181 access (the box's
 #                       provisioning key), full text including the BEGIN/END lines.
 #

--- a/apps/api/bin/kamal-secrets-push
+++ b/apps/api/bin/kamal-secrets-push
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Sync apps/api/.kamal/secrets → the KAMAL_SECRETS_B64 GitHub Actions secret
+# that .github/workflows/deploy-api.yml decodes at deploy time.
+#
+# The deploy workflow can't read your local .kamal/secrets, so it reads a
+# base64 copy of it from the KAMAL_SECRETS_B64 repo secret. Whenever you change
+# ANY value in .kamal/secrets (rotate a key, swap a provider, etc.), run this so
+# auto-deploy uses the new values:
+#
+#   apps/api/bin/kamal-secrets-push            # push the secret
+#   apps/api/bin/kamal-secrets-push --deploy   # push, then kick off a deploy
+#
+# Requires the gh CLI, authenticated (`gh auth login`) with repo access.
+# (The SSH_PRIVATE_KEY secret is separate and only changes on key rotation.)
+set -euo pipefail
+
+REPO="whiteboard-works/biteworthy"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+secrets_file="$here/../.kamal/secrets"
+
+if [[ ! -s "$secrets_file" ]]; then
+  echo "error: $secrets_file is missing or empty — nothing to push" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI not found. Install it (https://cli.github.com) and run 'gh auth login'." >&2
+  exit 1
+fi
+
+# tr strips the line wrapping macOS `base64` adds; the workflow decodes with
+# plain `base64 -d`, which is happy either way, but single-line is tidiest.
+base64 < "$secrets_file" | tr -d '\n' | gh secret set KAMAL_SECRETS_B64 --repo "$REPO"
+echo "✓ KAMAL_SECRETS_B64 updated from apps/api/.kamal/secrets"
+
+if [[ "${1:-}" == "--deploy" ]]; then
+  echo "→ dispatching deploy-api…"
+  gh workflow run deploy-api.yml --repo "$REPO" --ref master
+  echo "✓ deploy triggered — watch it in the Actions tab (or: gh run watch \$(gh run list --workflow deploy-api.yml --limit 1 --json databaseId --jq '.[0].databaseId'))"
+else
+  echo "  New values take effect on the next deploy. To ship now:"
+  echo "    apps/api/bin/kamal-secrets-push --deploy    # or merge an apps/api change to master"
+fi

--- a/docs/status.md
+++ b/docs/status.md
@@ -28,7 +28,12 @@ the Phase 5 pause) are archived in
   base64 of `apps/api/.kamal/secrets` (decoded to the file in CI, holds every
   app secret + KAMAL_REGISTRY_PASSWORD), plus `SSH_PRIVATE_KEY` (root@box key).
   **MANUAL, user: add both repo secrets before the first run**, else the
-  preflight step fails loudly.
+  preflight step fails loudly. First run (on the #405 merge) went green —
+  pipeline validated end-to-end.
+- **Secret rotation helper** `apps/api/bin/kamal-secrets-push`: re-encodes
+  `.kamal/secrets` → the `KAMAL_SECRETS_B64` repo secret via `gh secret set`
+  (add `--deploy` to also dispatch deploy-api). Run it after changing any
+  secret value so auto-deploy picks up the new values.
 
 2026-07-14 (post-launch fixes 2) — CORS + email. Branch `fix/production-cors`.
 


### PR DESCRIPTION
## Summary

- Adds `apps/api/bin/kamal-secrets-push`: re-encodes `.kamal/secrets` → the `KAMAL_SECRETS_B64` repo secret via `gh secret set`, so rotating a value is one command instead of a manual encode-and-paste. `--deploy` also dispatches deploy-api.
- Points the deploy-api workflow's rotation note at the helper.
