### PR TITLE
feat(web): add "Scan a menu" nav entry for signed-in users

### DIFF
--- a/apps/web/src/app/_SiteHeader.tsx
+++ b/apps/web/src/app/_SiteHeader.tsx
@@ -164,11 +164,21 @@ export function SiteHeader() {
         <nav className="flex min-h-[1.5rem] items-center gap-bw-4 text-bw-sm">
           {signedIn === true && (
             <>
+              {/* Scanning is the core action and needs a home — a signed-in
+                  user otherwise has no way to reach /ingest, and onboarding
+                  (which scanning doesn't require) becomes a dead end. */}
+              <Link
+                href="/ingest"
+                data-testid="nav-scan"
+                className="font-semibold text-bite hover:text-bite-dark"
+              >
+                Scan a menu
+              </Link>
               {needsProfile && (
                 <Link
                   href="/onboarding"
                   data-testid="nav-food-profile"
-                  className="font-semibold text-bite hover:text-bite-dark"
+                  className="font-semibold text-zinc-700 hover:text-bite-dark"
                 >
                   Food profile
                 </Link>

--- a/apps/web/src/app/__tests__/SiteHeader.test.tsx
+++ b/apps/web/src/app/__tests__/SiteHeader.test.tsx
@@ -52,19 +52,22 @@ afterEach(() => {
 });
 
 describe('SiteHeader', () => {
-  it('shows Sign in + Sign up when signed out and never the account controls', async () => {
+  it('shows Sign in + Sign up when signed out and never the account/scan controls', async () => {
     stubAuth({ signedIn: false });
     render(<SiteHeader />);
     expect(await screen.findByTestId('nav-signin')).toBeInTheDocument();
     expect(screen.getByTestId('nav-signup')).toBeInTheDocument();
     expect(screen.queryByTestId('nav-account')).not.toBeInTheDocument();
     expect(screen.queryByTestId('nav-logout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('nav-scan')).not.toBeInTheDocument();
   });
 
-  it('shows Account + Log out when signed in, and logging out returns home', async () => {
+  it('shows Scan + Account + Log out when signed in, and logging out returns home', async () => {
     stubAuth({ signedIn: true });
     render(<SiteHeader />);
     expect(await screen.findByTestId('nav-account')).toBeInTheDocument();
+    // Signed-in users always get a path to the scanner (regardless of onboarding).
+    expect(screen.getByTestId('nav-scan')).toHaveAttribute('href', '/ingest');
     expect(screen.queryByTestId('nav-signin')).not.toBeInTheDocument();
 
     await act(async () => {


### PR DESCRIPTION
## Summary

- Signed-in users had **no way to reach `/ingest`** — the header only showed Food profile / Account, so onboarding was a dead end and scanning was unreachable without typing the URL.
- Adds a prominent **"Scan a menu"** header link for signed-in users (scanning doesn't require onboarding).
