### PR TITLE
feat(api): verify-flow redesign PR-1 — instant dishes + background enrichment

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
@@ -47,7 +47,16 @@ module Api
           # promotion step.
           if decision == "accepted"
             item.save! if item.changed?
-            item.promote!(decided_by: current_user)
+            if run.staged? || run.published?
+              item.promote!(decided_by: current_user)
+            else
+              # Verify-flow redesign: dishes are visible + acceptable while
+              # enrichment (resolve) is still running, but promote! must wait
+              # until the item has its ingredient/tag payloads — an Item can't
+              # go live without them. Record the acceptance now; ResolveTagsJob
+              # batch-promotes it when the run reaches :staged.
+              item.update!(decision: "accepted", decided_at: Time.current)
+            end
           else
             item.update!(decision: "edited", decided_at: Time.current)
           end

--- a/apps/api/app/jobs/extract_menu_job.rb
+++ b/apps/api/app/jobs/extract_menu_job.rb
@@ -22,7 +22,7 @@ class ExtractMenuJob < ApplicationJob
 
   def perform(ingestion_run_id)
     run = IngestionRun.find(ingestion_run_id)
-    return if run.staged? || run.published? || run.failed?
+    return if run.resolving? || run.staged? || run.published? || run.failed?
 
     # Job dispatch fires when the run enters `:extracting` — being
     # called BEFORE that means we got dispatched manually; flip the
@@ -45,10 +45,40 @@ class ExtractMenuJob < ApplicationJob
     return if out.nil?
     result, elapsed_ms = out
 
-    run.update!(
-      staging:    result,
-      latency_ms: elapsed_ms
-    )
-    run.transition_to!(:resolving)
+    # Verify-flow redesign: materialize the dishes NOW (empty ingredient/tag
+    # payloads) so the verify page shows them immediately, then transition to
+    # :resolving where the resolve stages enrich each item in the background.
+    # Atomic with the transition so a run never sits in :resolving without its
+    # items. Guarded above (return if resolving?) against a re-run.
+    run.transaction do
+      run.update!(staging: result, latency_ms: elapsed_ms)
+      materialize_items!(run)
+      run.transition_to!(:resolving)
+    end
+  end
+
+  private
+
+  # One IngestionItem per extracted item, in flat order, carrying the
+  # position so the resolve stages can write their indexed results back onto
+  # the right row. ingredients_payload / tags_payload stay empty ([] default)
+  # until enrichment fills them.
+  def materialize_items!(run)
+    position = 0
+    Array(run.staging["sections"]).each do |section|
+      section_name = section["name"]
+      Array(section["items"]).each do |item|
+        run.ingestion_items.create!(
+          name:           item["name"],
+          description:    item["description"],
+          section_name:   section_name,
+          prices_payload: Array(item["prices"]),
+          image_bbox:     item["image_bbox"],
+          position:       position,
+          decision:       "pending"
+        )
+        position += 1
+      end
+    end
   end
 end

--- a/apps/api/app/jobs/resolve_ingredients_job.rb
+++ b/apps/api/app/jobs/resolve_ingredients_job.rb
@@ -15,10 +15,12 @@ class ResolveIngredientsJob < ResolveStageJob
   def catalog_text = Ingestion::CatalogBuilder.ingredients_text
 
   def apply_and_advance(run, result, elapsed_ms)
-    run.update!(
-      staging:    apply_resolution(run.staging, result, key: :ingredients),
-      latency_ms: elapsed_ms
+    apply_resolution_to_items!(
+      run, result,
+      resolved_col:   :ingredients_payload,
+      unresolved_col: :unresolved_ingredients
     )
+    run.update!(latency_ms: elapsed_ms)
     ResolveTagsJob.perform_later(run.id)
   end
 end

--- a/apps/api/app/jobs/resolve_stage_job.rb
+++ b/apps/api/app/jobs/resolve_stage_job.rb
@@ -84,28 +84,24 @@ class ResolveStageJob < ApplicationJob
 
   def collect_items(staging) = self.class.collect_items(staging)
 
-  # Mutate a deep copy of staging by zipping the API response back onto
-  # each item by index, writing two new keys: `<key>` (resolved) and
-  # `unresolved_<key>`.
-  def apply_resolution(staging, result, key:)
-    new_staging = JSON.parse(staging.to_json) # deep copy + stringify
-    flat_index  = 0
-    by_index    = result["items"].index_by { |row| row["index"] }
+  # Verify-flow redesign: enrich the IngestionItems (materialized up front by
+  # ExtractMenuJob) in place — write this stage's resolution onto each item by
+  # `position`. The items, not staging, are now the source of truth the verify
+  # UI + promote! read. `collect_items(staging)` (flat order) and the item
+  # positions were both assigned in the same section→item order, so the model's
+  # row index maps straight to `item.position`. An item whose index the model
+  # didn't return keeps its empty defaults.
+  def apply_resolution_to_items!(run, result, resolved_col:, unresolved_col:)
+    by_index = Array(result["items"]).index_by { |row| row["index"] }
 
-    Array(new_staging["sections"]).each do |section|
-      Array(section["items"]).each do |item|
-        row = by_index[flat_index]
-        if row
-          item[key.to_s]            = row["resolved"]
-          item["unresolved_#{key}"] = row["unresolved"]
-        else
-          item[key.to_s]            ||= []
-          item["unresolved_#{key}"] ||= []
-        end
-        flat_index += 1
-      end
+    run.ingestion_items.where.not(position: nil).find_each do |item|
+      row = by_index[item.position]
+      next unless row
+
+      item.update!(
+        resolved_col   => Array(row["resolved"]),
+        unresolved_col => Array(row["unresolved"])
+      )
     end
-
-    new_staging
   end
 end

--- a/apps/api/app/jobs/resolve_tags_job.rb
+++ b/apps/api/app/jobs/resolve_tags_job.rb
@@ -1,55 +1,51 @@
-# Phase 2.4 — third stage of the AI ingestion pipeline.
+# Phase 2.4 — third (final) stage of the AI ingestion pipeline.
 #
 # Triggered by ResolveIngredientsJob on success. Same shape as the
-# ingredient stage (skeleton in ResolveStageJob) but with the tag
-# catalog. After writing the tag resolution back to staging, this job:
+# ingredient stage (skeleton in ResolveStageJob) but with the tag catalog.
 #
-# 1. Materializes IngestionItem rows (one per item in staging) with
-#    `decision: pending` so the swipe-verify UI in Phase 2.7 has
-#    something to show.
-# 2. Transitions the run to `:staged` (Phase 2.5's verify UI takes
-#    over from there).
+# Verify-flow redesign: the items were already materialized up front by
+# ExtractMenuJob, so this stage ENRICHES them in place (tags) rather than
+# creating them. Once every item carries its ingredient + tag payloads it:
+#   1. Promotes any item the user accepted while enrichment was still
+#      running (recorded then, but NOT promoted — an Item must never go live
+#      without its ingredients/tags).
+#   2. Transitions the run to :staged and runs the 80%-accepted publish check
+#      (a bulk pre-accept may already have crossed the threshold).
 class ResolveTagsJob < ResolveStageJob
   def stage        = "resolve_tags"
   def prompt       = Ingestion::ResolveTagsPrompt
   def catalog_text = Ingestion::CatalogBuilder.tags_text
 
   def apply_and_advance(run, result, elapsed_ms)
-    new_staging = apply_resolution(run.staging, result, key: :tags)
-
     run.transaction do
-      run.update!(staging: new_staging, latency_ms: elapsed_ms)
-      materialize_ingestion_items!(run)
+      apply_resolution_to_items!(
+        run, result,
+        resolved_col:   :tags_payload,
+        unresolved_col: :unresolved_tags
+      )
+      run.update!(latency_ms: elapsed_ms)
+      promote_accepted_items!(run)
       run.transition_to!(:staged)
+      run.maybe_publish!
     end
   end
 
   private
 
-  # Walk the resolved staging payload and create one IngestionItem
-  # per extracted item, ready for the swipe-verify UI to operate on.
-  def materialize_ingestion_items!(run)
-    Array(run.staging["sections"]).each do |section|
-      section_name = section["name"]
-      Array(section["items"]).each do |item|
-        IngestionItem.create!(
-          ingestion_run:           run,
-          name:                    item["name"],
-          description:             item["description"],
-          section_name:            section_name,
-          prices_payload:          Array(item["prices"]),
-          ingredients_payload:     Array(item["ingredients"]),
-          tags_payload:            Array(item["tags"]),
-          unresolved_ingredients:  Array(item["unresolved_ingredients"]),
-          unresolved_tags:         Array(item["unresolved_tags"]),
-          # Phase 4.11.2 — bbox is optional in the schema; nil is the
-          # signal "no inline photo for this dish." Phase 4.11.3's
-          # IngestionItem#promote! reads this column to decide whether
-          # to crop + attach.
-          image_bbox:              item["image_bbox"],
-          decision:                "pending"
-        )
-      end
+  # Items accepted while the run was still :resolving were recorded but not
+  # promoted (their payloads were empty then). Now that they're enriched,
+  # materialize the real Items. decided_by is the run's user, matching the
+  # community self-verify trust model (creator → suggested; admin-owned run /
+  # no user → confirmed). Best-effort per item so one bad promotion can't
+  # block the whole run from reaching :staged; promote! is idempotent.
+  def promote_accepted_items!(run)
+    run.ingestion_items.where(decision: "accepted", item_id: nil).find_each do |item|
+      item.promote!(decided_by: run.user)
+    rescue StandardError => e
+      Rails.logger.error(
+        "ResolveTagsJob: promote of pre-accepted IngestionItem##{item.id} failed: " \
+        "#{e.class} #{e.message}"
+      )
     end
   end
 end

--- a/apps/api/db/migrate/20260721120000_add_position_to_ingestion_items.rb
+++ b/apps/api/db/migrate/20260721120000_add_position_to_ingestion_items.rb
@@ -1,0 +1,9 @@
+class AddPositionToIngestionItems < ActiveRecord::Migration[8.1]
+  # Flat index of the item within its run's extraction order. Set when
+  # ExtractMenuJob materializes items up front (verify-flow redesign) so the
+  # resolve stages can write their indexed results back onto the right item.
+  # Nullable: rows from runs materialized the old way (at resolve-end) stay null.
+  def change
+    add_column :ingestion_items, :position, :integer
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_120000) do
     t.jsonb "ingredients_payload", default: []
     t.uuid "item_id"
     t.string "name"
+    t.integer "position"
     t.jsonb "prices_payload", default: []
     t.string "section_name"
     t.jsonb "tags_payload", default: []

--- a/apps/api/spec/jobs/extract_menu_job_spec.rb
+++ b/apps/api/spec/jobs/extract_menu_job_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe ExtractMenuJob, type: :job do
       expect(run.state_history.keys).to include("extracting", "resolving")
     end
 
+    it "materializes an IngestionItem per extracted dish up front (empty payloads) for instant review" do
+      described_class.perform_now(run.id)
+
+      item = run.ingestion_items.sole
+      expect(item).to have_attributes(
+        name: "Carne Asada Taco", section_name: "Tacos", position: 0, decision: "pending"
+      )
+      expect(item.prices_payload).to eq([{ "size" => nil, "price_cents" => 450 }])
+      # Enrichment fills these in the background — empty now so the dish shows immediately.
+      expect(item.ingredients_payload).to eq([])
+      expect(item.tags_payload).to eq([])
+    end
+
     it "is a no-op on already-staged runs" do
       run.update!(status: "staged")
       expect_any_instance_of(AnthropicClient).not_to receive(:messages_create)
@@ -68,6 +81,38 @@ RSpec.describe ExtractMenuJob, type: :job do
       expect(run.api_cost_cents).to be > 0
       expect(run.uncached_input_tokens).to eq(100_000)
       expect(run.model).to eq(AnthropicClient::DEFAULT_MODEL)
+    end
+  end
+
+  # Phase 4.11.2 — image_bbox handling moved here (materialize is now at
+  # extraction). promote! later reads it to crop + attach the inline dish photo.
+  describe "image_bbox from extraction" do
+    let(:extraction_with_bbox) do
+      {
+        "sections" => [
+          { "name" => "Appetizers", "items" => [
+              { "name" => "Spring Rolls", "description" => "Crispy veggie.",
+                "prices" => [{ "size" => nil, "price_cents" => 600 }],
+                "image_bbox" => { "x" => 0.1, "y" => 0.2, "w" => 0.3, "h" => 0.25 } },
+              { "name" => "Tom Yum", "description" => "Hot + sour soup.",
+                "prices" => [{ "size" => nil, "price_cents" => 800 }] }
+            ] }
+        ]
+      }
+    end
+
+    before do
+      attach_fake_input!
+      allow_any_instance_of(AnthropicClient)
+        .to receive(:messages_create).and_return(extraction_with_bbox)
+    end
+
+    it "copies image_bbox onto the item when present, leaves nil otherwise" do
+      described_class.perform_now(run.id)
+
+      expect(run.ingestion_items.find_by(name: "Spring Rolls").image_bbox)
+        .to eq("x" => 0.1, "y" => 0.2, "w" => 0.3, "h" => 0.25)
+      expect(run.ingestion_items.find_by(name: "Tom Yum").image_bbox).to be_nil
     end
   end
 

--- a/apps/api/spec/jobs/resolve_ingredients_job_spec.rb
+++ b/apps/api/spec/jobs/resolve_ingredients_job_spec.rb
@@ -56,9 +56,20 @@ RSpec.describe ResolveIngredientsJob, type: :job do
     create(:ingredient, slug: "grain-rice")
   end
 
-  # Move the run to :resolving so transition_to! doesn't fail
-  # (transition queued → resolving is invalid).
-  before { run.transition_to!(:resolving) }
+  # ExtractMenuJob now materializes items up front (position = flat index),
+  # and the run is at :resolving when the resolve stages run. Mirror that here.
+  before do
+    pos = 0
+    Array(run.staging["sections"]).each do |section|
+      Array(section["items"]).each do |it|
+        run.ingestion_items.create!(
+          name: it["name"], section_name: section["name"], position: pos, decision: "pending"
+        )
+        pos += 1
+      end
+    end
+    run.transition_to!(:resolving)
+  end
 
   describe "happy path" do
     before do
@@ -66,22 +77,19 @@ RSpec.describe ResolveIngredientsJob, type: :job do
         .to receive(:messages_create).and_return(resolution_response)
     end
 
-    it "writes resolved + unresolved arrays back into staging" do
+    it "writes resolved + unresolved arrays onto the items in place, by position" do
       described_class.perform_now(run.id)
 
-      run.reload
-      tacos = run.staging["sections"][0]["items"]
-      expect(tacos[0]["ingredients"]).to contain_exactly(
+      items = run.ingestion_items.order(:position)
+      expect(items[0].ingredients_payload).to contain_exactly(
         { "slug" => "meat-beef", "confidence" => 0.97 },
         { "slug" => "vegetable-onion", "confidence" => 0.92 }
       )
-      expect(tacos[1]["ingredients"]).to eq(
+      expect(items[1].ingredients_payload).to eq(
         [{ "slug" => "poultry-domestic-chicken", "confidence" => 0.95 }]
       )
-      expect(tacos[1]["unresolved_ingredients"]).to eq(["salsa verde"])
-
-      drinks = run.staging["sections"][1]["items"]
-      expect(drinks[0]["ingredients"]).to include(
+      expect(items[1].unresolved_ingredients).to eq(["salsa verde"])
+      expect(items[2].ingredients_payload).to include(
         { "slug" => "grain-rice", "confidence" => 0.99 }
       )
     end

--- a/apps/api/spec/jobs/resolve_tags_job_spec.rb
+++ b/apps/api/spec/jobs/resolve_tags_job_spec.rb
@@ -22,13 +22,31 @@ RSpec.describe ResolveTagsJob, type: :job do
     }
   end
 
+  # ExtractMenuJob materializes items up front; by the time ResolveTagsJob runs,
+  # ResolveIngredientsJob has already enriched them with ingredients. Recreate
+  # that state: items exist (position + ingredients_payload), tags still empty.
   let(:run) do
     r = create(:ingestion_run,
-               restaurant: restaurant,
-               status:     "resolving",
+               restaurant: restaurant, status: "resolving",
                staging:    staging_with_ingredients,
                state_history: { "extracting" => 5.minutes.ago.utc.iso8601,
                                 "resolving"  => Time.current.utc.iso8601 })
+    pos = 0
+    Array(staging_with_ingredients["sections"]).each do |section|
+      Array(section["items"]).each do |it|
+        r.ingestion_items.create!(
+          name:                   it["name"],
+          section_name:           section["name"],
+          position:               pos,
+          prices_payload:         Array(it["prices"]),
+          ingredients_payload:    Array(it["ingredients"]),
+          unresolved_ingredients: Array(it["unresolved_ingredients"]),
+          image_bbox:             it["image_bbox"],
+          decision:               "pending"
+        )
+        pos += 1
+      end
+    end
     r
   end
 
@@ -63,16 +81,17 @@ RSpec.describe ResolveTagsJob, type: :job do
         .to receive(:messages_create).and_return(tag_response)
     end
 
-    it "writes resolved tags into staging and creates IngestionItems" do
+    it "enriches the existing items with tags in place (by position) — no new items" do
       expect {
         described_class.perform_now(run.id)
-      }.to change(IngestionItem, :count).by(2)
+      }.not_to change(IngestionItem, :count)
 
-      run.reload
-      tacos = run.staging["sections"][0]["items"]
-      expect(tacos[0]["tags"]).to include({ "slug" => "cuisine-mexican", "confidence" => 0.99 })
-      expect(tacos[1]["tags"]).to include({ "slug" => "allergen-contains-dairy", "confidence" => 0.97 })
-      expect(tacos[1]["unresolved_tags"]).to eq(["queso-style"])
+      items = run.ingestion_items.order(:position)
+      expect(items[0].tags_payload).to include({ "slug" => "cuisine-mexican", "confidence" => 0.99 })
+      expect(items[1].tags_payload).to include({ "slug" => "allergen-contains-dairy", "confidence" => 0.97 })
+      expect(items[1].unresolved_tags).to eq(["queso-style"])
+      # Ingredients from the prior stage are preserved.
+      expect(items[0].ingredients_payload).to eq([{ "slug" => "meat-beef", "confidence" => 0.97 }])
     end
 
     it "transitions the run to :staged" do
@@ -82,28 +101,40 @@ RSpec.describe ResolveTagsJob, type: :job do
       expect(run.staged?).to be true
       expect(run.state_history.keys).to include("staged")
     end
+  end
 
-    it "materializes the IngestionItems with the right payloads" do
+  describe "deferred accepts (accepted while enrichment was running)" do
+    before do
+      allow_any_instance_of(AnthropicClient)
+        .to receive(:messages_create).and_return(tag_response)
+      # promote! needs the ingredient rows to build the joins.
+      create(:ingredient, slug: "meat-beef")
+    end
+
+    it "promotes items accepted during resolving once they're enriched, at :staged" do
+      # Accepted while :resolving — recorded but NOT promoted (empty payloads then).
+      accepted = run.ingestion_items.order(:position).first
+      accepted.update!(decision: "accepted", decided_at: Time.current)
+      expect(accepted.item_id).to be_nil
+
+      expect {
+        described_class.perform_now(run.id)
+      }.to change(Item, :count).by(1)
+
+      accepted.reload
+      expect(accepted.item_id).to be_present
+      # Safety property: the promoted Item carries the ingredient it was enriched
+      # with — nothing goes live without its allergen data.
+      expect(accepted.item.ingredients.pluck(:slug)).to include("meat-beef")
+    end
+
+    it "auto-publishes when the pre-accepted items cross the 80% threshold at :staged" do
+      run.ingestion_items.find_each { |i| i.update!(decision: "accepted", decided_at: Time.current) }
+
       described_class.perform_now(run.id)
 
-      first_item = IngestionItem.find_by(name: "Carne Asada Taco")
-      expect(first_item).to have_attributes(
-        ingestion_run:        run,
-        section_name:         "Tacos",
-        decision:             "pending"
-      )
-      expect(first_item.ingredients_payload).to eq(
-        [{ "slug" => "meat-beef", "confidence" => 0.97 }]
-      )
-      expect(first_item.tags_payload).to include(
-        { "slug" => "cuisine-mexican", "confidence" => 0.99 }
-      )
-      expect(first_item.prices_payload).to eq(
-        [{ "size" => nil, "price_cents" => 450 }]
-      )
-
-      cheese = IngestionItem.find_by(name: "Cheese Quesadilla")
-      expect(cheese.unresolved_tags).to eq(["queso-style"])
+      run.reload
+      expect(run.published?).to be true
     end
   end
 
@@ -113,71 +144,13 @@ RSpec.describe ResolveTagsJob, type: :job do
         .and_raise(AnthropicClient::ApiError.new(status: 500, body: "boom"))
     end
 
-    it "fails the run + does not create IngestionItems" do
-      expect {
-        described_class.perform_now(run.id)
-      }.not_to change(IngestionItem, :count)
+    it "fails the run and leaves the items un-enriched (tags still empty)" do
+      described_class.perform_now(run.id)
 
       run.reload
       expect(run.failed?).to be true
       expect(run.failure_message).to start_with("resolve_tags_api_error: 500")
-    end
-  end
-
-  # Phase 4.11.2 — when the extractor's payload included image_bbox
-  # (per-item bounding box for the inline dish photo), materialize
-  # must copy it onto the IngestionItem so Phase 4.11.3's promote!
-  # can crop + attach. Items without a bbox carry nil so the
-  # promote-time cropper skip kicks in cleanly.
-  describe "image_bbox from extraction" do
-    let(:staging_with_bbox) do
-      {
-        "sections" => [
-          { "name" => "Appetizers", "items" => [
-              { "name" => "Spring Rolls",
-                "description" => "Crispy veggie.",
-                "prices" => [{ "size" => nil, "price_cents" => 600 }],
-                "ingredients" => [],
-                "unresolved_ingredients" => [],
-                "image_bbox" => { "x" => 0.1, "y" => 0.2, "w" => 0.3, "h" => 0.25 } },
-              { "name" => "Tom Yum",
-                "description" => "Hot + sour soup.",
-                "prices" => [{ "size" => nil, "price_cents" => 800 }],
-                "ingredients" => [],
-                "unresolved_ingredients" => [] }
-            ] }
-        ]
-      }
-    end
-
-    let(:run_with_bbox) do
-      create(:ingestion_run,
-             restaurant: restaurant, status: "resolving",
-             staging:    staging_with_bbox,
-             state_history: { "extracting" => 5.minutes.ago.utc.iso8601,
-                              "resolving"  => Time.current.utc.iso8601 })
-    end
-
-    let(:empty_tag_response) do
-      { "items" => [
-        { "index" => 0, "resolved" => [], "unresolved" => [] },
-        { "index" => 1, "resolved" => [], "unresolved" => [] }
-      ] }
-    end
-
-    before do
-      allow_any_instance_of(AnthropicClient)
-        .to receive(:messages_create).and_return(empty_tag_response)
-    end
-
-    it "copies image_bbox onto the IngestionItem when present, leaves nil otherwise" do
-      described_class.perform_now(run_with_bbox.id)
-
-      with_photo    = IngestionItem.find_by(name: "Spring Rolls")
-      without_photo = IngestionItem.find_by(name: "Tom Yum")
-
-      expect(with_photo.image_bbox).to eq("x" => 0.1, "y" => 0.2, "w" => 0.3, "h" => 0.25)
-      expect(without_photo.image_bbox).to be_nil
+      expect(run.ingestion_items.first.tags_payload).to eq([])
     end
   end
 end

--- a/apps/api/spec/jobs/resolve_tags_job_spec.rb
+++ b/apps/api/spec/jobs/resolve_tags_job_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe ResolveTagsJob, type: :job do
   # ExtractMenuJob materializes items up front; by the time ResolveTagsJob runs,
   # ResolveIngredientsJob has already enriched them with ingredients. Recreate
   # that state: items exist (position + ingredients_payload), tags still empty.
-  let(:run) do
+  # let! (eager) so the items exist BEFORE a `change(IngestionItem, :count)`
+  # block measures the job — the job must not create new items.
+  let!(:run) do
     r = create(:ingestion_run,
                restaurant: restaurant, status: "resolving",
                staging:    staging_with_ingredients,

--- a/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
@@ -139,6 +139,33 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
       end
     end
 
+    context "decision: accepted while the run is still enriching (:resolving)" do
+      # Verify-flow redesign: a resolving run's dishes are visible + acceptable,
+      # but promote! must wait until enrichment fills the ingredient/tag payloads
+      # — an Item can't go live without them. The acceptance is recorded now and
+      # ResolveTagsJob batch-promotes it at :staged.
+      let(:resolving_run) do
+        create(:ingestion_run, restaurant: restaurant, user: non_admin, status: "resolving")
+      end
+      let!(:resolving_item) do
+        create(:ingestion_item, ingestion_run: resolving_run, name: "Enchilada", position: 0)
+      end
+
+      it "records the acceptance but defers promotion (no Item created yet)" do
+        expect {
+          patch "/api/v1/ingestion_runs/#{resolving_run.id}/items/#{resolving_item.id}",
+                params: { decision: "accepted" }.to_json,
+                headers: auth_for(non_admin)
+        }.not_to change(Item, :count)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["decision"]).to eq("accepted")
+        expect(body["item_id"]).to  be_nil
+        expect(resolving_item.reload.decided_at).to be_present
+      end
+    end
+
     context "decision: edited (without accepting)" do
       it "saves the edited fields but does NOT materialize an Item" do
         expect {

--- a/docs/plans/verify-flow-redesign.md
+++ b/docs/plans/verify-flow-redesign.md
@@ -1,0 +1,113 @@
+# Verify-flow redesign (Phase 2 "one flow")
+
+## Context
+
+The scan → verify flow works, but the UX is weak (surfaced testing RGP's Wraps —
+37 items in a flat list, ~40s of "Matching ingredients…" before anything shows).
+The owner asked for, as one cohesive redesign:
+
+1. **Instant dishes** — a "basic LLM given a website/photo can extract dishes
+   very quickly," so show them fast; do ingredient/tag matching in the background.
+2. **Wait for enrichment after approvals** — you can approve dishes immediately,
+   but publishing waits until matching finishes (the dietary filter needs
+   ingredients/tags — an `Item` must never go live without them).
+3. **Group by sub-menu** — lay verify items out by their section.
+4. **Accept All** — bulk-accept every pending item.
+5. **Undo** — reverse an accept.
+
+## The load-bearing mechanic: *when a dish becomes a real `Item`*
+
+`IngestionItem#promote!` builds the real `Item` + `ItemIngredient`/`ItemTag` joins
+from `ingredients_payload`/`tags_payload`. **Promote must not run before those
+payloads are filled** — otherwise a dish goes live with no ingredients/tags and
+the filter can't protect a celiac/allergic user. That is the safety invariant the
+whole redesign turns on.
+
+Today: extract → resolve ingredients → resolve tags → **materialize items** →
+staged → verify shows them → accept calls `promote!` (payloads already present).
+
+New: extract → **materialize items now (empty payloads)** → resolve fills payloads
+in the background → verify shows dishes immediately → accept is allowed but
+`promote!` is **deferred** until the item is enriched.
+
+## State model (no new DB states)
+
+`extracting` → `resolving` → `staged` → `published`, but with new meaning:
+
+- **resolving** = dishes exist + are visible; ingredients/tags are being matched.
+  "Enriched" is a per-**run** property (resolve does all items in 2 batch calls),
+  so during `resolving` every item shows "matching…"; at `staged` all are enriched.
+- **staged** = fully enriched; any accepted-during-resolving items get promoted.
+
+## Backend
+
+### Migration
+- `add_column :ingestion_items, :position, :integer` (nullable; new runs set it,
+  old rows stay null). Resolve maps its indexed results back to items by position.
+
+### ExtractMenuJob
+- After writing `staging`, **materialize `IngestionItem` rows** (name, description,
+  prices_payload, section_name, image_bbox, `position` = flat index; empty
+  ingredient/tag payloads; decision `pending`), then transition to `resolving`.
+
+### ResolveIngredientsJob / ResolveTagsJob (in `ResolveStageJob`)
+- Prompt still built from `staging` (flat order). After the call, **update each
+  `IngestionItem` by `position`** with its resolution:
+  - ingredients job → `ingredients_payload`, `unresolved_ingredients`
+  - tags job → `tags_payload`, `unresolved_tags`
+- ResolveTagsJob (last), inside a transaction: **batch-promote** items already
+  `decision: accepted` with `item_id` nil (accepted during resolving), then
+  `maybe_publish!`, then transition to `staged`. Batch-promote uses `run.user` as
+  `decided_by` (community self-verify's normal case → `suggested`; admin-owned run
+  → `confirmed`). Edge case — a *different* admin accepting a community run during
+  resolving lands `suggested` (safe; admins re-confirm via Phase 6.4). *(Drop the
+  old `materialize_ingestion_items!` — items already exist.)*
+
+### Accept / defer-promote (IngestionItemsController#update)
+- decision `accepted`: if run enriched (`staged?`/`published?`) → `promote!` now;
+  else record `decision: accepted` + `decided_at`, **no promote** (item_id stays
+  nil). `maybe_publish!` already requires `staged?`, so no publish during resolving.
+
+### Accept All — `POST /ingestion_runs/:id/items/accept_all`
+- Accept every `pending` item in one transaction (same defer-or-promote rule),
+  then `maybe_publish!`. Returns the updated items.
+
+### Undo — `POST /ingestion_runs/:id/items/:id/undo` (or `decision: pending`)
+- Revert an accepted item to `pending`: if promoted (`item_id` present), destroy
+  the `Item` (cascades to `item_ingredients`/`item_tags`) and null `item_id`;
+  clear `decided_at`. Pre-publish scope; if the run had published, the item is
+  removed from the live menu (run stays published). Re-`maybe_publish!` is a no-op
+  downward (we don't un-publish the run).
+
+### Run payload
+- Expose `staged_item_count` (dishes found) so the verify header can say "N dishes"
+  during resolving. `enriched` = `status in [staged, published]`.
+
+## Frontend — verify page (`/ingest/verify/[runId]`)
+
+- Fetch items as soon as they exist (status `resolving` OR `staged`), not only
+  `staged`.
+- **Group by `section_name`** with sub-menu headers; ungrouped/nil section last.
+- Per item: name + price always; ingredient/tag chips show **"matching…"** while
+  `status == resolving`, then the resolved chips at `staged`.
+- **Accept All** button (calls accept_all); **Undo** on accepted rows.
+- Publish messaging: "Accept ≥80% to publish — publishing finalizes once matching
+  finishes." Publish only fires at `staged`.
+- Fold in the earlier progress idea lightly (dish count + stage label).
+
+## PR breakdown (incremental, each shippable + tested)
+
+1. **PR-1 backend pipeline** — position migration; materialize-at-extraction;
+   resolve-updates-items-in-place; defer-promote + batch-promote-on-staged. The
+   safety-critical core. Heavy specs on promote-timing + filter correctness.
+2. **PR-2 backend endpoints** — Accept All + Undo.
+3. **PR-3 web** — verify page redesign (grouping, instant dishes, matching status,
+   Accept All, Undo, publish messaging).
+
+Mobile verify screen mirrors PR-3 as a follow-up.
+
+## Safety checklist (must hold at every step)
+- No `Item` is ever created (`promote!`) before its `ingredients_payload`/
+  `tags_payload` are populated.
+- Publish (`maybe_publish!`) only fires when the run is `staged` (fully enriched).
+- Undo fully removes the promoted `Item` + joins (no orphan live items).

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,24 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Verify-flow redesign PR-1: instant dishes + background enrichment
+(backend pipeline). Branch `feat/verify-flow-redesign`. See
+`docs/plans/verify-flow-redesign.md`.
+
+- The safety invariant: `promote!` (creates the real filterable Item + ingredient/
+  tag joins) must never run before a dish is enriched. The pipeline now:
+  extract → **materialize dishes now** (empty payloads, `position`) → resolve
+  ENRICHES the items in place (ingredients then tags) → at `:staged`, batch-promote
+  any items accepted during resolving, then the publish check.
+- ExtractMenuJob materializes items (moved off ResolveTagsJob); ResolveStageJob
+  writes resolution onto items by position (dropped the staging-mutation);
+  ResolveTagsJob enriches tags + promotes deferred accepts + stages + publishes.
+  Controller: accept while `:resolving` records the decision but DEFERS promote
+  (no Item without payloads). Migration: `position` on ingestion_items.
+- Specs rewritten (extract/resolve×2/controller) — couldn't run rspec locally
+  (no gem bundle), so ci-api is the first real run; expect to iterate. PR-2
+  (Accept All + Undo) and PR-3 (verify page: grouping, matching status) next.
+
 2026-07-21 — Failed runs no longer burn the per-user scan quota. Branch `fix/quota-excludes-failed`.
 
 - Verifying the earlier fixes was blocked: all 5 of the reporter's daily quota


### PR DESCRIPTION
## Summary

PR-1 of the verify-flow redesign (`docs/plans/verify-flow-redesign.md`). Restructures the ingestion pipeline so the verify page can show dishes right after extraction while ingredient/tag matching runs in the background — **without ever creating a real `Item` before it's enriched** (the dietary filter depends on that).

- **ExtractMenuJob** materializes dishes immediately (empty payloads, `position`), then → `:resolving`.
- **Resolve stages** enrich the existing items in place by position (was: mutate staging + materialize at the end). ResolveTagsJob then batch-promotes items accepted-while-resolving, transitions to `:staged`, and runs the publish check.
- **Controller**: accepting during `:resolving` records the decision but **defers `promote!`** to `:staged`.
- Migration: `position` on `ingestion_items`.

Specs rewritten for the new flow. Next: PR-2 (Accept All + Undo), PR-3 (verify page redesign).
