### PR TITLE
feat(api,web): route ingestion inputs by content-type; add copy/paste import

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -58,6 +58,9 @@ INGESTION_DAILY_COST_CEILING_CENTS=2000
 # into the vision prompt). Bytes default matches UrlFetcher's 10 MB.
 INGESTION_MAX_INPUT_FILES=10
 INGESTION_MAX_INPUT_FILE_BYTES=10485760
+# Char cap on the copy/paste import (source_text). A very long menu is
+# well under this; the whole thing goes into the extraction prompt.
+INGESTION_MAX_SOURCE_TEXT_CHARS=50000
 
 # --- Mailer ------------------------------------------------------------------
 # Used by Devise for password-reset emails. The mailer itself isn't

--- a/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
@@ -14,9 +14,10 @@ module Api
     # trust handling (suggested-confidence promotion) is Phase 6.3.
     class IngestionRunsController < BaseController
       def create
-        restaurant = Restaurant.find(params.require(:restaurant_id))
-        files      = Array(params[:inputs]).reject(&:blank?)
-        source_url = params[:source_url].to_s.presence
+        restaurant  = Restaurant.find(params.require(:restaurant_id))
+        files       = Array(params[:inputs]).reject(&:blank?)
+        source_url  = params[:source_url].to_s.presence
+        source_text = params[:source_text].to_s.presence
 
         # Phase 6.2 ownership rule: non-admins may scan drafts they
         # created (the new-restaurant flow) or published restaurants
@@ -27,12 +28,13 @@ module Api
           return
         end
 
-        if files.empty? && source_url.nil?
+        if files.empty? && source_url.nil? && source_text.nil?
           render json: { error: "no_inputs" }, status: :unprocessable_entity
           return
         end
 
         return unless validate_files!(files)
+        return unless validate_source_text!(source_text)
 
         # Cheap unlocked pre-check so an over-quota caller can't make
         # us do an outbound URL fetch (codex P2 on #298). Advisory only
@@ -62,6 +64,8 @@ module Api
 
           if fetched
             create_from_fetched(restaurant, source_url, fetched)
+          elsif source_text
+            create_from_text(restaurant, source_text)
           else
             create_from_files(restaurant, files)
           end
@@ -109,10 +113,31 @@ module Api
         render json: serialize_run(run), status: :created
       end
 
+      # Copy/paste path — the user pastes raw menu text instead of a
+      # file/URL. Stored as a text/plain input blob so it flows through
+      # the same pipeline; ExtractMenuPrompt sends text blobs as a text
+      # content block (not an image).
+      def create_from_text(restaurant, text)
+        run = IngestionRun.create!(
+          user:       current_user,
+          restaurant: restaurant,
+          input_kind: "text"
+        )
+        run.inputs.attach(
+          io:           StringIO.new(text),
+          filename:     "pasted-menu.txt",
+          content_type: "text/plain"
+        )
+        run.transition_to!(:extracting)
+
+        render json: serialize_run(run), status: :created
+      end
+
       PER_USER_DAILY_RUNS_DEFAULT      = 5
       DAILY_COST_CEILING_CENTS_DEFAULT = 2_000 # $20/day across all non-admin spend
       MAX_INPUT_FILES_DEFAULT          = 10
       MAX_INPUT_FILE_BYTES_DEFAULT     = 10 * 1024 * 1024 # match UrlFetcher's 10 MB cap
+      MAX_SOURCE_TEXT_CHARS_DEFAULT    = 50_000           # a very long menu is well under this
 
       ALLOWED_INPUT_CONTENT_TYPES = %w[
         image/jpeg image/png image/heic image/heif image/webp application/pdf
@@ -209,6 +234,25 @@ module Api
 
       def max_input_file_bytes
         Integer(ENV.fetch("INGESTION_MAX_INPUT_FILE_BYTES", MAX_INPUT_FILE_BYTES_DEFAULT))
+      end
+
+      def max_source_text_chars
+        Integer(ENV.fetch("INGESTION_MAX_SOURCE_TEXT_CHARS", MAX_SOURCE_TEXT_CHARS_DEFAULT))
+      end
+
+      # Pasted-text bound — mirrors the multipart file caps (codex P2 on
+      # #297): the extraction prompt puts the whole thing in the request,
+      # so cap it regardless of who sent it.
+      def validate_source_text!(text)
+        return true if text.nil?
+
+        if text.length > max_source_text_chars
+          render json: { error: "text_too_large", limit_chars: max_source_text_chars },
+                 status: :unprocessable_entity
+          return false
+        end
+
+        true
       end
 
       def detect_input_kind(file)

--- a/apps/api/app/models/ingestion_run.rb
+++ b/apps/api/app/models/ingestion_run.rb
@@ -1,5 +1,5 @@
 class IngestionRun < ApplicationRecord
-  INPUT_KINDS = %w[photo url pdf].freeze
+  INPUT_KINDS = %w[photo url pdf text].freeze
   STATUSES    = %w[queued extracting resolving staged published failed].freeze
 
   # The pipeline marches forward through these states. `failed` is

--- a/apps/api/app/services/anthropic_client.rb
+++ b/apps/api/app/services/anthropic_client.rb
@@ -163,6 +163,30 @@ class AnthropicClient
     }
   end
 
+  # Build a document content block (Claude reads PDFs natively) from an
+  # ActiveStorage::Blob or a raw IO/String. Menu PDFs go through here —
+  # Anthropic's vision `image` block only accepts jpeg/png/gif/webp, so a
+  # PDF sent as an image 400s.
+  def document_block(source, media_type: nil)
+    if source.respond_to?(:download)
+      data       = source.download
+      media_type ||= source.content_type
+    elsif source.respond_to?(:read)
+      data = source.read
+    else
+      data = source.to_s
+    end
+
+    {
+      type: "document",
+      source: {
+        type:       "base64",
+        media_type: media_type || "application/pdf",
+        data:       Base64.strict_encode64(data)
+      }
+    }
+  end
+
   private
 
   def connection

--- a/apps/api/app/services/ingestion/extract_menu_prompt.rb
+++ b/apps/api/app/services/ingestion/extract_menu_prompt.rb
@@ -11,9 +11,9 @@ module Ingestion
     SYSTEM_INSTRUCTIONS = <<~MD.strip
       You are an OCR + structuring system for restaurant menus.
 
-      You will be given a restaurant menu as one or more images, a PDF,
-      or pasted/scraped text (potentially multi-page). Extract every
-      visible menu item and group them by section heading.
+      You will be given one or more images of a menu (potentially
+      multi-page). Extract every visible menu item and group them by
+      section heading.
 
       Respond with **STRICT JSON ONLY** that matches this shape:
 
@@ -60,9 +60,13 @@ module Ingestion
         physically closest to the item's name + description.
     MD
 
-    USER_INSTRUCTIONS = "Extract every menu item from the menu above."
-
-    IMAGE_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
+    # NOTE: kept verbatim ("these images") on purpose — the ExtractMenuJob
+    # live-cassette smoke matches the recorded request on body, so editing
+    # this text (or SYSTEM_INSTRUCTIONS) invalidates the committed cassette
+    # and needs a re-record with a real API key. The content-type routing
+    # below is what makes PDF/text work; the wording is cosmetic. Generalize
+    # it only alongside a cassette re-record.
+    USER_INSTRUCTIONS = "Extract every menu item from these images."
 
     # Build the system blocks array. Marks the instructions as
     # cached so a re-extraction within the 5-minute window pays

--- a/apps/api/app/services/ingestion/extract_menu_prompt.rb
+++ b/apps/api/app/services/ingestion/extract_menu_prompt.rb
@@ -11,9 +11,9 @@ module Ingestion
     SYSTEM_INSTRUCTIONS = <<~MD.strip
       You are an OCR + structuring system for restaurant menus.
 
-      You will be given one or more images of a menu (potentially
-      multi-page). Extract every visible menu item and group them by
-      section heading.
+      You will be given a restaurant menu as one or more images, a PDF,
+      or pasted/scraped text (potentially multi-page). Extract every
+      visible menu item and group them by section heading.
 
       Respond with **STRICT JSON ONLY** that matches this shape:
 
@@ -60,7 +60,9 @@ module Ingestion
         physically closest to the item's name + description.
     MD
 
-    USER_INSTRUCTIONS = "Extract every menu item from these images."
+    USER_INSTRUCTIONS = "Extract every menu item from the menu above."
+
+    IMAGE_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
 
     # Build the system blocks array. Marks the instructions as
     # cached so a re-extraction within the 5-minute window pays
@@ -69,12 +71,33 @@ module Ingestion
       client.system_blocks(text: SYSTEM_INSTRUCTIONS, cache: true)
     end
 
-    # Build the user message: every input attachment is added as an
-    # image block, then the short text instruction.
+    # Build the user message: each input attachment becomes the content
+    # block Anthropic expects for its type, then the short instruction.
     def self.user_messages(client, blobs)
-      content = blobs.map { |blob| client.image_block(blob) }
+      content = blobs.map { |blob| content_block(client, blob) }
       content << { type: "text", text: USER_INSTRUCTIONS }
       [{ role: "user", content: content }]
+    end
+
+    # Route each input by content-type. Anthropic's vision `image` block
+    # only accepts jpeg/png/gif/webp, so PDFs and text (URL scrapes come
+    # back as text/html; pasted menus as text/plain) must NOT be sent as
+    # images — doing so 400s with "media_type should be image/...".
+    #   * PDF   → document block (Claude reads PDFs natively)
+    #   * text/*→ text block (the model reads the menu text directly)
+    #   * else  → image block (jpeg/png/gif/webp — and, unchanged,
+    #             heic/heif, which still 400; converting them is a
+    #             follow-up, but a text block of raw HEIC bytes would be
+    #             worse, so they stay on the image path)
+    def self.content_block(client, blob)
+      ct = blob.content_type.to_s
+      if ct == "application/pdf"
+        client.document_block(blob)
+      elsif ct.start_with?("text/")
+        { type: "text", text: blob.download.to_s }
+      else
+        client.image_block(blob)
+      end
     end
   end
 end

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -85,6 +85,40 @@ RSpec.describe "Ingestion runs API", type: :request do
       expect(response.parsed_body["input_kind"]).to eq("pdf")
     end
 
+    context "with source_text (copy/paste — no file or URL)" do
+      it "creates a text run, stores the text as a text/plain blob, and 201s" do
+        allow(ExtractMenuJob).to receive(:perform_later)
+
+        expect {
+          post "/api/v1/ingestion_runs",
+               params: { restaurant_id: restaurant.id, source_text: "Appetizers\nHummus 8" },
+               headers: auth_for(non_admin)
+        }.to change(IngestionRun, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body).to include("status" => "extracting", "input_kind" => "text")
+
+        run = IngestionRun.last
+        expect(run.inputs.attached?).to be(true)
+        expect(run.inputs.blobs.first.content_type).to eq("text/plain")
+        expect(run.inputs.blobs.first.download).to include("Hummus")
+      end
+
+      it "422s text_too_large when the pasted text exceeds the char cap" do
+        old = ENV["INGESTION_MAX_SOURCE_TEXT_CHARS"]
+        ENV["INGESTION_MAX_SOURCE_TEXT_CHARS"] = "10"
+
+        post "/api/v1/ingestion_runs",
+             params: { restaurant_id: restaurant.id, source_text: "x" * 50 },
+             headers: auth_for(non_admin)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body).to include("error" => "text_too_large", "limit_chars" => 10)
+      ensure
+        ENV["INGESTION_MAX_SOURCE_TEXT_CHARS"] = old
+      end
+    end
+
     context "with source_url (Phase 2.8)" do
       let(:menu_url) { "https://durango-restaurants.example/cream-bean-berry/menu" }
 

--- a/apps/api/spec/services/ingestion/extract_menu_prompt_spec.rb
+++ b/apps/api/spec/services/ingestion/extract_menu_prompt_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Ingestion::ExtractMenuPrompt do
+  # Anthropic's vision `image` block only accepts jpeg/png/gif/webp, so
+  # PDFs and text (URL scrapes arrive as text/html, pasted menus as
+  # text/plain) must route to document/text blocks instead. The actual
+  # block bytes are AnthropicClient's job (tested there); here we only
+  # assert the routing.
+  let(:client) do
+    Class.new do
+      def image_block(_blob) = { type: "image" }
+      def document_block(_blob) = { type: "document" }
+    end.new
+  end
+
+  def blob(content_type, bytes = "x")
+    instance_double(ActiveStorage::Blob, content_type: content_type, download: bytes)
+  end
+
+  def input_blocks(*blobs)
+    described_class.user_messages(client, blobs).first[:content]
+  end
+
+  it "routes jpeg/png/gif/webp to image blocks" do
+    %w[image/jpeg image/png image/gif image/webp].each do |ct|
+      expect(input_blocks(blob(ct)).first).to include(type: "image")
+    end
+  end
+
+  it "routes application/pdf to a document block, not an image" do
+    expect(input_blocks(blob("application/pdf", "%PDF")).first).to include(type: "document")
+  end
+
+  it "routes text/html (URL scrape) and text/plain (paste) to text blocks with the content" do
+    %w[text/html text/plain].each do |ct|
+      block = input_blocks(blob(ct, "Menu\nHummus 8")).first
+      expect(block[:type]).to eq("text")
+      expect(block[:text]).to include("Hummus")
+    end
+  end
+
+  it "appends the short instruction after the inputs" do
+    expect(input_blocks(blob("image/jpeg")).last)
+      .to include(type: "text", text: described_class::USER_INSTRUCTIONS)
+  end
+end

--- a/apps/web/src/app/ingest/__tests__/page.paste.test.tsx
+++ b/apps/web/src/app/ingest/__tests__/page.paste.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, replace: vi.fn() }),
+}));
+
+const ingestFromText = vi.fn();
+vi.mock('../../../lib/ingestion', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/ingestion')>();
+  return { ...actual, ingestFromText: (...a: unknown[]) => ingestFromText(...a) };
+});
+
+import IngestPage from '../page';
+
+// Provide a restaurant id via the manual-UUID escape hatch so submit clears
+// the "pick a restaurant first" guard without driving NewRestaurantPicker.
+function setRestaurant() {
+  fireEvent.change(screen.getByPlaceholderText(/aaaaaaaa/), {
+    target: { value: 'rest-uuid-1' },
+  });
+}
+
+beforeEach(() => {
+  push.mockReset();
+  ingestFromText.mockReset();
+});
+
+describe('IngestPage — paste menu text', () => {
+  it('imports pasted text via ingestFromText and routes to the verify page', async () => {
+    ingestFromText.mockResolvedValue({ id: 'run-77' });
+    render(<IngestPage />);
+    setRestaurant();
+
+    fireEvent.change(screen.getByTestId('paste-input'), {
+      target: { value: 'Appetizers\nHummus — chickpeas, tahini … 8' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('paste-submit'));
+    });
+
+    await waitFor(() => expect(ingestFromText).toHaveBeenCalledTimes(1));
+    expect(ingestFromText.mock.calls[0]![0]).toMatchObject({
+      restaurantId: 'rest-uuid-1',
+      sourceText: 'Appetizers\nHummus — chickpeas, tahini … 8',
+    });
+    expect(push).toHaveBeenCalledWith('/ingest/verify/run-77');
+  });
+
+  it('blocks submit and warns when the textarea is empty', async () => {
+    render(<IngestPage />);
+    setRestaurant();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('paste-submit'));
+    });
+
+    expect(ingestFromText).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('Paste the menu text.');
+  });
+});

--- a/apps/web/src/app/ingest/page.tsx
+++ b/apps/web/src/app/ingest/page.tsx
@@ -6,6 +6,7 @@ import type { Route } from 'next';
 import {
   ingestFromFile,
   ingestFromUrl,
+  ingestFromText,
   friendlyIngestionError,
   IngestionRequestError,
 } from '../../lib/ingestion';
@@ -25,6 +26,7 @@ export default function IngestPage() {
   const [restaurant, setRestaurant] = useState<{ id: string; name: string } | null>(null);
   const [manualId, setManualId] = useState('');
   const [sourceUrl, setSourceUrl] = useState('');
+  const [sourceText, setSourceText] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -33,7 +35,7 @@ export default function IngestPage() {
 
   const onPickFile = (e: ChangeEvent<HTMLInputElement>) => setFile(e.target.files?.[0] ?? null);
 
-  const submit = async (mode: 'url' | 'file') => {
+  const submit = async (mode: 'url' | 'file' | 'text') => {
     setError(null);
     if (!restaurantId) {
       setError('Pick or create a restaurant first.');
@@ -47,13 +49,19 @@ export default function IngestPage() {
       setError('Drop a file.');
       return;
     }
+    if (mode === 'text' && !sourceText.trim()) {
+      setError('Paste the menu text.');
+      return;
+    }
 
     try {
       setSubmitting(true);
       const run =
         mode === 'url'
           ? await ingestFromUrl({ restaurantId, sourceUrl })
-          : await ingestFromFile({ restaurantId, file: file! });
+          : mode === 'file'
+            ? await ingestFromFile({ restaurantId, file: file! })
+            : await ingestFromText({ restaurantId, sourceText });
       router.push(`/ingest/verify/${run.id}` as Route);
     } catch (e) {
       if (e instanceof IngestionRequestError && e.status === 401) {
@@ -175,6 +183,31 @@ export default function IngestPage() {
           className="rounded bg-orange-600 px-4 py-2 font-semibold text-white disabled:opacity-50"
         >
           {submitting ? 'Uploading…' : 'Upload file'}
+        </button>
+      </section>
+
+      <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
+        <h2 className="text-lg font-semibold">Or paste the menu text</h2>
+        <p className="text-sm text-zinc-600">
+          Copy the menu from a website, email, or PDF and paste it here — handy when there’s no
+          clean link or photo.
+        </p>
+        <textarea
+          value={sourceText}
+          onChange={(e) => setSourceText(e.target.value)}
+          placeholder={'Appetizers\nHummus — chickpeas, tahini, olive oil … 8\n…'}
+          rows={8}
+          data-testid="paste-input"
+          className="w-full rounded border border-zinc-300 px-3 py-2 font-mono text-sm"
+        />
+        <button
+          type="button"
+          onClick={() => void submit('text')}
+          disabled={submitting}
+          data-testid="paste-submit"
+          className="rounded bg-orange-600 px-4 py-2 font-semibold text-white disabled:opacity-50"
+        >
+          {submitting ? 'Submitting…' : 'Import pasted text'}
         </button>
       </section>
 

--- a/apps/web/src/lib/__tests__/ingestion.test.ts
+++ b/apps/web/src/lib/__tests__/ingestion.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   ingestFromFile,
   ingestFromUrl,
+  ingestFromText,
   IngestionRequestError,
   type IngestionRunPayload,
 } from '../ingestion';
@@ -70,6 +71,37 @@ describe('ingestFromUrl', () => {
       status: 422,
       body: { error: 'url_fetch_failed', reason: 'non_2xx', status: 503 },
     });
+  });
+});
+
+describe('ingestFromText', () => {
+  it('POSTs source_text as JSON to the Next proxy (no file, no Authorization)', async () => {
+    const fetchImpl = fakeFetch(201, { ...sampleRun, input_kind: 'text' });
+
+    const result = await ingestFromText({
+      restaurantId: 'rest-1',
+      sourceText: 'Appetizers\nHummus — chickpeas, tahini … 8',
+      fetchImpl,
+    });
+
+    expect(result.input_kind).toBe('text');
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/ingestion_runs');
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('same-origin');
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init.body as string)).toEqual({
+      restaurant_id: 'rest-1',
+      source_text: 'Appetizers\nHummus — chickpeas, tahini … 8',
+    });
+  });
+
+  it('propagates a text_too_large 422', async () => {
+    const fetchImpl = fakeFetch(422, { error: 'text_too_large', limit_chars: 50000 });
+    await expect(
+      ingestFromText({ restaurantId: 'rest-1', sourceText: 'x'.repeat(10), fetchImpl }),
+    ).rejects.toMatchObject({ status: 422, body: { error: 'text_too_large' } });
   });
 });
 

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -242,3 +242,16 @@ export async function ingestFromFile(opts: {
   form.append('inputs[]', file, file.name);
   return postIngestionRun(form, fetchImpl, true);
 }
+
+export async function ingestFromText(opts: {
+  restaurantId: string;
+  sourceText: string;
+  fetchImpl?: typeof fetch;
+}): Promise<IngestionRunPayload> {
+  const { restaurantId, sourceText, fetchImpl = fetch } = opts;
+  return postIngestionRun(
+    JSON.stringify({ restaurant_id: restaurantId, source_text: sourceText }),
+    fetchImpl,
+    false,
+  );
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,8 +17,26 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Route ingestion inputs by content-type + copy/paste import.
+Branch `feat/ingest-content-types` (the "next PR" from the fence entry below).
+
+- Fixes the URL-import 400 (`media_type should be image/...`): `ExtractMenuPrompt`
+  sent every input as a vision `image` block, but URL fetches come back as
+  `text/html` and PDFs as `application/pdf` — neither is a valid image. Now
+  routed per content-type: PDF → document block (Claude reads PDFs natively),
+  text/* (URL HTML + pasted) → text block, images (jpeg/png/gif/webp) → image
+  block. HEIC/HEIF still route as images (deferred; a text block of raw HEIC
+  bytes would be worse — conversion is the real follow-up).
+- Delivers the requested **copy/paste import**: `POST /api/v1/ingestion_runs`
+  now accepts `source_text` → a `text` run storing the paste as a text/plain
+  input blob through the same pipeline; capped at 50k chars
+  (`INGESTION_MAX_SOURCE_TEXT_CHARS`). New `/ingest` textarea + `ingestFromText`.
+- Added `AnthropicClient#document_block`, `input_kind: "text"`. Specs: prompt
+  routing (image/pdf/text) + request (text run, text_too_large) + web (lib +
+  paste page). Web vitest 208, typecheck/lint green; Ruby specs on ci-api.
+
 2026-07-21 — Ingestion pipeline bugs surfaced once R2 upload worked. Branches
-`fix/anthropic-json-fence` (this one) + follow-ups.
+`fix/anthropic-json-fence` + follow-ups.
 
 - After the R2 fix, real scans exposed downstream failures (from prod runs):
   1. **Photo (jpeg)**: extraction succeeds, then resolve fails —


### PR DESCRIPTION
## Summary

- **Fixes the URL-import 400** (`media_type should be image/...`): extraction sent every input to Claude as a vision `image` block, but URL fetches come back as `text/html` and PDFs as `application/pdf` — neither is a valid image. Now routed by content-type: PDF → document block, text/* (URL HTML + pasted) → text block, images → image block. (HEIC/HEIF still route as images — deferred.)
- **Adds the copy/paste import**: `POST /api/v1/ingestion_runs` accepts `source_text` → a `text` run stored as a text/plain input blob through the same pipeline (50k-char cap). New `/ingest` textarea.
