### PR TITLE
fix(api): don't count failed runs against the per-user scan quota

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_runs_controller.rb
@@ -209,9 +209,16 @@ module Api
         true
       end
 
+      # Failed runs don't count against the per-user quota — a scan that
+      # errored produced no value and the user must be able to retry. Spend
+      # is still guarded separately by the daily cost ceiling
+      # (`todays_spend_cents` sums EVERY run's billed cost, failures included),
+      # so a burst of failing calls can't leak past the budget. In-flight +
+      # successful runs still count, so the quota bounds real usage.
       def runs_in_last_24h
         IngestionRun.where(user_id: current_user.id)
                     .where(created_at: 24.hours.ago..)
+                    .where.not(status: "failed")
                     .count
       end
 

--- a/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_runs_spec.rb
@@ -315,6 +315,15 @@ RSpec.describe "Ingestion runs API", type: :request do
         expect(response).to have_http_status(:created)
       end
 
+      it "does not count failed runs — a user whose scans errored can still retry" do
+        # Two failed runs in the window would exceed the limit of 2 if counted.
+        create(:ingestion_run, :failed, user: non_admin, restaurant: restaurant)
+        create(:ingestion_run, :failed, user: non_admin, restaurant: restaurant)
+
+        create_run_as(non_admin)
+        expect(response).to have_http_status(:created)
+      end
+
       it "is per-user — another user's runs don't count against mine" do
         other = create(:user, password: "password123", is_admin: false)
         2.times { create(:ingestion_run, user: other, restaurant: restaurant) }

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,16 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Failed runs no longer burn the per-user scan quota. Branch `fix/quota-excludes-failed`.
+
+- Verifying the earlier fixes was blocked: all 5 of the reporter's daily quota
+  slots were consumed by *failed* test runs (media_type/fence/bare-array errors,
+  each now fixed + deployed). `runs_in_last_24h` counted every run regardless of
+  status, so a user whose scans errored couldn't retry. Now excludes
+  `status: "failed"` — spend is still guarded by the daily cost ceiling
+  (`todays_spend_cents` sums all runs, failures included). This auto-frees the
+  reporter's 5 dead slots. Spec: a failed run doesn't count toward the quota.
+
 2026-07-21 — Tolerate bare-array resolve responses. Branch `fix/resolve-array-response`.
 
 - Live scan failed: `resolve_ingredients_validation_failed: property '#/' of type


### PR DESCRIPTION
## Summary

- Failed scans consumed the 5/day per-user quota, so a user whose scans errored (media_type / fence / bare-array bugs — all now fixed) couldn't retry. `runs_in_last_24h` now excludes `status: "failed"`.
- Spend stays guarded by the daily cost ceiling (`todays_spend_cents` sums every run, failures included).
