### PR TITLE
feat(api): Accept All + Undo for the verify flow (PR-2)

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
@@ -17,7 +17,7 @@ module Api
 
       def index
         run = authorized_run
-        items = run.ingestion_items.order(:created_at)
+        items = run.ingestion_items.order(:position, :created_at)
         render json: { items: items.map { |it| serialize_item(it) } }
       end
 
@@ -40,28 +40,17 @@ module Api
         end
 
         case decision
-        when "accepted", "edited"
-          # Edited+then-accepted: a separate request will resubmit
-          # decision: accepted. Editing alone records the change but
-          # doesn't promote — keeps the human in control of the final
-          # promotion step.
-          if decision == "accepted"
-            item.save! if item.changed?
-            if run.staged? || run.published?
-              item.promote!(decided_by: current_user)
-            else
-              # Verify-flow redesign: dishes are visible + acceptable while
-              # enrichment (resolve) is still running, but promote! must wait
-              # until the item has its ingredient/tag payloads — an Item can't
-              # go live without them. Record the acceptance now; ResolveTagsJob
-              # batch-promotes it when the run reaches :staged.
-              item.update!(decision: "accepted", decided_at: Time.current)
-            end
-          else
-            item.update!(decision: "edited", decided_at: Time.current)
-          end
+        when "accepted"
+          item.save! if item.changed?
+          apply_acceptance!(run, item)
+        when "edited"
+          # Editing alone records the change but doesn't promote — keeps the
+          # human in control of the final acceptance step.
+          item.update!(decision: "edited", decided_at: Time.current)
         when "rejected"
           item.update!(decision: "rejected", decided_at: Time.current)
+        when "pending"
+          undo_decision!(item)
         end
 
         run.maybe_publish!
@@ -69,7 +58,47 @@ module Api
         render json: serialize_item(item.reload)
       end
 
+      # POST /api/v1/ingestion_runs/:run_id/items/accept_all
+      #
+      # Bulk-accept every still-pending item, applying the same rule as a
+      # single accept: promote now if the run is enriched (:staged/:published),
+      # else record the acceptance for ResolveTagsJob to promote at :staged.
+      def accept_all
+        run = authorized_run
+
+        ActiveRecord::Base.transaction do
+          run.ingestion_items.where(decision: "pending").find_each do |item|
+            apply_acceptance!(run, item)
+          end
+        end
+
+        run.maybe_publish!
+
+        items = run.ingestion_items.order(:position, :created_at)
+        render json: { items: items.map { |it| serialize_item(it) } }
+      end
+
       private
+
+      # Accept an item: promote it to a real Item now if the run is enriched,
+      # otherwise record the acceptance and defer promote! to the :staged
+      # batch-promote — an Item must never go live without its payloads.
+      def apply_acceptance!(run, item)
+        if run.staged? || run.published?
+          item.promote!(decided_by: current_user)
+        else
+          item.update!(decision: "accepted", decided_at: Time.current)
+        end
+      end
+
+      # Undo — revert a decision to pending. If the item was promoted (its Item
+      # is live on the restaurant), remove that Item + its ingredient/tag joins.
+      # The FK ingestion_items.item_id → items is RESTRICT, so release it first.
+      def undo_decision!(item)
+        promoted = item.item
+        item.update!(decision: "pending", item_id: nil, decided_at: nil)
+        promoted&.destroy
+      end
 
       # The run's creator or an admin. Memoized so index/update don't
       # re-fetch what the before_action already loaded.
@@ -99,6 +128,7 @@ module Api
           id:                     item.id,
           ingestion_run_id:       item.ingestion_run_id,
           item_id:                item.item_id,
+          position:               item.position,
           name:                   item.name,
           description:            item.description,
           section_name:           item.section_name,

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -103,7 +103,9 @@ Rails.application.routes.draw do
       # validation).
       get "/users/:handle", to: "users#show", as: :user, constraints: { handle: /[A-Za-z0-9_]{3,30}/ }
       resources :ingestion_runs, only: [:create, :show] do
-        resources :items, only: [:index, :update], controller: "ingestion_items"
+        resources :items, only: [:index, :update], controller: "ingestion_items" do
+          collection { post :accept_all }
+        end
       end
     end
   end

--- a/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
@@ -234,4 +234,62 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
       expect(run.reload.published?).to be true
     end
   end
+
+  describe "POST /api/v1/ingestion_runs/:run_id/items/accept_all" do
+    it "promotes every pending item at once for an enriched (:staged) run" do
+      create(:ingestion_item, ingestion_run: run, name: "Bean Taco", position: 1)
+
+      expect {
+        post "/api/v1/ingestion_runs/#{run.id}/items/accept_all", headers: auth_for(admin)
+      }.to change(Item, :count).by(2)
+
+      expect(response).to have_http_status(:ok)
+      run.reload
+      expect(run.ingestion_items.pluck(:decision)).to all(eq("accepted"))
+      expect(run.ingestion_items.pluck(:item_id)).to all(be_present)
+    end
+
+    it "defers promotion for a still-resolving run (records accepts, creates no Items)" do
+      resolving = create(:ingestion_run, restaurant: restaurant, user: non_admin, status: "resolving")
+      create(:ingestion_item, ingestion_run: resolving, name: "A", position: 0)
+      create(:ingestion_item, ingestion_run: resolving, name: "B", position: 1)
+
+      expect {
+        post "/api/v1/ingestion_runs/#{resolving.id}/items/accept_all", headers: auth_for(non_admin)
+      }.not_to change(Item, :count)
+
+      expect(resolving.ingestion_items.pluck(:decision)).to all(eq("accepted"))
+      expect(resolving.ingestion_items.pluck(:item_id)).to all(be_nil)
+    end
+
+    it "403s a stranger" do
+      other    = create(:ingestion_run, :staged, restaurant: restaurant, user: non_admin)
+      stranger = create(:user, password: "password123")
+
+      post "/api/v1/ingestion_runs/#{other.id}/items/accept_all", headers: auth_for(stranger)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "undo (PATCH decision: pending)" do
+    it "reverts an accepted+promoted item to pending and removes its live Item + joins" do
+      patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+            params: { decision: "accepted" }.to_json, headers: auth_for(admin)
+      promoted_id = response.parsed_body["item_id"]
+      expect(Item.exists?(promoted_id)).to be true
+
+      expect {
+        patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+              params: { decision: "pending" }.to_json, headers: auth_for(admin)
+      }.to change(Item, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["decision"]).to eq("pending")
+      expect(body["item_id"]).to be_nil
+      expect(Item.exists?(promoted_id)).to be false
+      expect(ItemIngredient.where(item_id: promoted_id)).to be_empty
+    end
+  end
 end

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,17 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Verify-flow redesign PR-2: Accept All + Undo. Branch `feat/verify-accept-all-undo`.
+
+- `POST /ingestion_runs/:id/items/accept_all` — bulk-accepts every pending item,
+  same defer-or-promote rule as a single accept (promote now if enriched, else
+  record for the :staged batch-promote). Undo = `PATCH decision: pending` — reverts
+  a decision to pending and, if the item was promoted, destroys its live Item +
+  ingredient/tag joins (FK is RESTRICT, so item_id is released first). Shared
+  `apply_acceptance!`; items now serialized with `position` + ordered by it.
+- Next: PR-3 (verify page redesign — grouping, matching status, Accept All / Undo
+  buttons). PR-1 (pipeline) deployed; re-verifying end-to-end via Chrome.
+
 2026-07-21 — Verify-flow redesign PR-1: instant dishes + background enrichment
 (backend pipeline). Branch `feat/verify-flow-redesign`. See
 `docs/plans/verify-flow-redesign.md`.


### PR DESCRIPTION
## Summary

- **Accept All** — `POST /ingestion_runs/:id/items/accept_all` bulk-accepts every pending item (same defer-or-promote rule as a single accept).
- **Undo** — `PATCH decision: pending` reverts a decision; if promoted, destroys the live `Item` + its ingredient/tag joins (RESTRICT FK released first).
- Shared `apply_acceptance!`; items serialized with `position` + ordered by it. PR-2 of the verify-flow redesign.
