### PR TITLE
perf(api): run resolve stages on a fast Haiku model (scan speed, phase 1)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -61,6 +61,11 @@ INGESTION_MAX_INPUT_FILE_BYTES=10485760
 # Char cap on the copy/paste import (source_text). A very long menu is
 # well under this; the whole thing goes into the extraction prompt.
 INGESTION_MAX_SOURCE_TEXT_CHARS=50000
+# Model for the resolve stages (ingredient/tag catalog mapping). Defaults
+# to a fast Haiku model — resolve is slug-lookup, not deep reasoning, so
+# this is the main lever on the "Matching ingredients…" wait. Extraction
+# (vision) stays on the stronger default model.
+INGESTION_RESOLVE_MODEL=claude-haiku-4-5-20251001
 
 # --- Mailer ------------------------------------------------------------------
 # Used by Devise for password-reset emails. The mailer itself isn't

--- a/apps/api/app/jobs/concerns/timed_anthropic_call.rb
+++ b/apps/api/app/jobs/concerns/timed_anthropic_call.rb
@@ -19,8 +19,8 @@ module TimedAnthropicCall
   #
   # Returns `[result, elapsed_ms]`, or `nil` when the call failed and the
   # run was already marked failed (so callers `return if out.nil?`).
-  def timed_anthropic_call(run, api_error:, validation_error:)
-    client  = AnthropicClient.new
+  def timed_anthropic_call(run, api_error:, validation_error:, model: nil)
+    client  = AnthropicClient.new(model: model)
     started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     begin

--- a/apps/api/app/jobs/resolve_stage_job.rb
+++ b/apps/api/app/jobs/resolve_stage_job.rb
@@ -26,7 +26,12 @@ class ResolveStageJob < ApplicationJob
       return
     end
 
-    out = timed_anthropic_call(run, api_error: "#{stage}_api_error", validation_error: "#{stage}_validation_failed") do |client|
+    out = timed_anthropic_call(
+      run,
+      api_error:        "#{stage}_api_error",
+      validation_error: "#{stage}_validation_failed",
+      model:            resolve_model
+    ) do |client|
       client.messages_create(
         system:          prompt.system(client, catalog_text),
         messages:        prompt.user_messages(items),
@@ -49,6 +54,14 @@ class ResolveStageJob < ApplicationJob
 
   # The curated catalog text the prompt is primed with.
   def catalog_text = raise(NotImplementedError)
+
+  # Resolve is catalog slug-mapping, not deep reasoning, so it runs on a
+  # faster/cheaper model than extraction's vision call — the dominant
+  # cut to the "Matching ingredients…" wait. Overridable per-env for
+  # tuning/rollback without a redeploy.
+  DEFAULT_RESOLVE_MODEL = "claude-haiku-4-5-20251001"
+
+  def resolve_model = ENV.fetch("INGESTION_RESOLVE_MODEL", DEFAULT_RESOLVE_MODEL)
 
   # Persist a successful resolution and advance the pipeline. Receives
   # the run, the API result, and the elapsed milliseconds.

--- a/apps/api/app/services/ingestion/usage_cost.rb
+++ b/apps/api/app/services/ingestion/usage_cost.rb
@@ -21,6 +21,14 @@ module Ingestion
         output:      1_500,
         cache_read:  30,
         cache_write: 375
+      },
+      # claude-haiku-4-5: $1/MTok input, $5/MTok output (cache read 0.1x
+      # input, cache write 1.25x). Used by the resolve stages.
+      "claude-haiku-4-5-20251001" => {
+        input:       100,
+        output:      500,
+        cache_read:  10,
+        cache_write: 125
       }
     }.freeze
 

--- a/apps/api/spec/jobs/resolve_ingredients_job_spec.rb
+++ b/apps/api/spec/jobs/resolve_ingredients_job_spec.rb
@@ -94,6 +94,13 @@ RSpec.describe ResolveIngredientsJob, type: :job do
       run.reload
       expect(run.latency_ms).to be >= 0
     end
+
+    it "runs on the faster resolve model, not the default extraction model" do
+      expect(AnthropicClient).to receive(:new)
+        .with(model: "claude-haiku-4-5-20251001").and_call_original
+
+      described_class.perform_now(run.id)
+    end
   end
 
   describe "no items in staging" do

--- a/apps/api/spec/services/ingestion/usage_cost_spec.rb
+++ b/apps/api/spec/services/ingestion/usage_cost_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Ingestion::UsageCost do
       expect(described_class.cents({})).to eq(0)
     end
 
+    it "prices the faster resolve model (haiku) at its own lower rate" do
+      # 1M input at $1/MTok = 100 cents; 1M output at $5/MTok = 500 cents
+      usage = { "input_tokens" => 1_000_000, "output_tokens" => 1_000_000 }
+
+      expect(described_class.cents(usage, model: "claude-haiku-4-5-20251001")).to eq(600)
+    end
+
     it "falls back to default-model pricing for unknown models" do
       usage = { "input_tokens" => 1_000_000 }
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,26 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Faster resolve stage (scan speed, Phase 1 of 2). Branch `feat/parallel-resolve`.
+
+- User: "Matching ingredients…" is slow + no feedback. Traced it: ingestion is
+  **3 sequential LLM calls** (extract → resolve ingredients → resolve tags) and
+  the verify page shows nothing until all 3 finish. The two resolve calls are the
+  wait. Agreed plan = "Both": **Phase 1** (this) faster resolve; **Phase 2** show
+  dishes right after extraction + enrich (ingredients/tags) in the background,
+  gating publish on enrichment.
+- **Phase 1**: the resolve stages do catalog **slug-mapping**, not deep reasoning,
+  so they now run on a fast Haiku model (`INGESTION_RESOLVE_MODEL`, default
+  `claude-haiku-4-5-20251001`) instead of the Sonnet vision model. Extraction
+  stays on Sonnet. Threaded `model:` through `timed_anthropic_call` (one place —
+  request + cost pricing); added Haiku to `UsageCost` ($1/$5 per MTok). Kept the
+  sequential chain — **parallelizing the two resolve jobs was deliberately NOT
+  done**: `record_api_usage!`/staging are read-modify-write ("jobs run
+  sequentially per run" invariant), so concurrency would need row-lock hardening
+  that Phase 2's background-per-item enrichment restructures anyway.
+- Specs: resolve job asserts the Haiku model; UsageCost prices Haiku. `ruby -c`
+  clean; full rspec on ci-api. **Next: Phase 2 (instant dishes + bg enrich).**
+
 2026-07-21 — Route ingestion inputs by content-type + copy/paste import.
 Branch `feat/ingest-content-types` (the "next PR" from the fence entry below).
 


### PR DESCRIPTION
## Summary

- The slow "Matching ingredients…" phase is two LLM calls mapping extracted dishes onto the ingredient/tag catalogs — slug lookup, not reasoning. Run them on a fast **Haiku** model (`INGESTION_RESOLVE_MODEL`, default `claude-haiku-4-5-20251001`); extraction (vision) stays on Sonnet.
- Threads `model:` through `timed_anthropic_call` (request + cost pricing in one place); adds Haiku's rate to `UsageCost`.
- Phase 1 of 2 — Phase 2 will show dishes right after extraction and enrich in the background. Parallelizing the two resolve jobs was intentionally deferred (read-modify-write races that Phase 2 restructures anyway).
