### PR TITLE
fix(api): disable aws-sdk default checksums for Cloudflare R2 uploads

### DIFF
--- a/apps/api/config/storage.yml
+++ b/apps/api/config/storage.yml
@@ -28,3 +28,12 @@ r2:
   region: <%= ENV.fetch("R2_REGION", "auto") %>
   bucket: <%= ENV["R2_BUCKET"] %>
   force_path_style: true
+  # aws-sdk-core >= 3.201 defaults to adding a CRC32 request checksum
+  # (request_checksum_calculation: "when_supported"). Cloudflare R2 rejects
+  # any request carrying more than one checksum — "You can only specify one
+  # non-default checksum at a time" — which 500s EVERY blob upload (menu
+  # ingestion + dish photos). Only send a checksum when the operation
+  # actually requires it. Active Storage forwards these straight to
+  # Aws::S3::Client (S3Service passes leftover storage.yml keys through).
+  request_checksum_calculation: when_required
+  response_checksum_validation: when_required

--- a/apps/api/spec/config/storage_spec.rb
+++ b/apps/api/spec/config/storage_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "erb"
+require "yaml"
+
+# Guards the Cloudflare R2 fix: aws-sdk-core >= 3.201 adds a default CRC32
+# request checksum, and R2 rejects any request with more than one checksum
+# ("You can only specify one non-default checksum at a time"), 500-ing every
+# blob upload (menu ingestion + dish photos). The r2 service must pin the
+# checksum options to "when_required" so the SDK stops adding them.
+RSpec.describe "R2 Active Storage config" do
+  let(:config) do
+    raw = ERB.new(File.read(Rails.root.join("config/storage.yml"))).result
+    YAML.safe_load(raw, aliases: true)
+  end
+
+  it "disables the aws-sdk default request/response checksums (R2 rejects multi-checksum requests)" do
+    expect(config.dig("r2", "request_checksum_calculation")).to eq("when_required")
+    expect(config.dig("r2", "response_checksum_validation")).to eq("when_required")
+  end
+end

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,29 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Fix menu-scan 500 (Cloudflare R2 checksum incompatibility). Branch `fix/r2-checksum-ingestion-500`.
+
+- **User report**: signed in but "can't scan menus" — `POST /api/v1/ingestion_runs`
+  returned `Ingestion request failed: 500` on both URL and photo. Prod logs
+  (via `kamal app logs`) showed the blob uploads to R2 ("Uploaded file to key")
+  then `Aws::S3::Errors::InvalidRequest (You can only specify one non-default
+  checksum at a time.)` at `ingestion_runs_controller.rb:159`.
+- **Root cause**: `aws-sdk-core 3.254` / `aws-sdk-s3 1.228` default to adding a
+  CRC32 request checksum (`request_checksum_calculation: when_supported`, the
+  default since 3.201). Cloudflare R2 rejects requests carrying more than one
+  checksum, so every Active Storage blob op 500s (menu ingestion + dish photos).
+- **Fix**: pin `request_checksum_calculation` + `response_checksum_validation`
+  to `when_required` on the `r2` service in `config/storage.yml` (Active Storage
+  forwards leftover keys to `Aws::S3::Client`). Added `spec/config/storage_spec.rb`
+  guarding it. Needs an API deploy (deploy-api.yml auto-deploys on master merge).
+- **Fallout**: each failed attempt still persisted an IngestionRun (stuck in
+  `extracting`, 0 items) that counts against the 5/user/day quota — the reporter
+  burned all 5 slots and now hits `quota_exceeded`. Cleaning up those dead runs
+  post-deploy to unblock. **Follow-up**: a create that 500s shouldn't leave a
+  committed run / shouldn't burn quota (transaction/rollback gap).
+- **Also reported (queued)**: no nav path to `/ingest` for signed-in users; add
+  a copy/paste (raw menu text) import option alongside URL/photo.
+
 2026-07-21 — Fix broken Vercel web deploys (Tailwind v4 regression). Branch `fix/tailwind-v3-repin-vercel-build`.
 
 - **Every Vercel web deploy had been failing** since Dependabot #421 (527025b)


### PR DESCRIPTION
## Summary

- **Fixes the "can't scan menus" 500.** Every menu upload (URL + photo) and dish-photo attach 500s: `aws-sdk-core 3.254` defaults to adding a CRC32 request checksum, and Cloudflare R2 rejects requests with more than one checksum (`Aws::S3::Errors::InvalidRequest: You can only specify one non-default checksum at a time`).
- Pin `request_checksum_calculation` + `response_checksum_validation` to `when_required` on the `r2` storage service so the SDK only sends a checksum when required. Guarded by a new config spec.

Diagnosed from production logs; confirmed the blob uploads then a follow-up S3 request fails on the checksum.
