### PR TITLE
feat(web): homepage restaurant discovery + Restaurants links everywhere

### DIFF
--- a/apps/web/src/app/_RestaurantCards.tsx
+++ b/apps/web/src/app/_RestaurantCards.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import type { Route } from 'next';
+import type { ReactElement } from 'react';
+import type { RestaurantSummary } from '../lib/restaurants';
+
+/**
+ * Presentational grid of restaurant cards linking to each restaurant's
+ * filtered menu page. Shared by the homepage "browse" section and the
+ * /restaurants index — both fetch server-side and pass the summaries in.
+ */
+export function RestaurantCards({
+  restaurants,
+}: {
+  restaurants: RestaurantSummary[];
+}): ReactElement {
+  return (
+    <ul className="grid gap-bw-4 sm:grid-cols-2 lg:grid-cols-3">
+      {restaurants.map((r) => (
+        <li key={r.id}>
+          <Link
+            href={`/restaurants/${r.slug}` as Route}
+            data-testid={`restaurant-card-${r.slug}`}
+            className="flex h-full flex-col rounded-bw-lg border border-zinc-200 bg-white p-bw-5 shadow-sm transition hover:border-bite hover:shadow-md"
+          >
+            <p className="text-bw-lg font-bold text-zinc-900">{r.name}</p>
+            <p className="mt-bw-1 text-bw-sm text-zinc-500">
+              {r.city.name}
+              {r.city.region ? `, ${r.city.region}` : ''}
+            </p>
+            <p className="mt-bw-4 text-bw-sm font-bold text-bite">See what you can eat →</p>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/app/_SiteHeader.tsx
+++ b/apps/web/src/app/_SiteHeader.tsx
@@ -162,6 +162,14 @@ export function SiteHeader() {
 
         {/* Reserve height while auth state resolves so the bar doesn't jump. */}
         <nav className="flex min-h-[1.5rem] items-center gap-bw-4 text-bw-sm">
+          {/* Discovery — visible to everyone, signed in or not. */}
+          <Link
+            href="/restaurants"
+            data-testid="nav-restaurants"
+            className="font-semibold text-zinc-700 hover:text-bite-dark"
+          >
+            Restaurants
+          </Link>
           {signedIn === true && (
             <>
               {/* Scanning is the core action and needs a home — a signed-in

--- a/apps/web/src/app/__tests__/SiteHeader.test.tsx
+++ b/apps/web/src/app/__tests__/SiteHeader.test.tsx
@@ -57,6 +57,8 @@ describe('SiteHeader', () => {
     render(<SiteHeader />);
     expect(await screen.findByTestId('nav-signin')).toBeInTheDocument();
     expect(screen.getByTestId('nav-signup')).toBeInTheDocument();
+    // Discovery link is always present, signed in or out.
+    expect(screen.getByTestId('nav-restaurants')).toHaveAttribute('href', '/restaurants');
     expect(screen.queryByTestId('nav-account')).not.toBeInTheDocument();
     expect(screen.queryByTestId('nav-logout')).not.toBeInTheDocument();
     expect(screen.queryByTestId('nav-scan')).not.toBeInTheDocument();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
 import { buildLandingMetadata } from '../lib/landing-meta';
+import { fetchRestaurants, type RestaurantSummary } from '../lib/restaurants';
+import { RestaurantCards } from './_RestaurantCards';
 import WaitlistForm from './_waitlist-form';
+
+// ISR: keep the landing static + fast, but let the live restaurant list
+// refresh every 5 minutes as menus get published.
+export const revalidate = 300;
 
 /**
  * Phase 5.5 — marketing landing.
@@ -33,10 +39,50 @@ export default function HomePage(): ReactElement {
   return (
     <main className="bg-white">
       <Hero />
+      <BrowseRestaurants />
       <FeatureRow />
       <DurangoNote />
       <Footer />
     </main>
+  );
+}
+
+async function BrowseRestaurants(): Promise<ReactElement> {
+  let restaurants: RestaurantSummary[] = [];
+  try {
+    restaurants = await fetchRestaurants({ revalidate: 300 });
+  } catch {
+    // API hiccup — show the empty state, never break the landing page.
+  }
+
+  return (
+    <section className="mx-auto max-w-5xl px-bw-6 py-bw-16">
+      <div className="flex flex-wrap items-end justify-between gap-bw-3">
+        <h2 className="text-bw-2xl font-bold text-zinc-900">Menus you can filter right now</h2>
+        {restaurants.length > 0 && (
+          <a
+            href="/restaurants"
+            data-testid="home-browse-all"
+            className="text-bw-sm font-bold text-bite hover:text-bite-dark"
+          >
+            Browse all restaurants →
+          </a>
+        )}
+      </div>
+
+      {restaurants.length === 0 ? (
+        <div className="mt-bw-4 rounded-bw-lg border border-zinc-200 bg-zinc-50 p-bw-6 text-bw-base text-zinc-600">
+          We&rsquo;re adding Durango menus now. Know a spot that isn&rsquo;t here?{' '}
+          <a href="/ingest" className="font-bold text-bite hover:text-bite-dark">
+            Scan its menu →
+          </a>
+        </div>
+      ) : (
+        <div className="mt-bw-6">
+          <RestaurantCards restaurants={restaurants.slice(0, 6)} />
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -151,6 +197,9 @@ function Footer(): ReactElement {
           &copy; {new Date().getFullYear()} BiteWorthy &middot; Made in Durango, CO.
         </p>
         <nav className="flex flex-wrap gap-bw-4">
+          <a href="/restaurants" className="hover:text-zinc-700" data-testid="footer-restaurants">
+            Restaurants
+          </a>
           <a href="/story" className="hover:text-zinc-700" data-testid="footer-story">
             Our story
           </a>

--- a/apps/web/src/app/restaurants/page.tsx
+++ b/apps/web/src/app/restaurants/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import Link from 'next/link';
+import { fetchRestaurants, type RestaurantSummary } from '../../lib/restaurants';
+import { RestaurantCards } from '../_RestaurantCards';
+
+// ISR: the browse list refreshes every 5 minutes as menus are published.
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: 'Restaurants — BiteWorthy',
+  description:
+    'Browse restaurants and see only the dishes you can eat — for allergies, intolerances, and every dietary need, with why.',
+};
+
+export default async function RestaurantsPage(): Promise<ReactElement> {
+  let restaurants: RestaurantSummary[] = [];
+  try {
+    restaurants = await fetchRestaurants({ revalidate: 300 });
+  } catch {
+    // API hiccup — render the empty state rather than 500 the page.
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl px-bw-6 py-bw-12">
+      <p className="text-bite text-bw-sm font-bold uppercase tracking-[0.2em]">Browse</p>
+      <h1 className="mt-bw-2 text-bw-3xl font-bold text-zinc-900">Restaurants</h1>
+      <p className="mt-bw-3 max-w-2xl text-bw-base text-zinc-600">
+        Pick a place — BiteWorthy shows only the dishes that fit your dietary filter, with{' '}
+        <span className="font-bold">why</span>, every time.
+      </p>
+
+      {restaurants.length === 0 ? (
+        <div
+          className="mt-bw-8 rounded-bw-lg border border-zinc-200 bg-zinc-50 p-bw-6 text-bw-base text-zinc-600"
+          data-testid="restaurants-empty"
+        >
+          No published menus yet.{' '}
+          <Link href="/ingest" className="font-bold text-bite hover:text-bite-dark">
+            Scan a menu →
+          </Link>{' '}
+          to add the first one.
+        </div>
+      ) : (
+        <div className="mt-bw-8" data-testid="restaurants-list">
+          <RestaurantCards restaurants={restaurants} />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/lib/__tests__/restaurants.test.ts
+++ b/apps/web/src/lib/__tests__/restaurants.test.ts
@@ -3,9 +3,11 @@ import {
   clearNeverHide,
   fetchRestaurant,
   fetchRestaurantItems,
+  fetchRestaurants,
   setNeverHide,
   type Restaurant,
   type RestaurantItemsResponse,
+  type RestaurantSummary,
 } from '../restaurants';
 
 const restaurantPayload: Restaurant = {
@@ -148,5 +150,37 @@ describe('setNeverHide / clearNeverHide (Phase 4.2)', () => {
   it('throws on non-2xx', async () => {
     const fetchImpl = fakeFetch(401, { error: 'unauth' });
     await expect(setNeverHide('item-1', { fetchImpl })).rejects.toThrow(/401/);
+  });
+});
+
+describe('fetchRestaurants', () => {
+  const summary: RestaurantSummary = {
+    id: 'r1',
+    slug: 'marias',
+    name: "Maria's Tacos",
+    status: 'published',
+    city: { slug: 'durango', name: 'Durango', region: 'CO' },
+    street: null,
+    latitude: null,
+    longitude: null,
+  };
+
+  it('GETs the published list and unwraps { restaurants }', async () => {
+    const fetchImpl = fakeFetch(200, { restaurants: [summary] });
+
+    const result = await fetchRestaurants({ fetchImpl });
+
+    expect(result).toEqual([summary]);
+    const [url] = fetchImpl.mock.calls[0] as unknown as [string];
+    expect(url).toContain('/api/v1/restaurants');
+  });
+
+  it('appends ?q= when a search term is given', async () => {
+    const fetchImpl = fakeFetch(200, { restaurants: [] });
+
+    await fetchRestaurants({ q: 'taco', fetchImpl });
+
+    const [url] = fetchImpl.mock.calls[0] as unknown as [string];
+    expect(url).toContain('/restaurants?q=taco');
   });
 });

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -45,6 +45,18 @@ export interface Restaurant {
   city: RestaurantCity;
 }
 
+/** The lighter shape `GET /api/v1/restaurants` returns for browse/discovery. */
+export interface RestaurantSummary {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+  city: { slug: string; name: string; region: string };
+  street: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
 /**
  * Items endpoint payload. The server enriches reasons with name +
  * family — same shape `applyProfile` from filter-engine produces, so
@@ -109,6 +121,24 @@ export async function fetchRestaurant(
   return api<Restaurant>(`/restaurants/${encodeURIComponent(slugOrId)}`, {
     fetchImpl: opts.fetchImpl,
   });
+}
+
+/**
+ * The published-restaurants list for the homepage + /restaurants browse
+ * surfaces. Optional `q` filters by name (server-side ILIKE). Server-side
+ * callers can pass a `revalidate` window for ISR caching.
+ */
+export async function fetchRestaurants(
+  opts: FetchOptions & { q?: string; revalidate?: number } = {},
+): Promise<RestaurantSummary[]> {
+  const qs = opts.q ? `?q=${encodeURIComponent(opts.q)}` : '';
+  const init =
+    opts.revalidate !== undefined ? { next: { revalidate: opts.revalidate } } : {};
+  const body = await api<{ restaurants: RestaurantSummary[] }>(`/restaurants${qs}`, {
+    fetchImpl: opts.fetchImpl,
+    ...init,
+  });
+  return body.restaurants;
 }
 
 /** Phase 4.5 — fetch a single item by id under a restaurant. */

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,19 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Homepage discovery: show restaurants + menu links everywhere.
+Branch `feat/homepage-discovery`.
+
+- Owner: "the homepage feels dead — show restaurants, add menu links to the top
+  pages." Now that RGP's Wraps is published (37 items) there's real content to
+  surface. Added: `fetchRestaurants()` (published list) → a homepage "Menus you
+  can filter right now" section (server-fetched, ISR 5m, graceful empty state),
+  a new `/restaurants` browse index, a persistent **Restaurants** nav link in the
+  header (every page, signed in or out) + a footer link. Cards link to each
+  `/restaurants/[slug]` filtered menu.
+- Web vitest 210 (+2), typecheck/lint green; `next build` regenerates the typed
+  route for /restaurants. Verify-flow redesign PR-3 (verify UI) still queued.
+
 2026-07-21 — Verify-flow redesign PR-2: Accept All + Undo. Branch `feat/verify-accept-all-undo`.
 
 - `POST /ingestion_runs/:id/items/accept_all` — bulk-accepts every pending item,


### PR DESCRIPTION
## Summary

- The homepage now shows a **"Menus you can filter right now"** section — server-fetched published restaurants (ISR 5m, graceful empty state) linking to each filtered menu.
- New **`/restaurants`** browse index page.
- A persistent **"Restaurants"** link in the header (every page, signed in or out) + a homepage footer link.

Brings the site to life now that RGP's Wraps is published (37 items).
