### PR TITLE
feat(web): verify page redesign — instant dishes, grouping, Accept All, Undo (PR-3)

### DIFF
--- a/apps/web/src/app/api/ingestion_runs/[id]/items/accept_all/route.ts
+++ b/apps/web/src/app/api/ingestion_runs/[id]/items/accept_all/route.ts
@@ -1,0 +1,16 @@
+/**
+ * `POST /api/ingestion_runs/:id/items/accept_all` — proxies the verify
+ * page's "Accept All" to Rails (bulk-accept every pending item).
+ */
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../../../lib/api-proxy';
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxyAuthed(`/api/v1/ingestion_runs/${encodeURIComponent(id)}/items/accept_all`, {
+    method: 'POST',
+  });
+}

--- a/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
@@ -8,23 +8,27 @@ import {
 } from '../../../../lib/ingestion';
 
 /**
- * Phase 6.5 — one staged item in the web verify list. The web twin
- * of mobile's swipe-verify card (Phase 2.7): accept promotes (with
- * the Phase 6.3 trust level of whoever is signed in), reject buries.
+ * One item in the web verify list. Accept promotes (with the Phase 6.3 trust
+ * level of whoever is signed in); Reject buries; Undo reverts a decision (and
+ * un-promotes a live Item). While the run is still enriching, the dish shows
+ * immediately but its ingredient/tag chips read "matching…" until resolve
+ * fills them (verify-flow redesign).
  */
 export function VerifyItemRow({
   runId,
   item,
+  enriched,
   onDecided,
 }: {
   runId: string;
   item: IngestionItemPayload;
+  enriched: boolean;
   onDecided: (updated: IngestionItemPayload) => void;
 }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const decide = async (decision: 'accepted' | 'rejected') => {
+  const decide = async (decision: 'accepted' | 'rejected' | 'pending') => {
     setError(null);
     try {
       setBusy(true);
@@ -47,46 +51,59 @@ export function VerifyItemRow({
           <p className="font-semibold">
             {item.name}
             {price != null && (
-              <span className="ml-2 font-normal text-zinc-500">
-                ${(price / 100).toFixed(2)}
-              </span>
+              <span className="ml-2 font-normal text-zinc-500">${(price / 100).toFixed(2)}</span>
             )}
           </p>
-          {item.section_name && (
-            <p className="text-xs uppercase tracking-wide text-zinc-400">{item.section_name}</p>
-          )}
           {item.description && <p className="mt-1 text-sm text-zinc-600">{item.description}</p>}
-          <p className="mt-2 flex flex-wrap gap-1">
-            {item.ingredients_payload.map((row) => (
-              <span
-                key={row.slug}
-                className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700"
-              >
-                {row.slug}
-              </span>
-            ))}
-            {item.tags_payload.map((row) => (
-              <span
-                key={row.slug}
-                className="rounded-full bg-orange-50 px-2 py-0.5 text-xs text-orange-700"
-              >
-                {row.slug}
-              </span>
-            ))}
-          </p>
+
+          {enriched ? (
+            <p className="mt-2 flex flex-wrap gap-1">
+              {item.ingredients_payload.map((row) => (
+                <span
+                  key={row.slug}
+                  className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-700"
+                >
+                  {row.slug}
+                </span>
+              ))}
+              {item.tags_payload.map((row) => (
+                <span
+                  key={row.slug}
+                  className="rounded-full bg-orange-50 px-2 py-0.5 text-xs text-orange-700"
+                >
+                  {row.slug}
+                </span>
+              ))}
+            </p>
+          ) : (
+            <p className="mt-2 text-xs italic text-zinc-400" data-testid="item-matching">
+              matching ingredients &amp; tags…
+            </p>
+          )}
         </div>
 
         <div className="flex shrink-0 flex-col items-end gap-2">
           {decided ? (
-            <span
-              className={
-                item.decision === 'accepted'
-                  ? 'rounded bg-green-100 px-2 py-1 text-sm font-semibold text-green-800'
-                  : 'rounded bg-zinc-100 px-2 py-1 text-sm font-semibold text-zinc-600'
-              }
-            >
-              {item.decision}
-            </span>
+            <>
+              <span
+                className={
+                  item.decision === 'accepted'
+                    ? 'rounded bg-green-100 px-2 py-1 text-sm font-semibold text-green-800'
+                    : 'rounded bg-zinc-100 px-2 py-1 text-sm font-semibold text-zinc-600'
+                }
+              >
+                {item.decision}
+              </span>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void decide('pending')}
+                data-testid="undo"
+                className="text-xs font-semibold text-zinc-500 underline hover:text-zinc-800 disabled:opacity-50"
+              >
+                Undo
+              </button>
+            </>
           ) : (
             <>
               <button

--- a/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
@@ -15,6 +15,7 @@ const item: IngestionItemPayload = {
   id: 'item-1',
   ingestion_run_id: 'run-1',
   item_id: null,
+  position: 0,
   name: 'Pad Thai',
   description: 'Rice noodles, peanut, lime.',
   section_name: 'Noodles',
@@ -32,22 +33,27 @@ const item: IngestionItemPayload = {
 // beforeEach (empirically verified). Per-test mockImplementation
 // overrides + toHaveBeenLastCalledWith give the same isolation.
 describe('VerifyItemRow', () => {
-
-  it('renders name, price, section, and payload chips', () => {
-    render(<VerifyItemRow runId="run-1" item={item} onDecided={vi.fn()} />);
+  it('renders name, price, and payload chips when enriched', () => {
+    render(<VerifyItemRow runId="run-1" item={item} enriched onDecided={vi.fn()} />);
 
     expect(screen.getByText('Pad Thai')).toBeInTheDocument();
     expect(screen.getByText('$14.50')).toBeInTheDocument();
-    expect(screen.getByText('Noodles')).toBeInTheDocument();
     expect(screen.getByText('nut-peanut')).toBeInTheDocument();
     expect(screen.getByText('cuisine-thai')).toBeInTheDocument();
+  });
+
+  it('shows "matching…" instead of chips while the run is still enriching', () => {
+    render(<VerifyItemRow runId="run-1" item={item} enriched={false} onDecided={vi.fn()} />);
+
+    expect(screen.getByTestId('item-matching')).toBeInTheDocument();
+    expect(screen.queryByText('nut-peanut')).toBeNull();
   });
 
   it('accept wires through decideRunItem and reports the updated item', async () => {
     const updated = { ...item, decision: 'accepted' as const };
     decideMock.mockResolvedValue(updated);
     const onDecided = vi.fn();
-    render(<VerifyItemRow runId="run-1" item={item} onDecided={onDecided} />);
+    render(<VerifyItemRow runId="run-1" item={item} enriched onDecided={onDecided} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
@@ -59,24 +65,49 @@ describe('VerifyItemRow', () => {
     });
   });
 
-  it('decided items show a status badge instead of buttons', () => {
+  it('decided items show a status badge + Undo (no Accept/Reject)', () => {
     render(
       <VerifyItemRow
         runId="run-1"
         item={{ ...item, decision: 'accepted' }}
+        enriched
         onDecided={vi.fn()}
       />,
     );
 
     expect(screen.getByText('accepted')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Accept' })).toBeNull();
+    expect(screen.getByTestId('undo')).toBeInTheDocument();
+  });
+
+  it('Undo reverts the decision via decideRunItem(pending)', async () => {
+    const reverted = { ...item, decision: 'pending' as const };
+    decideMock.mockResolvedValue(reverted);
+    const onDecided = vi.fn();
+    render(
+      <VerifyItemRow
+        runId="run-1"
+        item={{ ...item, decision: 'accepted' }}
+        enriched
+        onDecided={onDecided}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('undo'));
+
+    await waitFor(() => expect(onDecided).toHaveBeenCalledWith(reverted));
+    expect(decideMock).toHaveBeenLastCalledWith({
+      runId: 'run-1',
+      itemId: 'item-1',
+      decision: 'pending',
+    });
   });
 
   it('renders the friendly error when the decision fails', async () => {
     decideMock.mockImplementation(() =>
       Promise.reject(new ingestion.IngestionRequestError(503, { error: 'cost_ceiling_reached' })),
     );
-    render(<VerifyItemRow runId="run-1" item={item} onDecided={vi.fn()} />);
+    render(<VerifyItemRow runId="run-1" item={item} enriched onDecided={vi.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
 

--- a/apps/web/src/app/ingest/verify/[runId]/page.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
+  acceptAllRunItems,
   fetchRun,
   fetchRunItems,
   friendlyIngestionError,
@@ -14,7 +15,7 @@ import { VerifyItemRow } from './_VerifyItemRow';
 const PIPELINE_LABELS: Record<IngestionRunPayload['status'], string> = {
   queued: 'Waiting in line…',
   extracting: 'Reading the menu…',
-  resolving: 'Matching ingredients…',
+  resolving: 'Dishes found — matching ingredients…',
   staged: 'Ready to verify',
   published: 'Published!',
   failed: 'Extraction failed',
@@ -22,11 +23,27 @@ const PIPELINE_LABELS: Record<IngestionRunPayload['status'], string> = {
 
 const POLL_MS = 3_000;
 
+// Group items by sub-menu (section), preserving first-seen (menu) order; items
+// with no section land under a neutral "Menu" header.
+function groupBySection(
+  items: IngestionItemPayload[],
+): Array<[string, IngestionItemPayload[]]> {
+  const groups = new Map<string, IngestionItemPayload[]>();
+  for (const it of items) {
+    const key = it.section_name?.trim() || 'Menu';
+    const arr = groups.get(key) ?? [];
+    arr.push(it);
+    groups.set(key, arr);
+  }
+  return [...groups.entries()];
+}
+
 /**
- * Phase 6.5 — web verify page. Polls the run while the pipeline is
- * working, then renders the staged items for accept/reject. The 80%
- * threshold (Phase 2.5) flips the run + restaurant to published as
- * decisions come in; we re-poll after each decision to notice.
+ * Verify page (verify-flow redesign). Dishes are materialized at extraction, so
+ * they show up during `:resolving` — grouped by sub-menu, each with its
+ * ingredient/tag chips "matching…" until enrichment lands. Accept / Reject /
+ * Undo per dish, plus Accept All. Publishing only fires once matching finishes
+ * (`:staged`), so a dish never goes live without its allergen data.
  */
 export default function VerifyRunPage({ params }: { params: Promise<{ runId: string }> }) {
   const { runId } = use(params);
@@ -34,15 +51,20 @@ export default function VerifyRunPage({ params }: { params: Promise<{ runId: str
   const [run, setRun] = useState<IngestionRunPayload | null>(null);
   const [items, setItems] = useState<IngestionItemPayload[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [acceptingAll, setAcceptingAll] = useState(false);
   const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
       const latest = await fetchRun(runId);
       setRun(latest);
-      if (latest.status === 'staged' || latest.status === 'published') {
+      // Dishes exist from :resolving on — show them (and keep them fresh as
+      // enrichment fills in), not just at :staged.
+      if (['resolving', 'staged', 'published'].includes(latest.status)) {
         setItems(await fetchRunItems(runId));
-      } else if (latest.status !== 'failed') {
+      }
+      // Keep polling until enrichment settles or the run terminates.
+      if (!['staged', 'published', 'failed'].includes(latest.status)) {
         pollTimer.current = setTimeout(() => void refresh(), POLL_MS);
       }
     } catch (e) {
@@ -63,7 +85,23 @@ export default function VerifyRunPage({ params }: { params: Promise<{ runId: str
     void fetchRun(runId).then(setRun).catch(() => undefined);
   };
 
+  const onAcceptAll = async () => {
+    setError(null);
+    try {
+      setAcceptingAll(true);
+      setItems(await acceptAllRunItems(runId));
+      await fetchRun(runId).then(setRun);
+    } catch (e) {
+      setError(friendlyIngestionError(e));
+    } finally {
+      setAcceptingAll(false);
+    }
+  };
+
+  const enriched = run?.status === 'staged' || run?.status === 'published';
   const decidedCount = items?.filter((it) => it.decision !== 'pending').length ?? 0;
+  const pendingCount = items?.filter((it) => it.decision === 'pending').length ?? 0;
+  const stillWorking = run != null && ['queued', 'extracting', 'resolving'].includes(run.status);
 
   return (
     <main className="mx-auto max-w-3xl space-y-6 p-6">
@@ -74,7 +112,7 @@ export default function VerifyRunPage({ params }: { params: Promise<{ runId: str
         <h1 className="mt-1 text-3xl font-bold">
           {run ? PIPELINE_LABELS[run.status] : 'Loading…'}
         </h1>
-        {run && run.status !== 'staged' && run.status !== 'published' && run.status !== 'failed' && (
+        {stillWorking && !items && (
           <p className="mt-2 text-zinc-600" role="status">
             This usually takes under a minute. The page refreshes itself.
           </p>
@@ -99,16 +137,46 @@ export default function VerifyRunPage({ params }: { params: Promise<{ runId: str
         </div>
       )}
 
-      {items && (
+      {items && items.length > 0 && (
         <>
-          <p className="text-sm text-zinc-500" role="status">
-            {decidedCount} of {items.length} decided — accept at least 80% to publish.
-          </p>
-          <ul className="space-y-3">
-            {items.map((item) => (
-              <VerifyItemRow key={item.id} runId={runId} item={item} onDecided={onDecided} />
-            ))}
-          </ul>
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+            <div className="text-sm text-zinc-600" role="status">
+              <span className="font-semibold text-zinc-900">{items.length} dishes</span>
+              {!enriched && <span className="text-zinc-500"> · still matching ingredients &amp; tags…</span>}
+              <span className="mt-1 block">
+                {decidedCount} of {items.length} decided — accept at least 80% to publish
+                {!enriched && ' (publishing finalizes once matching finishes)'}.
+              </span>
+            </div>
+            {pendingCount > 0 && (
+              <button
+                type="button"
+                onClick={() => void onAcceptAll()}
+                disabled={acceptingAll}
+                data-testid="accept-all"
+                className="shrink-0 rounded bg-green-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              >
+                {acceptingAll ? 'Accepting…' : `Accept all ${pendingCount}`}
+              </button>
+            )}
+          </div>
+
+          {groupBySection(items).map(([section, sectionItems]) => (
+            <section key={section} className="space-y-3" data-testid={`verify-section-${section}`}>
+              <h2 className="text-xs font-bold uppercase tracking-wide text-zinc-400">{section}</h2>
+              <ul className="space-y-3">
+                {sectionItems.map((it) => (
+                  <VerifyItemRow
+                    key={it.id}
+                    runId={runId}
+                    item={it}
+                    enriched={enriched}
+                    onDecided={onDecided}
+                  />
+                ))}
+              </ul>
+            </section>
+          ))}
         </>
       )}
 

--- a/apps/web/src/lib/__tests__/ingestion.test.ts
+++ b/apps/web/src/lib/__tests__/ingestion.test.ts
@@ -154,6 +154,7 @@ describe('ingestFromFile', () => {
 // ---------------------------------------------------------------------------
 
 import {
+  acceptAllRunItems,
   createRestaurant,
   decideRunItem,
   fetchRunItems,
@@ -165,6 +166,7 @@ const sampleItem: IngestionItemPayload = {
   id: 'item-1',
   ingestion_run_id: 'rrrr-1111',
   item_id: null,
+  position: 0,
   name: 'Pad Thai',
   description: 'Rice noodles, peanut, lime.',
   section_name: 'Noodles',
@@ -246,6 +248,26 @@ describe('fetchRunItems / decideRunItem', () => {
     expect(url).toBe('/api/ingestion_runs/rrrr-1111/items/item-1');
     expect(init.method).toBe('PATCH');
     expect(JSON.parse(init.body as string)).toEqual({ decision: 'accepted' });
+  });
+
+  it('Undo PATCHes decision: pending', async () => {
+    const fetchImpl = fakeFetch(200, { ...sampleItem, decision: 'pending' });
+
+    await decideRunItem({ runId: 'rrrr-1111', itemId: 'item-1', decision: 'pending', fetchImpl });
+
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ decision: 'pending' });
+  });
+
+  it('acceptAll POSTs to the collection route and unwraps items', async () => {
+    const fetchImpl = fakeFetch(200, { items: [{ ...sampleItem, decision: 'accepted' }] });
+
+    const items = await acceptAllRunItems('rrrr-1111', fetchImpl);
+
+    expect(items[0]!.decision).toBe('accepted');
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/ingestion_runs/rrrr-1111/items/accept_all');
+    expect(init.method).toBe('POST');
   });
 });
 

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -126,6 +126,8 @@ export interface IngestionItemPayload {
   id: string;
   ingestion_run_id: string;
   item_id: string | null;
+  /** Flat index within the run's extraction order — used to keep verify stable. */
+  position: number | null;
   name: string | null;
   description: string | null;
   section_name: string | null;
@@ -173,7 +175,8 @@ export async function fetchRunItems(
 export async function decideRunItem(opts: {
   runId: string;
   itemId: string;
-  decision: 'accepted' | 'rejected';
+  /** `pending` is Undo — reverts a decision (and un-promotes if it went live). */
+  decision: 'accepted' | 'rejected' | 'pending';
   fetchImpl?: typeof fetch;
 }): Promise<IngestionItemPayload> {
   const { fetchImpl = fetch } = opts;
@@ -196,6 +199,28 @@ export async function decideRunItem(opts: {
     throw new IngestionRequestError(res.status, parsed);
   }
   return (await res.json()) as IngestionItemPayload;
+}
+
+/** Bulk-accept every pending item on a run (Accept All). Returns all items. */
+export async function acceptAllRunItems(
+  runId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<IngestionItemPayload[]> {
+  const res = await fetchImpl(
+    `/api/ingestion_runs/${encodeURIComponent(runId)}/items/accept_all`,
+    { method: 'POST', credentials: 'same-origin' },
+  );
+  if (!res.ok) {
+    let parsed: IngestionApiError | null = null;
+    try {
+      parsed = (await res.json()) as IngestionApiError;
+    } catch {
+      // ignore
+    }
+    throw new IngestionRequestError(res.status, parsed);
+  }
+  const body = (await res.json()) as { items: IngestionItemPayload[] };
+  return body.items;
 }
 
 /**

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,19 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Verify-flow redesign PR-3: verify page UI. Branch `feat/verify-page-redesign`.
+
+- Surfaces the PR-1/PR-2 backend to users. The verify page now shows dishes from
+  `:resolving` on (not just `:staged`), **grouped by sub-menu** (section), each
+  row's ingredient/tag chips reading **"matching…"** until enrichment fills them.
+  Added **Accept All** (bulk) and **Undo** (per row → un-promote), and publish
+  messaging that reflects "finalizes once matching finishes." lib:
+  `acceptAllRunItems` + `decideRunItem(pending)`; new `/items/accept_all` proxy;
+  `position` on the item payload type.
+- Web vitest 214 (+4), typecheck/lint green. Verify-flow redesign (PR-1/2/3) done;
+  mobile verify screen mirrors this as a follow-up. Still open: confirm the new
+  pipeline with a live scan; the resolve JSON-parse robustness follow-up.
+
 2026-07-21 — Homepage discovery: show restaurants + menu links everywhere.
 Branch `feat/homepage-discovery`.
 


### PR DESCRIPTION
## Summary

Surfaces the verify-flow backend (PR-1 instant dishes/bg enrichment + PR-2 Accept All/Undo) in the UI:
- Dishes show from `:resolving` on (not just `:staged`), **grouped by sub-menu**; each row's chips read **"matching…"** until enriched.
- **Accept All** (bulk) + **Undo** (per row, reverts + un-promotes). Publish messaging notes it finalizes once matching finishes.
- `acceptAllRunItems` + `decideRunItem(pending)` lib; new `/items/accept_all` proxy; `position` on the item type.

Completes the verify-flow redesign (PR-1/2/3).
