### PR TITLE
fix(web): auth nav, onboarding exit, and longer sessions

### DIFF
--- a/apps/api/config/initializers/devise_jwt.rb
+++ b/apps/api/config/initializers/devise_jwt.rb
@@ -28,6 +28,12 @@ Devise.setup do |config|
       ["DELETE", %r{^/api/v1/auth/logout$}]
     ]
 
-    jwt.expiration_time = 30.minutes.to_i
+    # Token lifetime matches the web `bw_session` cookie (30 days) so a
+    # signed-in session doesn't silently die mid-use — the web client
+    # has no refresh wired, so a shorter access token would 401 every
+    # authenticated call once it lapsed while the cookie still lived.
+    # Revocation still works: logout rotates the user's jti, killing the
+    # token immediately regardless of its expiry.
+    jwt.expiration_time = 30.days.to_i
   end
 end

--- a/apps/api/spec/requests/api/v1/auth/login_spec.rb
+++ b/apps/api/spec/requests/api/v1/auth/login_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe "POST /api/v1/auth/login", type: :request do
     expect(response.parsed_body["user"]).to include("email" => user.email)
   end
 
+  it "issues a long-lived token so the session outlives a single sitting" do
+    # Regression: the token used to expire in 30 minutes while the web
+    # session cookie lived 30 days and nothing refreshed it, so any
+    # authenticated call after ~30 min 401'd. The token must now last
+    # well beyond a single session (matched to the cookie's 30 days).
+    post "/api/v1/auth/login",
+         params: { user: { email: user.email, password: "password123" } },
+         as: :json
+
+    token   = response.headers["Authorization"].sub(/\ABearer /, "")
+    payload = Warden::JWTAuth::TokenDecoder.new.call(token)
+    ttl     = payload["exp"] - Time.now.to_i
+
+    expect(ttl).to be > 1.day.to_i
+  end
+
   it "rejects a wrong password with 401" do
     post "/api/v1/auth/login",
          params: { user: { email: user.email, password: "wrong" } },

--- a/apps/web/src/app/_SiteHeader.tsx
+++ b/apps/web/src/app/_SiteHeader.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { logout } from '../lib/auth';
+
+/**
+ * Site-wide top bar. Until now the app had no nav at all: there was no
+ * way to reach /login, and a signed-in user got no indication they were
+ * logged in (the HttpOnly `bw_session` cookie is invisible to JS).
+ *
+ * Auth state comes from `GET /api/auth/session` (a `{ signedIn }` read
+ * that the server does against the cookie) rather than a cookie the
+ * client reads directly — so the SSR/SEO pages stay static and only
+ * this component pays the per-request read.
+ */
+export function SiteHeader() {
+  const router = useRouter();
+  // null = not yet known; render a neutral bar to avoid a Sign-in →
+  // Account flash and the layout shift that comes with it.
+  const [signedIn, setSignedIn] = useState<boolean | null>(null);
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/auth/session', { credentials: 'same-origin' })
+      .then((r) => (r.ok ? r.json() : { signedIn: false }))
+      .then((d: { signedIn?: boolean }) => {
+        if (active) setSignedIn(Boolean(d.signedIn));
+      })
+      .catch(() => {
+        if (active) setSignedIn(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const onLogout = async () => {
+    setLoggingOut(true);
+    try {
+      await logout();
+    } catch {
+      // The cookie is cleared client-side regardless; a failed upstream
+      // jti-rotation still leaves the browser signed out.
+    }
+    setSignedIn(false);
+    setLoggingOut(false);
+    router.replace('/');
+    router.refresh();
+  };
+
+  return (
+    <header
+      data-testid="site-header"
+      className="flex items-center justify-between border-b border-zinc-200 bg-white px-bw-6 py-bw-3"
+    >
+      <Link href="/" className="text-bw-lg font-bold text-bite hover:text-bite-dark">
+        BiteWorthy
+      </Link>
+
+      {/* Reserve height while auth state resolves so the bar doesn't jump. */}
+      <nav className="flex min-h-[1.5rem] items-center gap-bw-4 text-bw-sm">
+        {signedIn === true && (
+          <>
+            <Link
+              href="/profile/settings"
+              data-testid="nav-account"
+              className="font-semibold text-zinc-700 hover:text-bite-dark"
+            >
+              Account
+            </Link>
+            <button
+              type="button"
+              onClick={onLogout}
+              disabled={loggingOut}
+              data-testid="nav-logout"
+              className="font-semibold text-zinc-500 hover:text-zinc-800 disabled:opacity-60"
+            >
+              {loggingOut ? 'Logging out…' : 'Log out'}
+            </button>
+          </>
+        )}
+        {signedIn === false && (
+          <Link
+            href="/login"
+            data-testid="nav-signin"
+            className="font-semibold text-bite hover:text-bite-dark"
+          >
+            Sign in
+          </Link>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/apps/web/src/app/_SiteHeader.tsx
+++ b/apps/web/src/app/_SiteHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { logout } from '../lib/auth';
 
 /**
@@ -17,11 +17,17 @@ import { logout } from '../lib/auth';
  */
 export function SiteHeader() {
   const router = useRouter();
+  const pathname = usePathname();
   // null = not yet known; render a neutral bar to avoid a Sign-in →
   // Account flash and the layout shift that comes with it.
   const [signedIn, setSignedIn] = useState<boolean | null>(null);
   const [loggingOut, setLoggingOut] = useState(false);
 
+  // Re-read on every navigation (keyed on pathname), not just mount: a
+  // login/logout redirect is a soft nav that keeps this component
+  // mounted, so a mount-only check would show stale "Sign in" right
+  // after signing in. The previous value stays put while re-fetching,
+  // so there's no flash between routes.
   useEffect(() => {
     let active = true;
     fetch('/api/auth/session', { credentials: 'same-origin' })
@@ -35,7 +41,7 @@ export function SiteHeader() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [pathname]);
 
   const onLogout = async () => {
     setLoggingOut(true);

--- a/apps/web/src/app/__tests__/SiteHeader.test.tsx
+++ b/apps/web/src/app/__tests__/SiteHeader.test.tsx
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * The site-wide nav that gives a signed-in user any indication they're
+ * logged in (and everyone a way to reach /login). Auth state comes from
+ * GET /api/auth/session; logout goes through lib/auth.
+ */
+
+const mockReplace = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, refresh: mockRefresh }),
+}));
+
+const mockLogout = vi.fn();
+vi.mock('../../lib/auth', () => ({
+  logout: () => mockLogout(),
+}));
+
+import { SiteHeader } from '../_SiteHeader';
+
+function stubSession(signedIn: boolean) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: true, json: async () => ({ signedIn }) }),
+  );
+}
+
+beforeEach(() => {
+  mockReplace.mockReset();
+  mockRefresh.mockReset();
+  mockLogout.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SiteHeader', () => {
+  it('shows Sign in when signed out and never the account controls', async () => {
+    stubSession(false);
+    render(<SiteHeader />);
+    expect(await screen.findByTestId('nav-signin')).toBeInTheDocument();
+    expect(screen.queryByTestId('nav-account')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('nav-logout')).not.toBeInTheDocument();
+  });
+
+  it('shows Account + Log out when signed in, and logging out returns home', async () => {
+    stubSession(true);
+    render(<SiteHeader />);
+    expect(await screen.findByTestId('nav-account')).toBeInTheDocument();
+    expect(screen.queryByTestId('nav-signin')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('nav-logout'));
+    });
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+});

--- a/apps/web/src/app/__tests__/SiteHeader.test.tsx
+++ b/apps/web/src/app/__tests__/SiteHeader.test.tsx
@@ -11,6 +11,7 @@ const mockReplace = vi.fn();
 const mockRefresh = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace, refresh: mockRefresh }),
+  usePathname: () => '/',
 }));
 
 const mockLogout = vi.fn();

--- a/apps/web/src/app/api/auth/session/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/session/__tests__/route.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The `{ signedIn }` read the site header uses to pick Sign-in vs
+ * Account. Auth state must never be cacheable, or a shared cache could
+ * hand a signed-in response to a signed-out visitor.
+ */
+
+const mockGetServerUserId = vi.fn();
+vi.mock('../../../../../lib/server-auth', () => ({
+  getServerUserId: () => mockGetServerUserId(),
+}));
+
+import { GET } from '../route';
+
+beforeEach(() => {
+  mockGetServerUserId.mockReset();
+});
+
+describe('GET /api/auth/session', () => {
+  it('reports signedIn:false and forbids caching when there is no session', async () => {
+    mockGetServerUserId.mockResolvedValue(null);
+    const res = await GET();
+    expect(await res.json()).toEqual({ signedIn: false });
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('reports signedIn:true when a user id is present', async () => {
+    mockGetServerUserId.mockResolvedValue('user-1');
+    const res = await GET();
+    expect(await res.json()).toEqual({ signedIn: true });
+  });
+});

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -1,0 +1,26 @@
+/**
+ * `GET /api/auth/session` — the one auth-state read the client can make
+ * without touching the HttpOnly `bw_session` cookie itself.
+ *
+ * The site header (a client component) hits this to decide whether to
+ * show "Sign in" or "Account / Log out". Keeping it a dedicated route
+ * means the SSR/static pages don't have to read cookies in the root
+ * layout, so the marketing + SEO pages stay statically rendered.
+ *
+ * A static `session/` segment sits alongside the dynamic `[action]/`
+ * proxy; Next resolves this exact path here (the proxy only handles
+ * login/signup/logout POSTs).
+ */
+import { NextResponse } from 'next/server';
+import { getServerUserId } from '../../../../lib/server-auth';
+
+export async function GET() {
+  const userId = await getServerUserId();
+  return NextResponse.json(
+    { signedIn: userId !== null },
+    // Auth state is per-user and must never be cached by the browser or
+    // any shared cache — otherwise a signed-out visitor could read a
+    // signed-in response (or vice-versa).
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import type { ReactElement, ReactNode } from 'react';
 import { colors } from '@biteworthy/ui-tokens';
 import { PostHogProvider } from './_PostHogProvider';
+import { SiteHeader } from './_SiteHeader';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -24,7 +25,10 @@ export default function RootLayout({ children }: { children: ReactNode }): React
   return (
     <html lang="en">
       <body className="bg-white text-zinc-900 antialiased">
-        <PostHogProvider>{children}</PostHogProvider>
+        <PostHogProvider>
+          <SiteHeader />
+          {children}
+        </PostHogProvider>
         <SiteDisclaimer />
       </body>
     </html>

--- a/apps/web/src/app/onboarding/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/__tests__/page.test.tsx
@@ -66,6 +66,12 @@ describe('OnboardingPage — taste step (standalone "Improve my picks")', () => 
     expect(screen.getByTestId('save-taste')).toBeInTheDocument();
   });
 
+  it('does not show the full-flow Exit control (standalone has its own Cancel)', async () => {
+    render(<OnboardingPage />);
+    await screen.findByText('What do you love?');
+    expect(screen.queryByTestId('onboarding-exit')).not.toBeInTheDocument();
+  });
+
   it('cycles a tag chip neutral → liked on tap and saves only taste arrays', async () => {
     render(<OnboardingPage />);
     const chip = await screen.findByTestId('taste-tag-cuisine-thai');
@@ -101,6 +107,16 @@ describe('OnboardingPage — taste step (standalone "Improve my picks")', () => 
 
 describe('OnboardingPage — taste step in the full flow', () => {
   beforeEach(() => mockGet.mockReturnValue(null));
+
+  it('offers a persistent Exit from the very first step that returns home', async () => {
+    render(<OnboardingPage />);
+    // Rendered on presets (step 1) — the flow used to have no way out
+    // but completing it, so Exit must be reachable from the start.
+    const exit = await screen.findByTestId('onboarding-exit');
+    fireEvent.click(exit);
+    expect(mockReplace).toHaveBeenCalledWith('/');
+    expect(mockSaveProfile).not.toHaveBeenCalled();
+  });
 
   it('sits at step 4 of 5 between strictness and review, and is skippable', async () => {
     render(<OnboardingPage />);

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -240,6 +240,25 @@ function OnboardingFlow() {
 
   return (
     <main className="mx-auto max-w-2xl px-bw-6 py-bw-12">
+      {/* Persistent escape hatch — without it the only way out of the
+          multi-step flow was to complete it (or edit the URL). Standalone
+          "Improve my picks" already has its own Cancel on the taste step. */}
+      {!standalone && (
+        <div className="mb-bw-6 flex justify-end">
+          <button
+            type="button"
+            onClick={() => {
+              clearDraft();
+              router.replace('/');
+            }}
+            data-testid="onboarding-exit"
+            className="text-bw-sm font-semibold text-zinc-500 hover:text-zinc-800"
+          >
+            Exit
+          </button>
+        </div>
+      )}
+
       {step === 'presets' && (
         <PresetsStep
           presets={presets}

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,32 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-16 — Web auth UX + session lifetime. Branch `fix/web-auth-nav-and-onboarding-exit`.
+
+- **User report**: onboarding had no exit/skip, and "logging in does not work"
+  on the live site (redirects but authed calls 401; no indication of login or
+  profile anywhere). Read-only prod probes confirmed the login→Rails path is
+  wired correctly and the `bw_session` cookie is valid on the `bite-worthy.com`
+  apex — so login itself works. Two real defects produced the symptoms:
+  - **No auth UI**: root `layout.tsx` had no header/nav — no way to reach
+    `/login`, and a signed-in user saw no logged-in state. Added a client
+    `SiteHeader` (Sign in ↔ Account + Log out) backed by a new
+    `GET /api/auth/session` `{ signedIn }` read, so the SSR/SEO pages stay
+    static instead of the root layout reading cookies.
+  - **30-min session death**: `devise_jwt.rb` issued 30-minute JWTs while the
+    cookie lived 30 days with no web-side refresh, so any authed call ~30 min
+    post-login 401'd. Bumped `jwt.expiration_time` to 30 days to match the
+    cookie (logout still revokes via jti). User chose the match-cookie option
+    over wiring refresh.
+  - **Onboarding exit**: persistent "Exit" on every step of the main flow
+    (clears the draft, routes home); standalone "Improve my picks" keeps its
+    own Cancel.
+- Web: 188 vitest pass, typecheck + lint clean. API: new login-spec assertion
+  (token TTL > 1 day) passes; rubocop adds no new offenses. Note: the
+  `signup_spec` account-deletion example fails **locally only** (leftover seed
+  data in an undroppable local test DB → review slug collision); `ci-api` is
+  green for it on master, so a clean seedless CI run passes.
+
 2026-07-16 — Deploy-api host-key pinning. Branch `fix/deploy-api-pin-host-keys`.
 
 - **The 6de948a deploy failed** with `Net::SSH::HostKeyMismatch … fingerprint


### PR DESCRIPTION
## Summary

- Adds a site-wide header (Sign in ↔ Account / Log out) — the app had no nav, so there was no way to reach `/login` and a signed-in user saw no indication they were logged in.
- Adds a persistent **Exit** to every step of onboarding (the flow previously had no way out but completing it).
- Extends the JWT lifetime 30 min → 30 days to match the `bw_session` cookie, fixing the `onboarding → login → onboarding` loop caused by tokens dying ~30 min after login with no refresh wired.
