### PR TITLE
fix(api): tolerate a bare-array resolve response

### DIFF
--- a/apps/api/app/services/anthropic_client/response_parser.rb
+++ b/apps/api/app/services/anthropic_client/response_parser.rb
@@ -31,7 +31,7 @@ class AnthropicClient::ResponseParser
     # AnthropicClient::ValidationError on either JSON parse failure
     # or schema mismatch.
     def parse_and_validate(text, schema)
-      payload = JSON.parse(strip_code_fence(text))
+      payload = coerce_root(JSON.parse(strip_code_fence(text)), schema)
     rescue JSON::ParserError => e
       raise AnthropicClient::ValidationError.new(
         raw_body: text, errors: ["JSON parse failed: #{e.message}"]
@@ -56,6 +56,24 @@ class AnthropicClient::ResponseParser
         .sub(/\A```[a-z0-9]*[ \t]*\r?\n?/i, "") # opening ``` or ```json
         .sub(/\r?\n?```\s*\z/, "")              # closing ```
         .strip
+    end
+
+    # Models (especially faster ones) sometimes return a bare array when
+    # the schema wants a single-array object like {"items":[...]} — seen
+    # live at the resolve stage as "property '#/' of type array did not
+    # match ... object". When the parsed value is an Array and the schema
+    # is exactly one array-typed property, wrap it under that key so a
+    # well-formed body still validates. Anything else passes through
+    # unchanged (and genuinely-wrong shapes still fail validation).
+    def coerce_root(payload, schema)
+      return payload unless payload.is_a?(Array)
+      return payload unless (schema[:type] || schema["type"]) == "object"
+
+      props      = schema[:properties] || schema["properties"] || {}
+      array_keys = props.select { |_, spec| (spec[:type] || spec["type"]) == "array" }.keys
+      return payload unless array_keys.size == 1
+
+      { array_keys.first.to_s => payload }
     end
   end
 end

--- a/apps/api/spec/services/anthropic_client/response_parser_spec.rb
+++ b/apps/api/spec/services/anthropic_client/response_parser_spec.rb
@@ -33,4 +33,31 @@ RSpec.describe AnthropicClient::ResponseParser do
     expect { described_class.parse_and_validate('{"ok":"not a bool"}', schema) }
       .to raise_error(AnthropicClient::ValidationError)
   end
+
+  describe "bare-array coercion" do
+    it "wraps a bare array under the schema's single array property so it validates" do
+      # The live resolve failure: model returned [...] instead of {items:[...]}
+      # ("property '#/' of type array did not match ... object").
+      result = described_class.parse_and_validate(
+        '[{"index":0,"resolved":[],"unresolved":[]}]',
+        Ingestion::ResolutionSchema
+      )
+      expect(result["items"].first).to include("index" => 0)
+    end
+
+    it "coerces a bare array that is also markdown-fenced" do
+      result = described_class.parse_and_validate(
+        "```json\n[{\"index\":0,\"resolved\":[],\"unresolved\":[]}]\n```",
+        Ingestion::ResolutionSchema
+      )
+      expect(result["items"].size).to eq(1)
+    end
+
+    it "does NOT wrap when the schema isn't a single-array object (still fails)" do
+      # `schema` here is {ok: boolean} — no array property, so a bare array
+      # stays an array and fails validation rather than being force-wrapped.
+      expect { described_class.parse_and_validate('[1, 2]', schema) }
+        .to raise_error(AnthropicClient::ValidationError)
+    end
+  end
 end

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,17 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Tolerate bare-array resolve responses. Branch `fix/resolve-array-response`.
+
+- Live scan failed: `resolve_ingredients_validation_failed: property '#/' of type
+  array did not match ... object`. The resolve model returned a bare `[...]`
+  instead of the schema's `{"items":[...]}` wrapper (any model does this
+  occasionally; faster models more so). `ResponseParser#coerce_root` now wraps a
+  bare array under the schema's single array-typed property before validation —
+  conservative (only the unambiguous single-array-object case; genuinely-wrong
+  shapes still fail). Covered against the real `ResolutionSchema` + a fenced
+  variant.
+
 2026-07-21 — Faster resolve stage (scan speed, Phase 1 of 2). Branch `feat/parallel-resolve`.
 
 - User: "Matching ingredients…" is slow + no feedback. Traced it: ingestion is


### PR DESCRIPTION
## Summary

- Live scans failed at resolve: `property '#/' of type array did not match ... object` — the model returned a bare `[...]` instead of the schema's `{"items":[...]}` wrapper.
- `ResponseParser#coerce_root` wraps a bare array under the schema's single array-typed property before validation. Conservative: only the unambiguous single-array-object case; genuinely-wrong shapes still fail. Covered against the real `ResolutionSchema`.
