### PR TITLE
feat(web): homepage hero CTA becomes "Scan a menu" when logged in

### DIFF
--- a/apps/web/src/app/_HeroCta.tsx
+++ b/apps/web/src/app/_HeroCta.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+/**
+ * The landing hero's primary CTA, adapted to auth state: a signed-in user
+ * sees "Scan a menu" (the core action) instead of the onboarding CTA that a
+ * new visitor gets. Reads the same fast `/api/auth/session` the header uses.
+ *
+ * Defaults to the signed-out CTA until auth resolves — most landing visitors
+ * are logged out, so there's no swap for them; a signed-in user briefly sees
+ * "Try the web app" before it flips to "Scan a menu."
+ */
+const CTA_CLASS =
+  'rounded-bw-md bg-bite px-bw-6 py-bw-3 text-bw-base font-bold text-white shadow-sm hover:bg-bite-dark';
+
+export function HeroCta() {
+  const [signedIn, setSignedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetch('/api/auth/session', { credentials: 'same-origin' })
+      .then((r) => (r.ok ? r.json() : { signedIn: false }))
+      .then((d: { signedIn?: boolean }) => {
+        if (active) setSignedIn(Boolean(d.signedIn));
+      })
+      .catch(() => {
+        if (active) setSignedIn(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (signedIn) {
+    return (
+      <Link href="/ingest" data-testid="cta-scan" className={CTA_CLASS}>
+        Scan a menu →
+      </Link>
+    );
+  }
+
+  return (
+    <Link href="/onboarding" data-testid="cta-web" className={CTA_CLASS}>
+      Try the web app →
+    </Link>
+  );
+}

--- a/apps/web/src/app/__tests__/HeroCta.test.tsx
+++ b/apps/web/src/app/__tests__/HeroCta.test.tsx
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { HeroCta } from '../_HeroCta';
+
+function stubSession(signedIn: boolean) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: true, json: async () => ({ signedIn }) }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('HeroCta', () => {
+  it('shows "Scan a menu" → /ingest when signed in', async () => {
+    stubSession(true);
+    render(<HeroCta />);
+
+    const cta = await screen.findByTestId('cta-scan');
+    expect(cta).toHaveAttribute('href', '/ingest');
+    expect(screen.queryByTestId('cta-web')).not.toBeInTheDocument();
+  });
+
+  it('shows "Try the web app" → /onboarding when signed out', async () => {
+    stubSession(false);
+    render(<HeroCta />);
+
+    expect(screen.getByTestId('cta-web')).toHaveAttribute('href', '/onboarding');
+    await waitFor(() => expect(screen.queryByTestId('cta-scan')).not.toBeInTheDocument());
+  });
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
 import { buildLandingMetadata } from '../lib/landing-meta';
 import { fetchRestaurants, type RestaurantSummary } from '../lib/restaurants';
+import { HeroCta } from './_HeroCta';
 import { RestaurantCards } from './_RestaurantCards';
 import WaitlistForm from './_waitlist-form';
 
@@ -102,13 +103,7 @@ function Hero(): ReactElement {
       </p>
 
       <div className="mt-bw-8 flex flex-wrap gap-bw-3">
-        <a
-          href="/onboarding"
-          data-testid="cta-web"
-          className="rounded-bw-md bg-bite px-bw-6 py-bw-3 text-bw-base font-bold text-white shadow-sm hover:bg-bite-dark"
-        >
-          Try the web app →
-        </a>
+        <HeroCta />
         <ComingSoonBadge label="iOS app" />
         <ComingSoonBadge label="Android app" />
       </div>


### PR DESCRIPTION
## Summary

- The landing hero's primary CTA now adapts to auth: signed-in users see **"Scan a menu" → /ingest** (the core action) instead of "Try the web app → onboarding". Logged-out visitors keep the onboarding CTA.
- New `_HeroCta` client component reading the same `/api/auth/session` as the header.
