### PR TITLE
feat(web): direct signup entry, deferrable onboarding, auth analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Pnpm + Turborepo monorepo. Three apps + five shared packages:
 - `apps/mobile` — Expo SDK 56 + expo-router.
 - `packages/api-types` — TS types codegen'd from `docs/openapi.json` (see Cross-package contracts below).
 - `packages/filter-engine` — pure-TS dietary filter, shared by web + mobile, with Vitest tests. Mirrors the server-side SQL.
-- `packages/analytics` — the 9-event funnel taxonomy (`EVENTS` map + `EventPropsMap`). Event names/payloads are a contract with the launch dashboards — **renaming an event breaks downstream funnels**; add optional fields freely. `docs/analytics.md` documents each event; when doc and types disagree, the types win.
+- `packages/analytics` — the funnel-event taxonomy (`EVENTS` map + `EventPropsMap`; 9 core funnel/engagement events + 3 auth events). Event names/payloads are a contract with the launch dashboards — **renaming an event breaks downstream funnels**; add new events + optional fields freely. `docs/analytics.md` documents each event; when doc and types disagree, the types win.
 - `packages/ui-tokens` — design tokens consumed by Tailwind (web) and `StyleSheet.create` (mobile).
 - `packages/eslint-config` — minimal flat config; framework rules live per-app.
 

--- a/apps/web/src/app/_SiteHeader.tsx
+++ b/apps/web/src/app/_SiteHeader.tsx
@@ -10,30 +10,62 @@ import { logout } from '../lib/auth';
  * way to reach /login, and a signed-in user got no indication they were
  * logged in (the HttpOnly `bw_session` cookie is invisible to JS).
  *
- * Auth state comes from `GET /api/auth/session` (a `{ signedIn }` read
- * that the server does against the cookie) rather than a cookie the
- * client reads directly — so the SSR/SEO pages stay static and only
- * this component pays the per-request read.
+ * Auth state comes from `GET /api/auth/session` (a `{ signedIn,
+ * onboarded }` read the server does against the cookie) rather than a
+ * cookie the client reads directly — so the SSR/SEO pages stay static
+ * and only this component pays the per-request read.
+ *
+ * `onboarded` drives the resume nudge: a user who signed up but skipped
+ * the dietary-profile setup gets a quiet "Food profile" nav link plus a
+ * dismissible banner, both of which vanish once onboarding is done.
  */
+
+// Persisted so a dismissed nudge doesn't reappear on every navigation.
+// The banner still stops for good once `onboarded` flips true regardless.
+const NUDGE_DISMISSED_KEY = 'bw_profile_nudge_dismissed';
+
+// The nudge is noise on the auth + onboarding pages themselves.
+function nudgeSuppressed(pathname: string): boolean {
+  return (
+    pathname.startsWith('/onboarding') ||
+    pathname.startsWith('/login') ||
+    pathname.startsWith('/signup')
+  );
+}
+
 export function SiteHeader() {
   const router = useRouter();
   const pathname = usePathname();
   // null = not yet known; render a neutral bar to avoid a Sign-in →
   // Account flash and the layout shift that comes with it.
   const [signedIn, setSignedIn] = useState<boolean | null>(null);
+  // Default true so the nudge never flashes before the session resolves.
+  const [onboarded, setOnboarded] = useState(true);
   const [loggingOut, setLoggingOut] = useState(false);
+  const [nudgeDismissed, setNudgeDismissed] = useState(false);
+
+  useEffect(() => {
+    try {
+      setNudgeDismissed(localStorage.getItem(NUDGE_DISMISSED_KEY) === '1');
+    } catch {
+      // localStorage unavailable (private mode) — treat as not dismissed.
+    }
+  }, []);
 
   // Re-read on every navigation (keyed on pathname), not just mount: a
   // login/logout redirect is a soft nav that keeps this component
   // mounted, so a mount-only check would show stale "Sign in" right
-  // after signing in. The previous value stays put while re-fetching,
-  // so there's no flash between routes.
+  // after signing in. Keying on pathname also refreshes `onboarded`
+  // after the onboarding flow redirects home. The previous value stays
+  // put while re-fetching, so there's no flash between routes.
   useEffect(() => {
     let active = true;
     fetch('/api/auth/session', { credentials: 'same-origin' })
-      .then((r) => (r.ok ? r.json() : { signedIn: false }))
-      .then((d: { signedIn?: boolean }) => {
-        if (active) setSignedIn(Boolean(d.signedIn));
+      .then((r) => (r.ok ? r.json() : { signedIn: false, onboarded: true }))
+      .then((d: { signedIn?: boolean; onboarded?: boolean }) => {
+        if (!active) return;
+        setSignedIn(Boolean(d.signedIn));
+        setOnboarded(d.onboarded !== false);
       })
       .catch(() => {
         if (active) setSignedIn(false);
@@ -57,47 +89,106 @@ export function SiteHeader() {
     router.refresh();
   };
 
-  return (
-    <header
-      data-testid="site-header"
-      className="flex items-center justify-between border-b border-zinc-200 bg-white px-bw-6 py-bw-3"
-    >
-      <Link href="/" className="text-bw-lg font-bold text-bite hover:text-bite-dark">
-        BiteWorthy
-      </Link>
+  const dismissNudge = () => {
+    setNudgeDismissed(true);
+    try {
+      localStorage.setItem(NUDGE_DISMISSED_KEY, '1');
+    } catch {
+      // Best-effort — a non-persisted dismiss just reappears next load.
+    }
+  };
 
-      {/* Reserve height while auth state resolves so the bar doesn't jump. */}
-      <nav className="flex min-h-[1.5rem] items-center gap-bw-4 text-bw-sm">
-        {signedIn === true && (
-          <>
+  const needsProfile = signedIn === true && !onboarded;
+  const showNudge = needsProfile && !nudgeDismissed && !nudgeSuppressed(pathname);
+
+  return (
+    <>
+      <header
+        data-testid="site-header"
+        className="flex items-center justify-between border-b border-zinc-200 bg-white px-bw-6 py-bw-3"
+      >
+        <Link href="/" className="text-bw-lg font-bold text-bite hover:text-bite-dark">
+          BiteWorthy
+        </Link>
+
+        {/* Reserve height while auth state resolves so the bar doesn't jump. */}
+        <nav className="flex min-h-[1.5rem] items-center gap-bw-4 text-bw-sm">
+          {signedIn === true && (
+            <>
+              {needsProfile && (
+                <Link
+                  href="/onboarding"
+                  data-testid="nav-food-profile"
+                  className="font-semibold text-bite hover:text-bite-dark"
+                >
+                  Food profile
+                </Link>
+              )}
+              <Link
+                href="/profile/settings"
+                data-testid="nav-account"
+                className="font-semibold text-zinc-700 hover:text-bite-dark"
+              >
+                Account
+              </Link>
+              <button
+                type="button"
+                onClick={onLogout}
+                disabled={loggingOut}
+                data-testid="nav-logout"
+                className="font-semibold text-zinc-500 hover:text-zinc-800 disabled:opacity-60"
+              >
+                {loggingOut ? 'Logging out…' : 'Log out'}
+              </button>
+            </>
+          )}
+          {signedIn === false && (
+            <>
+              <Link
+                href="/login"
+                data-testid="nav-signin"
+                className="font-semibold text-zinc-700 hover:text-bite-dark"
+              >
+                Sign in
+              </Link>
+              <Link
+                href="/signup"
+                data-testid="nav-signup"
+                className="rounded-bw-md bg-bite px-bw-3 py-bw-1 font-bold text-white hover:bg-bite-dark"
+              >
+                Sign up
+              </Link>
+            </>
+          )}
+        </nav>
+      </header>
+
+      {showNudge && (
+        <div
+          role="note"
+          data-testid="profile-nudge"
+          className="flex items-center justify-between gap-bw-3 border-b border-warn/40 bg-warn/10 px-bw-6 py-bw-2 text-bw-sm text-zinc-800"
+        >
+          <span>
+            Your food filter isn&rsquo;t set up yet —{' '}
             <Link
-              href="/profile/settings"
-              data-testid="nav-account"
-              className="font-semibold text-zinc-700 hover:text-bite-dark"
+              href="/onboarding"
+              data-testid="profile-nudge-cta"
+              className="font-bold text-bite hover:text-bite-dark"
             >
-              Account
+              set it up →
             </Link>
-            <button
-              type="button"
-              onClick={onLogout}
-              disabled={loggingOut}
-              data-testid="nav-logout"
-              className="font-semibold text-zinc-500 hover:text-zinc-800 disabled:opacity-60"
-            >
-              {loggingOut ? 'Logging out…' : 'Log out'}
-            </button>
-          </>
-        )}
-        {signedIn === false && (
-          <Link
-            href="/login"
-            data-testid="nav-signin"
-            className="font-semibold text-bite hover:text-bite-dark"
+          </span>
+          <button
+            type="button"
+            onClick={dismissNudge}
+            data-testid="profile-nudge-dismiss"
+            className="shrink-0 font-semibold text-zinc-500 hover:text-zinc-800"
           >
-            Sign in
-          </Link>
-        )}
-      </nav>
-    </header>
+            Dismiss
+          </button>
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/web/src/app/_SiteHeader.tsx
+++ b/apps/web/src/app/_SiteHeader.tsx
@@ -1,27 +1,31 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { logout } from '../lib/auth';
+import { ONBOARDED_HINT_KEY } from '../lib/onboarding';
 
 /**
  * Site-wide top bar. Until now the app had no nav at all: there was no
  * way to reach /login, and a signed-in user got no indication they were
  * logged in (the HttpOnly `bw_session` cookie is invisible to JS).
  *
- * Auth state comes from `GET /api/auth/session` (a `{ signedIn,
- * onboarded }` read the server does against the cookie) rather than a
- * cookie the client reads directly — so the SSR/SEO pages stay static
- * and only this component pays the per-request read.
+ * Two independent reads back it:
+ *   - `GET /api/auth/session` → `{ signedIn }`, a fast LOCAL cookie read
+ *     that never blocks on the API — so the Sign-in ↔ Account nav always
+ *     resolves quickly.
+ *   - `GET /api/auth/onboarded` → `{ onboarded }`, which does hit Rails.
+ *     Kept separate so a slow API only delays the (optional) resume nudge,
+ *     never the auth nav. It fails safe to onboarded so we never nag.
  *
- * `onboarded` drives the resume nudge: a user who signed up but skipped
- * the dietary-profile setup gets a quiet "Food profile" nav link plus a
- * dismissible banner, both of which vanish once onboarding is done.
+ * The resume nudge (a quiet "Food profile" link + a dismissible banner)
+ * shows only for a signed-in user we've CONFIRMED hasn't onboarded, and
+ * vanishes the moment they finish.
  */
 
-// Persisted so a dismissed nudge doesn't reappear on every navigation.
-// The banner still stops for good once `onboarded` flips true regardless.
+// Dismissed-banner + onboarding-complete flags. Both are cleared on
+// logout so nothing leaks to a different account on a shared browser.
 const NUDGE_DISMISSED_KEY = 'bw_profile_nudge_dismissed';
 
 // The nudge is noise on the auth + onboarding pages themselves.
@@ -39,10 +43,14 @@ export function SiteHeader() {
   // null = not yet known; render a neutral bar to avoid a Sign-in →
   // Account flash and the layout shift that comes with it.
   const [signedIn, setSignedIn] = useState<boolean | null>(null);
-  // Default true so the nudge never flashes before the session resolves.
-  const [onboarded, setOnboarded] = useState(true);
+  // null = unknown (nudge stays hidden); only a confirmed `false` nudges.
+  const [onboarded, setOnboarded] = useState<boolean | null>(null);
   const [loggingOut, setLoggingOut] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
+  // Once we learn a user has onboarded it can't revert without a new
+  // login, so latch it and stop re-fetching /api/auth/onboarded on every
+  // navigation. Reset on logout.
+  const onboardedConfirmed = useRef(false);
 
   useEffect(() => {
     try {
@@ -52,20 +60,16 @@ export function SiteHeader() {
     }
   }, []);
 
-  // Re-read on every navigation (keyed on pathname), not just mount: a
-  // login/logout redirect is a soft nav that keeps this component
-  // mounted, so a mount-only check would show stale "Sign in" right
-  // after signing in. Keying on pathname also refreshes `onboarded`
-  // after the onboarding flow redirects home. The previous value stays
-  // put while re-fetching, so there's no flash between routes.
+  // signed-in state — re-read on every navigation (a login/logout redirect
+  // is a soft nav that keeps this mounted, so a mount-only check would show
+  // stale "Sign in"). Fast + local; the previous value stays put while
+  // re-fetching, so there's no flash between routes.
   useEffect(() => {
     let active = true;
     fetch('/api/auth/session', { credentials: 'same-origin' })
-      .then((r) => (r.ok ? r.json() : { signedIn: false, onboarded: true }))
-      .then((d: { signedIn?: boolean; onboarded?: boolean }) => {
-        if (!active) return;
-        setSignedIn(Boolean(d.signedIn));
-        setOnboarded(d.onboarded !== false);
+      .then((r) => (r.ok ? r.json() : { signedIn: false }))
+      .then((d: { signedIn?: boolean }) => {
+        if (active) setSignedIn(Boolean(d.signedIn));
       })
       .catch(() => {
         if (active) setSignedIn(false);
@@ -74,6 +78,40 @@ export function SiteHeader() {
       active = false;
     };
   }, [pathname]);
+
+  // onboarding status — only for signed-in users, and only until we've
+  // confirmed they're onboarded (then latched, so onboarded users don't
+  // pay a Rails round-trip on every navigation). A just-completed save
+  // leaves a one-shot sessionStorage hint so the nudge flips off on the
+  // redirect home without waiting for the fetch.
+  useEffect(() => {
+    if (signedIn !== true || onboardedConfirmed.current) return;
+    try {
+      if (sessionStorage.getItem(ONBOARDED_HINT_KEY) === '1') {
+        sessionStorage.removeItem(ONBOARDED_HINT_KEY);
+        onboardedConfirmed.current = true;
+        setOnboarded(true);
+        return;
+      }
+    } catch {
+      // sessionStorage unavailable — fall through to the fetch.
+    }
+    let active = true;
+    fetch('/api/auth/onboarded', { credentials: 'same-origin' })
+      .then((r) => (r.ok ? r.json() : { onboarded: true }))
+      .then((d: { onboarded?: boolean }) => {
+        if (!active) return;
+        const done = d.onboarded !== false;
+        if (done) onboardedConfirmed.current = true;
+        setOnboarded(done);
+      })
+      .catch(() => {
+        if (active) setOnboarded(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [signedIn, pathname]);
 
   const onLogout = async () => {
     setLoggingOut(true);
@@ -84,6 +122,17 @@ export function SiteHeader() {
       // jti-rotation still leaves the browser signed out.
     }
     setSignedIn(false);
+    // Reset the nudge lifecycle so a different account signing in on this
+    // browser is evaluated from scratch — neither the "confirmed
+    // onboarded" latch nor the dismissal may carry across users.
+    onboardedConfirmed.current = false;
+    setOnboarded(null);
+    setNudgeDismissed(false);
+    try {
+      localStorage.removeItem(NUDGE_DISMISSED_KEY);
+    } catch {
+      // no-op
+    }
     setLoggingOut(false);
     router.replace('/');
     router.refresh();
@@ -98,7 +147,7 @@ export function SiteHeader() {
     }
   };
 
-  const needsProfile = signedIn === true && !onboarded;
+  const needsProfile = signedIn === true && onboarded === false;
   const showNudge = needsProfile && !nudgeDismissed && !nudgeSuppressed(pathname);
 
   return (

--- a/apps/web/src/app/__tests__/SiteHeader.test.tsx
+++ b/apps/web/src/app/__tests__/SiteHeader.test.tsx
@@ -3,8 +3,10 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 /**
  * The site-wide nav that gives a signed-in user any indication they're
- * logged in (and everyone a way to reach /login). Auth state comes from
- * GET /api/auth/session; logout goes through lib/auth.
+ * logged in (and everyone a way to reach /login and /signup). Auth state
+ * comes from GET /api/auth/session; logout goes through lib/auth. A
+ * signed-in user who hasn't finished onboarding gets a Food-profile link
+ * plus a dismissible nudge.
  */
 
 const mockReplace = vi.fn();
@@ -21,10 +23,10 @@ vi.mock('../../lib/auth', () => ({
 
 import { SiteHeader } from '../_SiteHeader';
 
-function stubSession(signedIn: boolean) {
+function stubSession(signedIn: boolean, onboarded = true) {
   vi.stubGlobal(
     'fetch',
-    vi.fn().mockResolvedValue({ ok: true, json: async () => ({ signedIn }) }),
+    vi.fn().mockResolvedValue({ ok: true, json: async () => ({ signedIn, onboarded }) }),
   );
 }
 
@@ -32,6 +34,7 @@ beforeEach(() => {
   mockReplace.mockReset();
   mockRefresh.mockReset();
   mockLogout.mockReset().mockResolvedValue(undefined);
+  localStorage.clear();
 });
 
 afterEach(() => {
@@ -39,10 +42,11 @@ afterEach(() => {
 });
 
 describe('SiteHeader', () => {
-  it('shows Sign in when signed out and never the account controls', async () => {
+  it('shows Sign in + Sign up when signed out and never the account controls', async () => {
     stubSession(false);
     render(<SiteHeader />);
     expect(await screen.findByTestId('nav-signin')).toBeInTheDocument();
+    expect(screen.getByTestId('nav-signup')).toBeInTheDocument();
     expect(screen.queryByTestId('nav-account')).not.toBeInTheDocument();
     expect(screen.queryByTestId('nav-logout')).not.toBeInTheDocument();
   });
@@ -59,5 +63,28 @@ describe('SiteHeader', () => {
 
     await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
     expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+
+  it('does not nudge a signed-in user who has already onboarded', async () => {
+    stubSession(true, true);
+    render(<SiteHeader />);
+    expect(await screen.findByTestId('nav-account')).toBeInTheDocument();
+    expect(screen.queryByTestId('profile-nudge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('nav-food-profile')).not.toBeInTheDocument();
+  });
+
+  it('nudges a signed-in user who has not onboarded, and Dismiss sticks', async () => {
+    stubSession(true, false);
+    render(<SiteHeader />);
+
+    expect(await screen.findByTestId('profile-nudge')).toBeInTheDocument();
+    expect(screen.getByTestId('nav-food-profile')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('profile-nudge-dismiss'));
+
+    expect(screen.queryByTestId('profile-nudge')).not.toBeInTheDocument();
+    expect(localStorage.getItem('bw_profile_nudge_dismissed')).toBe('1');
+    // The quiet nav link stays even after the banner is dismissed.
+    expect(screen.getByTestId('nav-food-profile')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/__tests__/SiteHeader.test.tsx
+++ b/apps/web/src/app/__tests__/SiteHeader.test.tsx
@@ -3,10 +3,12 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 /**
  * The site-wide nav that gives a signed-in user any indication they're
- * logged in (and everyone a way to reach /login and /signup). Auth state
- * comes from GET /api/auth/session; logout goes through lib/auth. A
- * signed-in user who hasn't finished onboarding gets a Food-profile link
- * plus a dismissible nudge.
+ * logged in (and everyone a way to reach /login and /signup). Signed-in
+ * state comes from GET /api/auth/session (fast, local); onboarding status
+ * from GET /api/auth/onboarded (separate, so a slow API only delays the
+ * nudge). A signed-in user who hasn't finished onboarding gets a
+ * Food-profile link plus a dismissible banner; the dismissal is cleared
+ * on logout so it never leaks to the next account on a shared browser.
  */
 
 const mockReplace = vi.fn();
@@ -23,10 +25,18 @@ vi.mock('../../lib/auth', () => ({
 
 import { SiteHeader } from '../_SiteHeader';
 
-function stubSession(signedIn: boolean, onboarded = true) {
+const DISMISSED_KEY = 'bw_profile_nudge_dismissed';
+
+function stubAuth({ signedIn, onboarded = true }: { signedIn: boolean; onboarded?: boolean }) {
   vi.stubGlobal(
     'fetch',
-    vi.fn().mockResolvedValue({ ok: true, json: async () => ({ signedIn, onboarded }) }),
+    vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: async () =>
+          String(url).includes('/api/auth/onboarded') ? { onboarded } : { signedIn },
+      }),
+    ),
   );
 }
 
@@ -43,7 +53,7 @@ afterEach(() => {
 
 describe('SiteHeader', () => {
   it('shows Sign in + Sign up when signed out and never the account controls', async () => {
-    stubSession(false);
+    stubAuth({ signedIn: false });
     render(<SiteHeader />);
     expect(await screen.findByTestId('nav-signin')).toBeInTheDocument();
     expect(screen.getByTestId('nav-signup')).toBeInTheDocument();
@@ -52,7 +62,7 @@ describe('SiteHeader', () => {
   });
 
   it('shows Account + Log out when signed in, and logging out returns home', async () => {
-    stubSession(true);
+    stubAuth({ signedIn: true });
     render(<SiteHeader />);
     expect(await screen.findByTestId('nav-account')).toBeInTheDocument();
     expect(screen.queryByTestId('nav-signin')).not.toBeInTheDocument();
@@ -66,7 +76,7 @@ describe('SiteHeader', () => {
   });
 
   it('does not nudge a signed-in user who has already onboarded', async () => {
-    stubSession(true, true);
+    stubAuth({ signedIn: true, onboarded: true });
     render(<SiteHeader />);
     expect(await screen.findByTestId('nav-account')).toBeInTheDocument();
     expect(screen.queryByTestId('profile-nudge')).not.toBeInTheDocument();
@@ -74,7 +84,7 @@ describe('SiteHeader', () => {
   });
 
   it('nudges a signed-in user who has not onboarded, and Dismiss sticks', async () => {
-    stubSession(true, false);
+    stubAuth({ signedIn: true, onboarded: false });
     render(<SiteHeader />);
 
     expect(await screen.findByTestId('profile-nudge')).toBeInTheDocument();
@@ -83,8 +93,26 @@ describe('SiteHeader', () => {
     fireEvent.click(screen.getByTestId('profile-nudge-dismiss'));
 
     expect(screen.queryByTestId('profile-nudge')).not.toBeInTheDocument();
-    expect(localStorage.getItem('bw_profile_nudge_dismissed')).toBe('1');
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe('1');
     // The quiet nav link stays even after the banner is dismissed.
     expect(screen.getByTestId('nav-food-profile')).toBeInTheDocument();
+  });
+
+  it('clears the dismissed flag on logout so the next account is nudged fresh', async () => {
+    // A prior account already dismissed the banner on this browser.
+    localStorage.setItem(DISMISSED_KEY, '1');
+    stubAuth({ signedIn: true, onboarded: false });
+    render(<SiteHeader />);
+
+    // Not-onboarded but the stale dismissal suppresses the banner.
+    expect(await screen.findByTestId('nav-food-profile')).toBeInTheDocument();
+    expect(screen.queryByTestId('profile-nudge')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('nav-logout'));
+    });
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem(DISMISSED_KEY)).toBeNull();
   });
 });

--- a/apps/web/src/app/api/auth/onboarded/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/onboarded/__tests__/route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `{ onboarded }` drives the header's resume nudge. It reads the profile
+ * from Rails, so unlike /api/auth/session it CAN call the API — but it
+ * fails safe to `true` (never nag) whenever it can't tell: signed out,
+ * non-200, or a fetch error.
+ */
+
+const mockGetServerJwt = vi.fn();
+vi.mock('../../../../../lib/server-auth', () => ({
+  getServerJwt: () => mockGetServerJwt(),
+}));
+
+import { GET } from '../route';
+
+function mockProfileFetch(body: { disclaimer_acknowledged_at?: string | null }, ok = true) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok,
+    json: async () => body,
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockGetServerJwt.mockReset();
+});
+
+describe('GET /api/auth/onboarded', () => {
+  it('returns onboarded:true without a lookup when signed out, and forbids caching', async () => {
+    mockGetServerJwt.mockResolvedValue(null);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const res = await GET();
+    expect(await res.json()).toEqual({ onboarded: true });
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports onboarded:true when the profile has a disclaimer_acknowledged_at', async () => {
+    mockGetServerJwt.mockResolvedValue('jwt-1');
+    mockProfileFetch({ disclaimer_acknowledged_at: '2026-07-20T00:00:00Z' });
+    expect(await (await GET()).json()).toEqual({ onboarded: true });
+  });
+
+  it('reports onboarded:false when onboarding has not been completed', async () => {
+    mockGetServerJwt.mockResolvedValue('jwt-1');
+    mockProfileFetch({ disclaimer_acknowledged_at: null });
+    expect(await (await GET()).json()).toEqual({ onboarded: false });
+  });
+
+  it('fails safe to onboarded:true when the profile lookup errors', async () => {
+    mockGetServerJwt.mockResolvedValue('jwt-1');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
+    expect(await (await GET()).json()).toEqual({ onboarded: true });
+  });
+});

--- a/apps/web/src/app/api/auth/onboarded/route.ts
+++ b/apps/web/src/app/api/auth/onboarded/route.ts
@@ -1,0 +1,39 @@
+/**
+ * `GET /api/auth/onboarded` → `{ onboarded }` — whether the signed-in
+ * user has finished the dietary-profile onboarding.
+ *
+ * The signal is the profile's `disclaimer_acknowledged_at` (stamped on
+ * the final onboarding save; null for a brand-new account), read from
+ * Rails `GET /api/v1/profile`. It lives in its own route — NOT folded
+ * into `/api/auth/session` — so the header's signed-in/out state stays a
+ * fast local cookie read that never blocks on Rails. Only this
+ * nudge-only value depends on the API, and it fails safe to `true`
+ * (never nag) whenever we can't tell: signed out, non-200, or a fetch
+ * error.
+ */
+import { NextResponse } from 'next/server';
+import { getServerJwt } from '../../../../lib/server-auth';
+import { API_BASE } from '../../../../lib/api-base';
+
+export async function GET() {
+  return NextResponse.json(
+    { onboarded: await hasOnboarded() },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}
+
+async function hasOnboarded(): Promise<boolean> {
+  const jwt = await getServerJwt();
+  if (!jwt) return true;
+  try {
+    const res = await fetch(`${API_BASE}/api/v1/profile`, {
+      headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    if (!res.ok) return true;
+    const body = (await res.json()) as { disclaimer_acknowledged_at?: string | null };
+    return Boolean(body.disclaimer_acknowledged_at);
+  } catch {
+    return true;
+  }
+}

--- a/apps/web/src/app/api/auth/session/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/session/__tests__/route.test.ts
@@ -1,67 +1,39 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * The `{ signedIn, onboarded }` read the site header uses to pick
- * Sign-in vs Account, and to decide whether to nudge a signed-in user
- * who hasn't finished onboarding. Auth state must never be cacheable,
- * or a shared cache could hand a signed-in response to a signed-out
- * visitor. `onboarded` fails safe to true so a transient API error
- * never nags an already-set-up user.
+ * The `{ signedIn }` read the site header uses to pick Sign-in vs
+ * Account. Auth state must never be cacheable, or a shared cache could
+ * hand a signed-in response to a signed-out visitor. It's a purely-local
+ * cookie read — it must NOT call the API, so signed-in state stays fast
+ * and independent of Rails health (onboarding status lives in the
+ * separate /api/auth/onboarded route).
  */
 
 const mockGetServerUserId = vi.fn();
-const mockGetServerJwt = vi.fn();
 vi.mock('../../../../../lib/server-auth', () => ({
   getServerUserId: () => mockGetServerUserId(),
-  getServerJwt: () => mockGetServerJwt(),
 }));
 
 import { GET } from '../route';
 
-function mockProfileFetch(body: { disclaimer_acknowledged_at?: string | null }, ok = true) {
-  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-    ok,
-    json: async () => body,
-  } as unknown as Response);
-}
-
 beforeEach(() => {
   vi.restoreAllMocks();
   mockGetServerUserId.mockReset();
-  mockGetServerJwt.mockReset();
 });
 
 describe('GET /api/auth/session', () => {
-  it('reports signedIn:false without a profile lookup, and forbids caching', async () => {
+  it('reports signedIn:false and forbids caching when there is no session', async () => {
     mockGetServerUserId.mockResolvedValue(null);
+    const res = await GET();
+    expect(await res.json()).toEqual({ signedIn: false });
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('reports signedIn:true without any upstream call when a user id is present', async () => {
+    mockGetServerUserId.mockResolvedValue('user-1');
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const res = await GET();
-    expect(await res.json()).toEqual({ signedIn: false, onboarded: false });
-    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(await res.json()).toEqual({ signedIn: true });
     expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it('reports onboarded:true when the profile has a disclaimer_acknowledged_at', async () => {
-    mockGetServerUserId.mockResolvedValue('user-1');
-    mockGetServerJwt.mockResolvedValue('jwt-1');
-    mockProfileFetch({ disclaimer_acknowledged_at: '2026-07-20T00:00:00Z' });
-    const res = await GET();
-    expect(await res.json()).toEqual({ signedIn: true, onboarded: true });
-  });
-
-  it('reports onboarded:false when onboarding has not been completed', async () => {
-    mockGetServerUserId.mockResolvedValue('user-1');
-    mockGetServerJwt.mockResolvedValue('jwt-1');
-    mockProfileFetch({ disclaimer_acknowledged_at: null });
-    const res = await GET();
-    expect(await res.json()).toEqual({ signedIn: true, onboarded: false });
-  });
-
-  it('fails safe to onboarded:true when the profile lookup errors', async () => {
-    mockGetServerUserId.mockResolvedValue('user-1');
-    mockGetServerJwt.mockResolvedValue('jwt-1');
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
-    const res = await GET();
-    expect(await res.json()).toEqual({ signedIn: true, onboarded: true });
   });
 });

--- a/apps/web/src/app/api/auth/session/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/session/__tests__/route.test.ts
@@ -1,33 +1,67 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * The `{ signedIn }` read the site header uses to pick Sign-in vs
- * Account. Auth state must never be cacheable, or a shared cache could
- * hand a signed-in response to a signed-out visitor.
+ * The `{ signedIn, onboarded }` read the site header uses to pick
+ * Sign-in vs Account, and to decide whether to nudge a signed-in user
+ * who hasn't finished onboarding. Auth state must never be cacheable,
+ * or a shared cache could hand a signed-in response to a signed-out
+ * visitor. `onboarded` fails safe to true so a transient API error
+ * never nags an already-set-up user.
  */
 
 const mockGetServerUserId = vi.fn();
+const mockGetServerJwt = vi.fn();
 vi.mock('../../../../../lib/server-auth', () => ({
   getServerUserId: () => mockGetServerUserId(),
+  getServerJwt: () => mockGetServerJwt(),
 }));
 
 import { GET } from '../route';
 
+function mockProfileFetch(body: { disclaimer_acknowledged_at?: string | null }, ok = true) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok,
+    json: async () => body,
+  } as unknown as Response);
+}
+
 beforeEach(() => {
+  vi.restoreAllMocks();
   mockGetServerUserId.mockReset();
+  mockGetServerJwt.mockReset();
 });
 
 describe('GET /api/auth/session', () => {
-  it('reports signedIn:false and forbids caching when there is no session', async () => {
+  it('reports signedIn:false without a profile lookup, and forbids caching', async () => {
     mockGetServerUserId.mockResolvedValue(null);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const res = await GET();
-    expect(await res.json()).toEqual({ signedIn: false });
+    expect(await res.json()).toEqual({ signedIn: false, onboarded: false });
     expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('reports signedIn:true when a user id is present', async () => {
+  it('reports onboarded:true when the profile has a disclaimer_acknowledged_at', async () => {
     mockGetServerUserId.mockResolvedValue('user-1');
+    mockGetServerJwt.mockResolvedValue('jwt-1');
+    mockProfileFetch({ disclaimer_acknowledged_at: '2026-07-20T00:00:00Z' });
     const res = await GET();
-    expect(await res.json()).toEqual({ signedIn: true });
+    expect(await res.json()).toEqual({ signedIn: true, onboarded: true });
+  });
+
+  it('reports onboarded:false when onboarding has not been completed', async () => {
+    mockGetServerUserId.mockResolvedValue('user-1');
+    mockGetServerJwt.mockResolvedValue('jwt-1');
+    mockProfileFetch({ disclaimer_acknowledged_at: null });
+    const res = await GET();
+    expect(await res.json()).toEqual({ signedIn: true, onboarded: false });
+  });
+
+  it('fails safe to onboarded:true when the profile lookup errors', async () => {
+    mockGetServerUserId.mockResolvedValue('user-1');
+    mockGetServerJwt.mockResolvedValue('jwt-1');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network'));
+    const res = await GET();
+    expect(await res.json()).toEqual({ signedIn: true, onboarded: true });
   });
 });

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -7,55 +7,26 @@
  * means the SSR/static pages don't have to read cookies in the root
  * layout, so the marketing + SEO pages stay statically rendered.
  *
- * It also reports `onboarded` — whether the signed-in user has finished
- * the dietary-profile onboarding — so the header can nudge users who
- * signed up but skipped setup. The signal is the profile's
- * `disclaimer_acknowledged_at` (stamped on the final onboarding save;
- * null for a brand-new account). We read it from `GET /api/v1/profile`
- * rather than the JWT, which doesn't carry it.
+ * Deliberately a purely-local cookie read (no upstream call): signed-in
+ * state must resolve fast and stay independent of Rails health, so the
+ * header never blanks out when the API is slow. The onboarding-status
+ * signal, which DOES need the API, lives in the separate
+ * `/api/auth/onboarded` route so it can't hold this one up.
  *
  * A static `session/` segment sits alongside the dynamic `[action]/`
  * proxy; Next resolves this exact path here (the proxy only handles
  * login/signup/logout POSTs).
  */
 import { NextResponse } from 'next/server';
-import { getServerJwt, getServerUserId } from '../../../../lib/server-auth';
-import { API_BASE } from '../../../../lib/api-base';
+import { getServerUserId } from '../../../../lib/server-auth';
 
 export async function GET() {
   const userId = await getServerUserId();
-  if (userId === null) {
-    return json({ signedIn: false, onboarded: false });
-  }
-  return json({ signedIn: true, onboarded: await hasOnboarded() });
-}
-
-/**
- * Whether the signed-in user has completed onboarding. `true` on any
- * lookup failure — we fail safe so a transient API hiccup never nags an
- * already-set-up user to "finish" a profile they already have.
- */
-async function hasOnboarded(): Promise<boolean> {
-  const jwt = await getServerJwt();
-  if (!jwt) return true;
-  try {
-    const res = await fetch(`${API_BASE}/api/v1/profile`, {
-      headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
-      cache: 'no-store',
-    });
-    if (!res.ok) return true;
-    const body = (await res.json()) as { disclaimer_acknowledged_at?: string | null };
-    return Boolean(body.disclaimer_acknowledged_at);
-  } catch {
-    return true;
-  }
-}
-
-function json(payload: { signedIn: boolean; onboarded: boolean }) {
-  return NextResponse.json(payload, {
+  return NextResponse.json(
+    { signedIn: userId !== null },
     // Auth state is per-user and must never be cached by the browser or
     // any shared cache — otherwise a signed-out visitor could read a
     // signed-in response (or vice-versa).
-    headers: { 'Cache-Control': 'no-store' },
-  });
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
 }

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -7,20 +7,55 @@
  * means the SSR/static pages don't have to read cookies in the root
  * layout, so the marketing + SEO pages stay statically rendered.
  *
+ * It also reports `onboarded` — whether the signed-in user has finished
+ * the dietary-profile onboarding — so the header can nudge users who
+ * signed up but skipped setup. The signal is the profile's
+ * `disclaimer_acknowledged_at` (stamped on the final onboarding save;
+ * null for a brand-new account). We read it from `GET /api/v1/profile`
+ * rather than the JWT, which doesn't carry it.
+ *
  * A static `session/` segment sits alongside the dynamic `[action]/`
  * proxy; Next resolves this exact path here (the proxy only handles
  * login/signup/logout POSTs).
  */
 import { NextResponse } from 'next/server';
-import { getServerUserId } from '../../../../lib/server-auth';
+import { getServerJwt, getServerUserId } from '../../../../lib/server-auth';
+import { API_BASE } from '../../../../lib/api-base';
 
 export async function GET() {
   const userId = await getServerUserId();
-  return NextResponse.json(
-    { signedIn: userId !== null },
+  if (userId === null) {
+    return json({ signedIn: false, onboarded: false });
+  }
+  return json({ signedIn: true, onboarded: await hasOnboarded() });
+}
+
+/**
+ * Whether the signed-in user has completed onboarding. `true` on any
+ * lookup failure — we fail safe so a transient API hiccup never nags an
+ * already-set-up user to "finish" a profile they already have.
+ */
+async function hasOnboarded(): Promise<boolean> {
+  const jwt = await getServerJwt();
+  if (!jwt) return true;
+  try {
+    const res = await fetch(`${API_BASE}/api/v1/profile`, {
+      headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    if (!res.ok) return true;
+    const body = (await res.json()) as { disclaimer_acknowledged_at?: string | null };
+    return Boolean(body.disclaimer_acknowledged_at);
+  } catch {
+    return true;
+  }
+}
+
+function json(payload: { signedIn: boolean; onboarded: boolean }) {
+  return NextResponse.json(payload, {
     // Auth state is per-user and must never be cached by the browser or
     // any shared cache — otherwise a signed-out visitor could read a
     // signed-in response (or vice-versa).
-    { headers: { 'Cache-Control': 'no-store' } },
-  );
+    headers: { 'Cache-Control': 'no-store' },
+  });
 }

--- a/apps/web/src/app/login/__tests__/page.test.tsx
+++ b/apps/web/src/app/login/__tests__/page.test.tsx
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Auth funnel analytics on the login form: every submit fires
+ * auth_started, then exactly one of auth_completed / auth_failed with a
+ * coarse, PII-free reason. Forms are submitted via fireEvent.submit so
+ * the handler runs regardless of jsdom's required-field handling.
+ */
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+
+const mockReplace = vi.fn();
+const mockGet = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+const mockLogin = vi.fn();
+// Partial mock: keep the real AuthError so `err instanceof AuthError`
+// (and its status) works; override only the network call.
+vi.mock('../../../lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/auth')>();
+  return { ...actual, login: (...a: unknown[]) => mockLogin(...a) };
+});
+
+vi.mock('../../_PostHogProvider', () => ({ useTracker: () => ({ track }) }));
+
+import { AuthError } from '../../../lib/auth';
+import LoginPage from '../page';
+
+function submit() {
+  const form = document.querySelector('form');
+  if (!form) throw new Error('no form rendered');
+  return act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+function fillCredentials(email = 'a@b.com', password = 'secret12') {
+  fireEvent.change(screen.getByLabelText('email'), { target: { value: email } });
+  fireEvent.change(screen.getByLabelText('password'), { target: { value: password } });
+}
+
+beforeEach(() => {
+  track.mockReset();
+  mockReplace.mockReset();
+  mockGet.mockReset().mockReturnValue(null);
+  mockLogin.mockReset();
+});
+
+describe('LoginPage analytics', () => {
+  it('tracks auth_started then auth_completed on a successful sign-in', async () => {
+    mockLogin.mockResolvedValue({});
+    render(<LoginPage />);
+    fillCredentials();
+    await submit();
+
+    await waitFor(() => expect(mockLogin).toHaveBeenCalledTimes(1));
+    expect(track).toHaveBeenCalledWith('auth_started', { method: 'login' });
+    expect(track).toHaveBeenCalledWith('auth_completed', { method: 'login' });
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+
+  it('tracks auth_failed:missing_fields without calling the API when empty', async () => {
+    render(<LoginPage />);
+    await submit();
+
+    expect(track).toHaveBeenCalledWith('auth_started', { method: 'login' });
+    expect(track).toHaveBeenCalledWith('auth_failed', { method: 'login', reason: 'missing_fields' });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('tracks auth_failed:wrong_credentials with the 401 status', async () => {
+    mockLogin.mockRejectedValue(new AuthError(401, 'nope'));
+    render(<LoginPage />);
+    fillCredentials();
+    await submit();
+
+    await waitFor(() =>
+      expect(track).toHaveBeenCalledWith('auth_failed', {
+        method: 'login',
+        reason: 'wrong_credentials',
+        status: 401,
+      }),
+    );
+    expect(track).not.toHaveBeenCalledWith('auth_completed', { method: 'login' });
+  });
+
+  it('tracks auth_failed:network (no status) when the request never reaches the API', async () => {
+    mockLogin.mockRejectedValue(new Error('fetch failed'));
+    render(<LoginPage />);
+    fillCredentials();
+    await submit();
+
+    await waitFor(() =>
+      expect(track).toHaveBeenCalledWith('auth_failed', { method: 'login', reason: 'network' }),
+    );
+  });
+});

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import type { Route } from 'next';
 import { login, AuthError } from '../../lib/auth';
+import { useTracker } from '../_PostHogProvider';
 
 /**
  * Phase 4.1 — web login page.
@@ -13,7 +14,19 @@ import { login, AuthError } from '../../lib/auth';
  * Rails and sets the HttpOnly `bw_session` cookie. After success the
  * user is bounced to `?next=…` (or the home page) — no JWT-paste,
  * no token in the URL.
+ *
+ * Instrumented with the auth funnel events (auth_started → auth_completed
+ * / auth_failed) so we can see conversion + where sign-in breaks. Only a
+ * coarse failure reason is sent — never the email or password.
  */
+
+/** Map an AuthError status to a coarse, PII-free failure reason. */
+function loginFailureReason(status: number): string {
+  if (status === 401) return 'wrong_credentials';
+  if (status >= 500) return 'server';
+  if (status === 0) return 'network';
+  return 'unknown';
+}
 export default function LoginPage() {
   // useSearchParams (in LoginForm) needs a Suspense boundary or the
   // production build fails prerendering — same pattern as /onboarding.
@@ -27,6 +40,7 @@ export default function LoginPage() {
 function LoginForm() {
   const router = useRouter();
   const params = useSearchParams();
+  const tracker = useTracker();
   const next = params.get('next') ?? '/';
 
   const [email, setEmail] = useState('');
@@ -37,18 +51,27 @@ function LoginForm() {
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    tracker.track('auth_started', { method: 'login' });
     if (!email || !password) {
       setError('Email and password required.');
+      tracker.track('auth_failed', { method: 'login', reason: 'missing_fields' });
       return;
     }
     try {
       setSubmitting(true);
       await login(email, password);
+      tracker.track('auth_completed', { method: 'login' });
       // `next` is a runtime query value — typedRoutes can't prove it.
       router.replace(next as Route);
     } catch (err) {
       const status = err instanceof AuthError ? err.status : 0;
       setError(status === 401 ? 'Wrong email or password.' : (err as Error).message);
+      tracker.track('auth_failed', {
+        method: 'login',
+        reason: loginFailureReason(status),
+        // Only attach a real HTTP status; 0 means it never reached the API.
+        ...(status > 0 ? { status } : {}),
+      });
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, type FormEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import type { Route } from 'next';
-import { login, AuthError } from '../../lib/auth';
+import { login, AuthError, authFailureReason } from '../../lib/auth';
 import { useTracker } from '../_PostHogProvider';
 
 /**
@@ -19,14 +19,6 @@ import { useTracker } from '../_PostHogProvider';
  * / auth_failed) so we can see conversion + where sign-in breaks. Only a
  * coarse failure reason is sent — never the email or password.
  */
-
-/** Map an AuthError status to a coarse, PII-free failure reason. */
-function loginFailureReason(status: number): string {
-  if (status === 401) return 'wrong_credentials';
-  if (status >= 500) return 'server';
-  if (status === 0) return 'network';
-  return 'unknown';
-}
 export default function LoginPage() {
   // useSearchParams (in LoginForm) needs a Suspense boundary or the
   // production build fails prerendering — same pattern as /onboarding.
@@ -68,7 +60,7 @@ function LoginForm() {
       setError(status === 401 ? 'Wrong email or password.' : (err as Error).message);
       tracker.track('auth_failed', {
         method: 'login',
-        reason: loginFailureReason(status),
+        reason: authFailureReason(status, { 401: 'wrong_credentials' }),
         // Only attach a real HTTP status; 0 means it never reached the API.
         ...(status > 0 ? { status } : {}),
       });

--- a/apps/web/src/app/onboarding/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/__tests__/page.test.tsx
@@ -118,6 +118,14 @@ describe('OnboardingPage — taste step in the full flow', () => {
     expect(mockSaveProfile).not.toHaveBeenCalled();
   });
 
+  it('offers a labelled Skip-for-now on step 1 that returns home without saving', async () => {
+    render(<OnboardingPage />);
+    const skip = await screen.findByTestId('onboarding-skip');
+    fireEvent.click(skip);
+    expect(mockReplace).toHaveBeenCalledWith('/');
+    expect(mockSaveProfile).not.toHaveBeenCalled();
+  });
+
   it('sits at step 4 of 5 between strictness and review, and is skippable', async () => {
     render(<OnboardingPage />);
     // presets (1) → ingredients (2) → strictness (3) → taste (4)

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -267,6 +267,10 @@ function OnboardingFlow() {
           selectedSlugs={draft.selectedPresetSlugs}
           onToggle={(slug) => dispatch({ type: 'TOGGLE_PRESET', slug })}
           onNext={() => setStep('ingredients')}
+          onSkip={() => {
+            clearDraft();
+            router.replace('/');
+          }}
         />
       )}
 
@@ -382,6 +386,7 @@ function PresetsStep({
   selectedSlugs,
   onToggle,
   onNext,
+  onSkip,
 }: {
   presets: DietaryPreset[];
   loading: boolean;
@@ -389,6 +394,7 @@ function PresetsStep({
   selectedSlugs: string[];
   onToggle: (slug: string) => void;
   onNext: () => void;
+  onSkip: () => void;
 }) {
   return (
     <>
@@ -437,6 +443,16 @@ function PresetsStep({
         </div>
       )}
       <NextButton label="Next →" onClick={onNext} testId="next-to-ingredients" />
+      {/* Safety is the whole product, but it's optional to set up right now —
+          a signed-in skipper gets nudged to finish later (SiteHeader). */}
+      <button
+        type="button"
+        onClick={onSkip}
+        data-testid="onboarding-skip"
+        className="mt-bw-3 w-full text-bw-sm font-semibold text-zinc-500 hover:text-zinc-700"
+      >
+        Skip for now — you can set this up later
+      </button>
     </>
   );
 }

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -19,6 +19,7 @@ import {
   saveProfile,
   saveTaste,
   searchIngredients,
+  ONBOARDED_HINT_KEY,
   type IngredientSearchResult,
   type TasteTag,
 } from '../../lib/onboarding';
@@ -196,6 +197,15 @@ function OnboardingFlow() {
       // the allergen-disclaimer checkbox, so record the acknowledgment.
       await saveProfile({ ...payload, acknowledge_disclaimer: true });
       clearDraft();
+      // Tell the header the profile is now set up so its resume nudge
+      // turns off immediately on the redirect home (no flash while the
+      // /api/auth/onboarded read is still in flight).
+      try {
+        sessionStorage.setItem(ONBOARDED_HINT_KEY, '1');
+      } catch {
+        // Best-effort — a missed hint just means the header confirms via
+        // the normal fetch instead.
+      }
       // Legal remediation E7 — funnel conversion only; the dietary
       // profile (preset/strictness/avoid sizes) is health data and is
       // never attached to this identified event.

--- a/apps/web/src/app/signup/__tests__/page.test.tsx
+++ b/apps/web/src/app/signup/__tests__/page.test.tsx
@@ -77,9 +77,11 @@ describe('SignupPage analytics', () => {
     expect(mockSignup).not.toHaveBeenCalled();
   });
 
-  it('tracks auth_failed:terms_unaccepted when the terms box is unchecked', async () => {
+  it('tracks auth_failed:terms_unaccepted — and the submit stays reachable so it fires', async () => {
     render(<SignupPage />);
     fill({ terms: false });
+    // The gate must be REACHABLE — a disabled button would emit nothing.
+    expect(screen.getByTestId('signup-submit')).not.toBeDisabled();
     await submit();
 
     expect(track).toHaveBeenCalledWith('auth_failed', {
@@ -89,7 +91,7 @@ describe('SignupPage analytics', () => {
     expect(mockSignup).not.toHaveBeenCalled();
   });
 
-  it('tracks auth_failed:email_taken with the 422 status', async () => {
+  it('tracks auth_failed:rejected with the 422 status (422 is any server validation failure)', async () => {
     mockSignup.mockRejectedValue(new AuthError(422, 'taken'));
     render(<SignupPage />);
     fill();
@@ -98,7 +100,7 @@ describe('SignupPage analytics', () => {
     await waitFor(() =>
       expect(track).toHaveBeenCalledWith('auth_failed', {
         method: 'signup',
-        reason: 'email_taken',
+        reason: 'rejected',
         status: 422,
       }),
     );

--- a/apps/web/src/app/signup/__tests__/page.test.tsx
+++ b/apps/web/src/app/signup/__tests__/page.test.tsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Auth funnel analytics on the signup form. Each client-side gate
+ * (weak password, age, terms) reports its own coarse reason so we can
+ * see which one blocks people; the API failure path reports email_taken
+ * with the 422 status. No email or password is ever sent.
+ */
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+
+const mockReplace = vi.fn();
+const mockGet = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+const mockSignup = vi.fn();
+vi.mock('../../../lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/auth')>();
+  return { ...actual, signup: (...a: unknown[]) => mockSignup(...a) };
+});
+
+vi.mock('../../_PostHogProvider', () => ({ useTracker: () => ({ track }) }));
+
+import { AuthError } from '../../../lib/auth';
+import SignupPage from '../page';
+
+function submit() {
+  const form = document.querySelector('form');
+  if (!form) throw new Error('no form rendered');
+  return act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+function fill({
+  email = 'a@b.com',
+  password = 'secret12',
+  age = true,
+  terms = true,
+}: { email?: string; password?: string; age?: boolean; terms?: boolean } = {}) {
+  fireEvent.change(screen.getByLabelText('email'), { target: { value: email } });
+  fireEvent.change(screen.getByLabelText('password'), { target: { value: password } });
+  if (age) fireEvent.click(screen.getByTestId('age-confirm'));
+  if (terms) fireEvent.click(screen.getByTestId('terms-accept'));
+}
+
+beforeEach(() => {
+  track.mockReset();
+  mockReplace.mockReset();
+  mockGet.mockReset().mockReturnValue(null);
+  mockSignup.mockReset();
+});
+
+describe('SignupPage analytics', () => {
+  it('tracks auth_started then auth_completed on a successful sign-up', async () => {
+    mockSignup.mockResolvedValue({});
+    render(<SignupPage />);
+    fill();
+    await submit();
+
+    await waitFor(() => expect(mockSignup).toHaveBeenCalledTimes(1));
+    expect(track).toHaveBeenCalledWith('auth_started', { method: 'signup' });
+    expect(track).toHaveBeenCalledWith('auth_completed', { method: 'signup' });
+    expect(mockReplace).toHaveBeenCalledWith('/onboarding');
+  });
+
+  it('tracks auth_failed:weak_password before hitting the API', async () => {
+    render(<SignupPage />);
+    fill({ password: 'short' });
+    await submit();
+
+    expect(track).toHaveBeenCalledWith('auth_failed', { method: 'signup', reason: 'weak_password' });
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+
+  it('tracks auth_failed:terms_unaccepted when the terms box is unchecked', async () => {
+    render(<SignupPage />);
+    fill({ terms: false });
+    await submit();
+
+    expect(track).toHaveBeenCalledWith('auth_failed', {
+      method: 'signup',
+      reason: 'terms_unaccepted',
+    });
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+
+  it('tracks auth_failed:email_taken with the 422 status', async () => {
+    mockSignup.mockRejectedValue(new AuthError(422, 'taken'));
+    render(<SignupPage />);
+    fill();
+    await submit();
+
+    await waitFor(() =>
+      expect(track).toHaveBeenCalledWith('auth_failed', {
+        method: 'signup',
+        reason: 'email_taken',
+        status: 422,
+      }),
+    );
+    expect(track).not.toHaveBeenCalledWith('auth_completed', { method: 'signup' });
+  });
+});

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, type FormEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import type { Route } from 'next';
-import { signup, AuthError } from '../../lib/auth';
+import { signup, AuthError, authFailureReason } from '../../lib/auth';
 import { useTracker } from '../_PostHogProvider';
 
 /**
@@ -15,16 +15,11 @@ import { useTracker } from '../_PostHogProvider';
  * Instrumented with the auth funnel events (auth_started → auth_completed
  * / auth_failed) — the client-side gates (weak password, age, terms) each
  * report their own coarse reason so we can see which one blocks people.
- * Never sends the email or password.
+ * That measurement needs the gates to be REACHABLE, so the submit button
+ * only disables while submitting (not on the age/terms boxes) — an
+ * unchecked box surfaces its error + event on submit instead of a dead,
+ * un-clickable button. Never sends the email or password.
  */
-
-/** Map an AuthError status to a coarse, PII-free failure reason. */
-function signupFailureReason(status: number): string {
-  if (status === 422) return 'email_taken';
-  if (status >= 500) return 'server';
-  if (status === 0) return 'network';
-  return 'unknown';
-}
 export default function SignupPage() {
   // useSearchParams (in SignupForm) needs a Suspense boundary or the
   // production build fails prerendering — same pattern as /onboarding.
@@ -83,7 +78,7 @@ function SignupForm() {
       setError(status === 422 ? 'That email is already in use.' : (err as Error).message);
       tracker.track('auth_failed', {
         method: 'signup',
-        reason: signupFailureReason(status),
+        reason: authFailureReason(status, { 422: 'rejected' }),
         // Only attach a real HTTP status; 0 means it never reached the API.
         ...(status > 0 ? { status } : {}),
       });
@@ -167,11 +162,11 @@ function SignupForm() {
 
         <button
           type="submit"
-          disabled={submitting || !ageConfirmed || !termsAccepted}
+          disabled={submitting}
           data-testid="signup-submit"
           className={[
             'mt-bw-2 rounded-bw-md bg-bite px-bw-4 py-bw-3 font-bold text-white',
-            submitting || !ageConfirmed || !termsAccepted ? 'opacity-60' : 'hover:bg-bite-dark',
+            submitting ? 'opacity-60' : 'hover:bg-bite-dark',
           ].join(' ')}
         >
           {submitting ? 'Creating…' : 'Create account'}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -5,12 +5,26 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import type { Route } from 'next';
 import { signup, AuthError } from '../../lib/auth';
+import { useTracker } from '../_PostHogProvider';
 
 /**
  * Phase 4.1 — web signup page. Posts to `/api/auth/signup` (Next
  * proxy → Rails) and gets the user signed in via the same HttpOnly
  * cookie path as login.
+ *
+ * Instrumented with the auth funnel events (auth_started → auth_completed
+ * / auth_failed) — the client-side gates (weak password, age, terms) each
+ * report their own coarse reason so we can see which one blocks people.
+ * Never sends the email or password.
  */
+
+/** Map an AuthError status to a coarse, PII-free failure reason. */
+function signupFailureReason(status: number): string {
+  if (status === 422) return 'email_taken';
+  if (status >= 500) return 'server';
+  if (status === 0) return 'network';
+  return 'unknown';
+}
 export default function SignupPage() {
   // useSearchParams (in SignupForm) needs a Suspense boundary or the
   // production build fails prerendering — same pattern as /onboarding.
@@ -24,6 +38,7 @@ export default function SignupPage() {
 function SignupForm() {
   const router = useRouter();
   const params = useSearchParams();
+  const tracker = useTracker();
   const next = params.get('next') ?? '/onboarding';
 
   const [email, setEmail] = useState('');
@@ -36,30 +51,42 @@ function SignupForm() {
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    tracker.track('auth_started', { method: 'signup' });
     if (!email || !password) {
       setError('Email and password required.');
+      tracker.track('auth_failed', { method: 'signup', reason: 'missing_fields' });
       return;
     }
     if (password.length < 8) {
       setError('Password must be at least 8 characters.');
+      tracker.track('auth_failed', { method: 'signup', reason: 'weak_password' });
       return;
     }
     if (!ageConfirmed) {
       setError('You must confirm you are at least 13 years old.');
+      tracker.track('auth_failed', { method: 'signup', reason: 'age_unconfirmed' });
       return;
     }
     if (!termsAccepted) {
       setError('You must agree to the Terms of Service and Privacy Policy.');
+      tracker.track('auth_failed', { method: 'signup', reason: 'terms_unaccepted' });
       return;
     }
     try {
       setSubmitting(true);
       await signup(email, password, ageConfirmed, termsAccepted);
+      tracker.track('auth_completed', { method: 'signup' });
       // `next` is a runtime query value — typedRoutes can't prove it.
       router.replace(next as Route);
     } catch (err) {
       const status = err instanceof AuthError ? err.status : 0;
       setError(status === 422 ? 'That email is already in use.' : (err as Error).message);
+      tracker.track('auth_failed', {
+        method: 'signup',
+        reason: signupFailureReason(status),
+        // Only attach a real HTTP status; 0 means it never reached the API.
+        ...(status > 0 ? { status } : {}),
+      });
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -29,6 +29,25 @@ export class AuthError extends Error {
   }
 }
 
+/**
+ * Coarse, PII-free failure reason for the auth analytics events, derived
+ * from an AuthError status. `specific` maps a status to a form-specific
+ * reason (login: 401 → wrong_credentials; signup: 422 → rejected — Rails
+ * returns 422 for any registration validation failure, not only a taken
+ * email, so we don't over-claim). Everything else collapses to
+ * server / network / unknown to keep the taxonomy small. `status === 0`
+ * means the request never reached the API.
+ */
+export function authFailureReason(
+  status: number,
+  specific: Record<number, string> = {},
+): string {
+  if (specific[status]) return specific[status]!;
+  if (status >= 500) return 'server';
+  if (status === 0) return 'network';
+  return 'unknown';
+}
+
 interface FetchOptions {
   fetchImpl?: typeof fetch;
 }

--- a/apps/web/src/lib/onboarding.ts
+++ b/apps/web/src/lib/onboarding.ts
@@ -9,6 +9,15 @@
 import type { DietaryPreset, Strictness } from '@biteworthy/filter-engine';
 import { api, type ApiOptions } from './api';
 
+/**
+ * One-shot, tab-scoped hint the onboarding flow sets on a successful
+ * final save. The SiteHeader reads (and clears) it to flip its resume
+ * nudge off instantly on the redirect home, instead of waiting on the
+ * `/api/auth/onboarded` round-trip — otherwise the "set up your profile"
+ * banner briefly flashes on the page the user just finished setting up.
+ */
+export const ONBOARDED_HINT_KEY = 'bw_onboarded_hint';
+
 export interface IngredientSearchResult {
   id: string;
   slug: string;

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -123,7 +123,7 @@ Fired on any failure — both client-side gates and API errors — so drop-off i
 | Field | Type | Notes |
 |---|---|---|
 | `method` | `"login" \| "signup"` | |
-| `reason` | `string` | Coarse category, never the raw error. Login: `missing_fields`, `wrong_credentials`, `server`, `network`, `unknown`. Signup adds the client gates: `weak_password`, `age_unconfirmed`, `terms_unaccepted`, `email_taken`. |
+| `reason` | `string` | Coarse category, never the raw error. Login: `missing_fields`, `wrong_credentials`, `server`, `network`, `unknown`. Signup adds the client gates (`weak_password`, `age_unconfirmed`, `terms_unaccepted`) and `rejected` for a server-side 422 (Rails returns 422 for any registration validation failure — duplicate email, invalid email, etc. — so it isn't labelled as specifically email-taken). |
 | `status` | `number?` | Upstream HTTP status when the failure came from the API (401 / 422 / 5xx); absent for client-side gates and network errors. |
 
 ## Privacy posture

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,6 +1,6 @@
 # Analytics — event taxonomy
 
-The 9 stable funnel events for Phase 5.8. Names + payload schemas are the contract between the call sites (web, mobile, api) and the dashboard. **Renaming any of these breaks downstream funnels** — add new optional fields freely; rename only with a coordinated dashboard update.
+The stable funnel + engagement events (9 core, plus 3 auth events). Names + payload schemas are the contract between the call sites (web, mobile, api) and the dashboard. **Renaming any of these breaks downstream funnels** — add new events + optional fields freely; rename only with a coordinated dashboard update.
 
 The canonical type definitions live in `packages/analytics/src/index.ts` (`EVENTS` map + `EventPropsMap`). When this doc and that file disagree, the type definitions win — they're the compile-time contract.
 
@@ -98,6 +98,33 @@ Fired when a Suggestion is submitted (Phase 4.10). The follow-up `decideSuggesti
 | `item_slug` | `string` | |
 | `restaurant_slug` | `string` | |
 | `kind` | `string` | `"add_ingredient"`, `"rename"`, etc. — see Phase 4.10. |
+
+## Auth events
+
+Auxiliary to the core funnel (they fire after `app_open`, before `profile_set`) — they measure the sign-in / sign-up flow so we can see conversion and *where* it breaks. **No PII**: never the email or password, only a coarse `method` / `reason` / `status`. Currently instrumented on **web** (`login/page.tsx`, `signup/page.tsx`); mobile can adopt the same events.
+
+### `auth_started`
+Fired on every submit of the login or signup form (before validation), so it counts intent.
+
+| Field | Type | Notes |
+|---|---|---|
+| `method` | `"login" \| "signup"` | Which form was submitted. |
+
+### `auth_completed`
+Fired once the account is signed in (before the post-auth redirect). `auth_started → auth_completed` is the conversion funnel.
+
+| Field | Type | Notes |
+|---|---|---|
+| `method` | `"login" \| "signup"` | |
+
+### `auth_failed`
+Fired on any failure — both client-side gates and API errors — so drop-off is attributable.
+
+| Field | Type | Notes |
+|---|---|---|
+| `method` | `"login" \| "signup"` | |
+| `reason` | `string` | Coarse category, never the raw error. Login: `missing_fields`, `wrong_credentials`, `server`, `network`, `unknown`. Signup adds the client gates: `weak_password`, `age_unconfirmed`, `terms_unaccepted`, `email_taken`. |
+| `status` | `number?` | Upstream HTTP status when the failure came from the API (401 / 422 / 5xx); absent for client-side gates and network errors. |
 
 ## Privacy posture
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -39,9 +39,17 @@ the Phase 5 pause) are archived in
   (coarse `method`/`reason`/`status`, never email/password). login + signup
   pages fire started→completed/failed; each client gate (weak_password,
   age_unconfirmed, terms_unaccepted) and API error (wrong_credentials 401,
-  email_taken 422, server, network) reports its own reason. Mobile can adopt
+  rejected 422, server, network) reports its own reason. Mobile can adopt
   the same events later (deliberately deferred). No `identify()` — keeps the
   anonymous-id posture. `docs/analytics.md` + CLAUDE.md updated.
+- **xhigh review addressed** (8 findings): signedIn stays a fast local read
+  (onboarding status split into `/api/auth/onboarded`, so the header nav never
+  blocks on Rails); nudge-dismissed flag cleared on logout + onboarded latch
+  reset per user (no leak across accounts on a shared browser); signup submit
+  no longer disabled on the age/terms boxes so those gate events actually fire;
+  onboarded fetch latches once true (no per-nav round-trip); one-shot
+  sessionStorage hint kills the post-onboarding nudge flash; shared
+  `authFailureReason` helper; 422 relabelled `rejected`.
 - Web vitest 201 (+13), analytics vitest 12 (+1 taxonomy assertion); typecheck
   + lint green across the workspace. No apps/api changes → ci-api untouched.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,34 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-20 — Web auth entry, deferrable onboarding, auth analytics. Branch `feature/web-auth-entry-onboarding-skip`.
+
+- **User asks**: (1) a direct login/signup button that doesn't route through
+  onboarding, (2) a way to skip onboarding and finish it later, (3) more
+  analytics on the sign-in/sign-up flows. All web.
+- **Sign up in the header**: `_SiteHeader` signed-out state now shows Sign in +
+  a primary **Sign up** button (was only a "Sign in" text link). Landing hero
+  unchanged.
+- **Resume nudge**: `GET /api/auth/session` now also returns `onboarded` — when
+  signed in it reads Rails `GET /api/v1/profile` and reports
+  `disclaimer_acknowledged_at != null` (fails safe to `true` on any lookup
+  error, so a hiccup never nags a set-up user; no API change — the field was
+  already in the payload). When `signedIn && !onboarded` the header shows a
+  quiet "Food profile" link + a dismissible banner (localStorage
+  `bw_profile_nudge_dismissed`); both hidden on /onboarding·/login·/signup and
+  gone for good once onboarding completes. Onboarding step 1 gained a labelled
+  **"Skip for now"** (same clear-draft + home as the existing Exit).
+- **Auth analytics**: 3 new events in `packages/analytics` (`auth_started`,
+  `auth_completed`, `auth_failed`) — auxiliary to the core funnel, PII-free
+  (coarse `method`/`reason`/`status`, never email/password). login + signup
+  pages fire started→completed/failed; each client gate (weak_password,
+  age_unconfirmed, terms_unaccepted) and API error (wrong_credentials 401,
+  email_taken 422, server, network) reports its own reason. Mobile can adopt
+  the same events later (deliberately deferred). No `identify()` — keeps the
+  anonymous-id posture. `docs/analytics.md` + CLAUDE.md updated.
+- Web vitest 201 (+13), analytics vitest 12 (+1 taxonomy assertion); typecheck
+  + lint green across the workspace. No apps/api changes → ci-api untouched.
+
 2026-07-16 — Web auth UX + session lifetime. Branch `fix/web-auth-nav-and-onboarding-exit`.
 
 - **User report**: onboarding had no exit/skip, and "logging in does not work"

--- a/packages/analytics/src/__tests__/index.test.ts
+++ b/packages/analytics/src/__tests__/index.test.ts
@@ -19,6 +19,9 @@ describe('EVENTS taxonomy', () => {
         'share_link_copied',
         'restaurant_claimed',
         'suggestion_submitted',
+        'auth_started',
+        'auth_completed',
+        'auth_failed',
       ].sort(),
     );
   });

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -52,6 +52,12 @@ export const EVENTS = {
   share_link_copied:    'share_link_copied',
   restaurant_claimed:   'restaurant_claimed',
   suggestion_submitted: 'suggestion_submitted',
+  // Auth flow — auxiliary to the core funnel (they fire after app_open,
+  // before profile_set). Track sign-in / sign-up attempt → outcome so we
+  // can see conversion + where the flow breaks. No PII (see below).
+  auth_started:         'auth_started',
+  auth_completed:       'auth_completed',
+  auth_failed:          'auth_failed',
 } as const;
 
 export type EventName = keyof typeof EVENTS;
@@ -127,6 +133,27 @@ export interface EventPropsMap {
     restaurant_slug: string;
     /** add_ingredient | rename | etc. — see Phase 4.10. */
     kind: string;
+  };
+  // Auth events carry a coarse method/reason/status only — never the
+  // email, password, or any PII (docs/analytics.md privacy rule).
+  auth_started: {
+    /** Which auth form the user submitted. */
+    method: 'login' | 'signup';
+  };
+  auth_completed: {
+    method: 'login' | 'signup';
+  };
+  auth_failed: {
+    method: 'login' | 'signup';
+    /**
+     * Coarse failure category — never the raw error text. Login:
+     * `missing_fields | wrong_credentials | server | network | unknown`.
+     * Signup adds the client-side gates:
+     * `weak_password | age_unconfirmed | terms_unaccepted | email_taken`.
+     */
+    reason: string;
+    /** Upstream HTTP status when the failure came from the API (else absent). */
+    status?: number;
   };
 }
 


### PR DESCRIPTION
## Summary

- **Direct login/signup** — the header (signed-out) now has a primary **Sign up** button next to Sign in, so account creation no longer routes through onboarding first.
- **Deferrable onboarding** — a labelled "Skip for now" on step 1, plus a smart resume nudge: the session endpoint reports `onboarded` (from `disclaimer_acknowledged_at`, no API change), and un-onboarded signed-in users get a "Food profile" link + a dismissible banner that disappear once they finish.
- **Auth analytics** — 3 new PII-free events (`auth_started` / `auth_completed` / `auth_failed`, coarse `method`/`reason`/`status`) instrument sign-in/sign-up so we can see conversion and where it breaks. Web only; shared events so mobile can adopt later.
