### PR TITLE
fix(api): strip markdown code fences before parsing Anthropic JSON

### DIFF
--- a/apps/api/app/services/anthropic_client/response_parser.rb
+++ b/apps/api/app/services/anthropic_client/response_parser.rb
@@ -31,7 +31,7 @@ class AnthropicClient::ResponseParser
     # AnthropicClient::ValidationError on either JSON parse failure
     # or schema mismatch.
     def parse_and_validate(text, schema)
-      payload = JSON.parse(text)
+      payload = JSON.parse(strip_code_fence(text))
     rescue JSON::ParserError => e
       raise AnthropicClient::ValidationError.new(
         raw_body: text, errors: ["JSON parse failed: #{e.message}"]
@@ -41,6 +41,21 @@ class AnthropicClient::ResponseParser
       raise AnthropicClient::ValidationError.new(raw_body: text, errors: errors) if errors.any?
 
       payload
+    end
+
+    # Despite the "STRICT JSON ONLY, no fences" system instruction, the
+    # model sometimes wraps its response in a ```json … ``` markdown fence
+    # (seen live in the resolve stage: "unexpected character: '```json'").
+    # Strip a surrounding fence so a well-formed body inside it still
+    # parses; text without a leading fence is returned unchanged.
+    def strip_code_fence(text)
+      stripped = text.to_s.strip
+      return stripped unless stripped.start_with?("```")
+
+      stripped
+        .sub(/\A```[a-z0-9]*[ \t]*\r?\n?/i, "") # opening ``` or ```json
+        .sub(/\r?\n?```\s*\z/, "")              # closing ```
+        .strip
     end
   end
 end

--- a/apps/api/spec/services/anthropic_client/response_parser_spec.rb
+++ b/apps/api/spec/services/anthropic_client/response_parser_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe AnthropicClient::ResponseParser do
+  # Minimal schema: an object with a required boolean `ok`.
+  let(:schema) do
+    {
+      "type" => "object",
+      "required" => ["ok"],
+      "properties" => { "ok" => { "type" => "boolean" } }
+    }
+  end
+
+  it "parses plain strict JSON" do
+    expect(described_class.parse_and_validate('{"ok":true}', schema)).to eq("ok" => true)
+  end
+
+  it "parses JSON wrapped in a ```json markdown fence (the live resolve failure)" do
+    text = "```json\n{\"ok\": true}\n```"
+    expect(described_class.parse_and_validate(text, schema)).to eq("ok" => true)
+  end
+
+  it "parses JSON wrapped in a bare ``` fence" do
+    text = "```\n{\"ok\": false}\n```"
+    expect(described_class.parse_and_validate(text, schema)).to eq("ok" => false)
+  end
+
+  it "still raises ValidationError on genuinely malformed JSON" do
+    expect { described_class.parse_and_validate("not json at all", schema) }
+      .to raise_error(AnthropicClient::ValidationError, /JSON parse failed/)
+  end
+
+  it "still raises ValidationError on schema mismatch" do
+    expect { described_class.parse_and_validate('{"ok":"not a bool"}', schema) }
+      .to raise_error(AnthropicClient::ValidationError)
+  end
+end

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,27 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Ingestion pipeline bugs surfaced once R2 upload worked. Branches
+`fix/anthropic-json-fence` (this one) + follow-ups.
+
+- After the R2 fix, real scans exposed downstream failures (from prod runs):
+  1. **Photo (jpeg)**: extraction succeeds, then resolve fails —
+     `resolve_ingredients_validation_failed: JSON parse failed: unexpected
+     character: '` + "```json" + `'`. The model wraps its strict-JSON reply in a
+     markdown fence and `ResponseParser` fed it straight to `JSON.parse`.
+  2. **URL import**: `UrlFetcher` fetches the menu web page (`text/html`) but
+     `ExtractMenuPrompt` sends every input as an `image_block` → Anthropic 400
+     `media_type should be image/jpeg|png|gif|webp`. Same for direct PDF uploads.
+- **This PR** fixes #1: `ResponseParser#strip_code_fence` strips a surrounding
+  ```` ```json … ``` ```` fence before parsing (falls through unchanged when
+  there's no fence; malformed JSON still raises). Unblocks the photo flow
+  end-to-end. Spec: `spec/services/anthropic_client/response_parser_spec.rb`.
+- **Next PR** fixes #2 + delivers the requested copy/paste import: route the
+  extraction content block by content-type — image → image_block, application/pdf
+  → document block, text/* (html + pasted) → text block — plus a `source_text`
+  param + `/ingest` textarea. (HEIC/HEIF still route as images for now; iOS web
+  uploads arrived as jpeg, so deferred.)
+
 2026-07-21 — Fix menu-scan 500 (Cloudflare R2 checksum incompatibility). Branch `fix/r2-checksum-ingestion-500`.
 
 - **User report**: signed in but "can't scan menus" — `POST /api/v1/ingestion_runs`


### PR DESCRIPTION
## Summary

- Live photo scans reached extraction but failed at resolve: `JSON parse failed: unexpected character: '` ```json `'`. The model wraps its strict-JSON reply in a markdown fence despite the "no fences" instruction.
- `ResponseParser#strip_code_fence` strips a surrounding ` ```json … ``` ` fence before `JSON.parse` (unchanged when absent; malformed JSON still raises). Hardens both extraction and resolve — the shared parser.
