### PR TITLE
feat(web): account page — show + edit dietary preferences (PR-1)

### DIFF
--- a/apps/api/app/controllers/api/v1/profiles_controller.rb
+++ b/apps/api/app/controllers/api/v1/profiles_controller.rb
@@ -85,7 +85,18 @@ module Api
       # {id, slug, name} rows the web account page renders without a
       # second round-trip. Unknown/stale ids resolve to nothing and drop
       # out — the same way scoring silently ignores them.
+      #
+      # Two queries total: every ingredient id is looked up once, every
+      # tag id once, then each list is sliced from the in-memory maps in
+      # its stored order.
       def profile_payload(profile)
+        ing = ingredient_lookup(
+          profile.avoid_ingredient_ids + profile.liked_ingredient_ids + profile.disliked_ingredient_ids
+        )
+        tag = tag_lookup(
+          profile.avoid_tag_ids + profile.liked_tag_ids + profile.disliked_tag_ids
+        )
+
         {
           avoid_ingredient_ids: profile.avoid_ingredient_ids,
           avoid_tag_ids:        profile.avoid_tag_ids,
@@ -94,36 +105,28 @@ module Api
           liked_tag_ids:           profile.liked_tag_ids,
           disliked_ingredient_ids: profile.disliked_ingredient_ids,
           disliked_tag_ids:        profile.disliked_tag_ids,
-          avoid_ingredients:    resolve_ingredients(profile.avoid_ingredient_ids),
-          avoid_tags:           resolve_tags(profile.avoid_tag_ids),
-          prefer_tags:          resolve_tags(profile.prefer_tag_ids),
-          liked_ingredients:    resolve_ingredients(profile.liked_ingredient_ids),
-          liked_tags:           resolve_tags(profile.liked_tag_ids),
-          disliked_ingredients: resolve_ingredients(profile.disliked_ingredient_ids),
-          disliked_tags:        resolve_tags(profile.disliked_tag_ids),
+          avoid_ingredients:    resolve(profile.avoid_ingredient_ids, ing, &INGREDIENT_ROW),
+          avoid_tags:           resolve(profile.avoid_tag_ids, tag, &TAG_ROW),
+          liked_ingredients:    resolve(profile.liked_ingredient_ids, ing, &INGREDIENT_ROW),
+          liked_tags:           resolve(profile.liked_tag_ids, tag, &TAG_ROW),
+          disliked_ingredients: resolve(profile.disliked_ingredient_ids, ing, &INGREDIENT_ROW),
+          disliked_tags:        resolve(profile.disliked_tag_ids, tag, &TAG_ROW),
           strictness:           profile.strictness,
           primary_dietary_profile: dietary_profile_summary(profile.primary_dietary_profile),
           disclaimer_acknowledged_at: profile.disclaimer_acknowledged_at&.iso8601
         }
       end
 
-      # Resolve an id array to ordered {id, slug, name} rows, dropping
-      # any id that no longer maps to a live row. One query, order
-      # preserved from the stored array.
-      def resolve_ingredients(ids)
-        by_id = Ingredient.where(id: ids).index_by { |i| i.id.to_s }
-        ids.filter_map do |id|
-          ing = by_id[id.to_s]
-          { id: ing.id, slug: ing.slug, name: ing.name } if ing
-        end
-      end
+      INGREDIENT_ROW = ->(i) { { id: i.id, slug: i.slug, name: i.name } }
+      TAG_ROW        = ->(t) { { id: t.id, slug: t.slug, name: t.name, family: t.family } }
 
-      def resolve_tags(ids)
-        by_id = Tag.where(id: ids).index_by { |t| t.id.to_s }
-        ids.filter_map do |id|
-          tag = by_id[id.to_s]
-          { id: tag.id, slug: tag.slug, name: tag.name, family: tag.family } if tag
-        end
+      def ingredient_lookup(ids) = Ingredient.where(id: ids.uniq).index_by { |i| i.id.to_s }
+      def tag_lookup(ids)        = Tag.where(id: ids.uniq).index_by { |t| t.id.to_s }
+
+      # Slice an id array into ordered rows from a pre-built lookup map,
+      # dropping any id the map doesn't cover (stale/removed).
+      def resolve(ids, lookup, &row)
+        ids.filter_map { |id| lookup[id.to_s] }.map(&row)
       end
 
       def dietary_profile_summary(preset)

--- a/apps/api/app/controllers/api/v1/profiles_controller.rb
+++ b/apps/api/app/controllers/api/v1/profiles_controller.rb
@@ -80,6 +80,11 @@ module Api
         profile.primary_dietary_profile_id = preset.id
       end
 
+      # The raw id arrays stay (mobile onboarding + filter-engine read
+      # them); the `*_ingredients` / `*_tags` arrays add the resolved
+      # {id, slug, name} rows the web account page renders without a
+      # second round-trip. Unknown/stale ids resolve to nothing and drop
+      # out — the same way scoring silently ignores them.
       def profile_payload(profile)
         {
           avoid_ingredient_ids: profile.avoid_ingredient_ids,
@@ -89,10 +94,36 @@ module Api
           liked_tag_ids:           profile.liked_tag_ids,
           disliked_ingredient_ids: profile.disliked_ingredient_ids,
           disliked_tag_ids:        profile.disliked_tag_ids,
+          avoid_ingredients:    resolve_ingredients(profile.avoid_ingredient_ids),
+          avoid_tags:           resolve_tags(profile.avoid_tag_ids),
+          prefer_tags:          resolve_tags(profile.prefer_tag_ids),
+          liked_ingredients:    resolve_ingredients(profile.liked_ingredient_ids),
+          liked_tags:           resolve_tags(profile.liked_tag_ids),
+          disliked_ingredients: resolve_ingredients(profile.disliked_ingredient_ids),
+          disliked_tags:        resolve_tags(profile.disliked_tag_ids),
           strictness:           profile.strictness,
           primary_dietary_profile: dietary_profile_summary(profile.primary_dietary_profile),
           disclaimer_acknowledged_at: profile.disclaimer_acknowledged_at&.iso8601
         }
+      end
+
+      # Resolve an id array to ordered {id, slug, name} rows, dropping
+      # any id that no longer maps to a live row. One query, order
+      # preserved from the stored array.
+      def resolve_ingredients(ids)
+        by_id = Ingredient.where(id: ids).index_by { |i| i.id.to_s }
+        ids.filter_map do |id|
+          ing = by_id[id.to_s]
+          { id: ing.id, slug: ing.slug, name: ing.name } if ing
+        end
+      end
+
+      def resolve_tags(ids)
+        by_id = Tag.where(id: ids).index_by { |t| t.id.to_s }
+        ids.filter_map do |id|
+          tag = by_id[id.to_s]
+          { id: tag.id, slug: tag.slug, name: tag.name, family: tag.family } if tag
+        end
       end
 
       def dietary_profile_summary(preset)

--- a/apps/api/app/models/user_profile.rb
+++ b/apps/api/app/models/user_profile.rb
@@ -32,8 +32,19 @@ class UserProfile < ApplicationRecord
     end
   end
 
+  # Only validate a taste array that this save actually changes. The
+  # goal is to catch a client sending a bad/typo'd UUID — not to
+  # re-check arrays we're leaving alone. Re-checking untouched arrays
+  # meant a partial PATCH (e.g. just `strictness`) would 422 whenever a
+  # stored taste id had gone stale (its taxonomy node was later removed
+  # by an admin), soft-locking the user out of editing ANY preference,
+  # including their safety filter. GET already tolerates stale ids by
+  # dropping them on read; writes must be just as forgiving of arrays
+  # they don't touch.
   def taste_ids_exist
     TASTE_FIELDS.each do |attr, kind|
+      next unless will_save_change_to_attribute?(attr)
+
       ids = self[attr].compact.uniq
       next if ids.empty?
 

--- a/apps/api/spec/requests/api/v1/profile_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_spec.rb
@@ -23,6 +23,44 @@ RSpec.describe "GET/PATCH /api/v1/profile", type: :request do
       get "/api/v1/profile"
       expect(response).to have_http_status(:unauthorized)
     end
+
+    # The account page renders names, not UUIDs, so GET resolves each id
+    # array to ordered {id, slug, name} rows in one payload. The raw id
+    # arrays stay for the mobile/onboarding clients that read them.
+    describe "resolved name rows" do
+      let(:cheese)    { create(:ingredient, slug: "dairy-cheese") }
+      let(:wheat)     { create(:ingredient, slug: "wheat") }
+      let(:fried_tag) { create(:tag, slug: "prep-fried") }
+
+      it "resolves avoid ids to {id, slug, name} rows in stored order" do
+        user.profile.update!(
+          avoid_ingredient_ids: [wheat.id, cheese.id],
+          avoid_tag_ids:        [fried_tag.id]
+        )
+
+        get "/api/v1/profile", headers: headers
+
+        body = response.parsed_body
+        expect(body["avoid_ingredients"]).to eq([
+          { "id" => wheat.id,  "slug" => "wheat",       "name" => "Wheat" },
+          { "id" => cheese.id, "slug" => "dairy-cheese", "name" => "Cheese" }
+        ])
+        expect(body["avoid_tags"]).to eq([
+          { "id" => fried_tag.id, "slug" => "prep-fried", "name" => "Fried", "family" => "prep" }
+        ])
+      end
+
+      it "drops ids that no longer resolve to a live row (stale ids)" do
+        stale = SecureRandom.uuid
+        user.profile.update!(avoid_ingredient_ids: [cheese.id, stale])
+
+        get "/api/v1/profile", headers: headers
+
+        body = response.parsed_body
+        expect(body["avoid_ingredient_ids"]).to contain_exactly(cheese.id, stale)
+        expect(body["avoid_ingredients"].map { |r| r["id"] }).to eq([cheese.id])
+      end
+    end
   end
 
   describe "PATCH /api/v1/profile" do

--- a/apps/api/spec/requests/api/v1/profile_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_spec.rb
@@ -246,6 +246,23 @@ RSpec.describe "GET/PATCH /api/v1/profile", type: :request do
         expect(response.parsed_body["errors"]).to have_key("liked_tag_ids")
       end
 
+      # A taste id can go stale when an admin removes its taxonomy node.
+      # A partial edit that doesn't touch taste must still succeed — it
+      # must not re-validate (and reject on) the untouched stale array,
+      # or the user is soft-locked out of editing every preference,
+      # including their safety filter. update_columns seeds the stale id
+      # past validation to mimic post-hoc taxonomy removal.
+      it "does not re-validate an untouched taste array (stale id can't block an unrelated edit)" do
+        user.profile.update_columns(liked_ingredient_ids: [SecureRandom.uuid])
+
+        patch "/api/v1/profile",
+              params: { strictness: "strict" }.to_json,
+              headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["strictness"]).to eq("strict")
+      end
+
       it "accepts an id that also sits in an avoid list (filter wins; scoring ignores it)" do
         patch "/api/v1/profile",
               params: {

--- a/apps/api/spec/swagger_helper.rb
+++ b/apps/api/spec/swagger_helper.rb
@@ -96,7 +96,7 @@ RSpec.configure do |config|
             required: %w[avoid_ingredient_ids avoid_tag_ids prefer_tag_ids
                          liked_ingredient_ids liked_tag_ids
                          disliked_ingredient_ids disliked_tag_ids
-                         avoid_ingredients avoid_tags prefer_tags
+                         avoid_ingredients avoid_tags
                          liked_ingredients liked_tags
                          disliked_ingredients disliked_tags
                          strictness primary_dietary_profile
@@ -116,7 +116,6 @@ RSpec.configure do |config|
               # ingredient/tag lookup. Stale ids drop out.
               avoid_ingredients:    { type: :array, items: { "$ref" => "#/components/schemas/IngredientRef" } },
               avoid_tags:           { type: :array, items: { "$ref" => "#/components/schemas/TagRef" } },
-              prefer_tags:          { type: :array, items: { "$ref" => "#/components/schemas/TagRef" } },
               liked_ingredients:    { type: :array, items: { "$ref" => "#/components/schemas/IngredientRef" } },
               liked_tags:           { type: :array, items: { "$ref" => "#/components/schemas/TagRef" } },
               disliked_ingredients: { type: :array, items: { "$ref" => "#/components/schemas/IngredientRef" } },

--- a/apps/api/spec/swagger_helper.rb
+++ b/apps/api/spec/swagger_helper.rb
@@ -72,11 +72,33 @@ RSpec.configure do |config|
               user: { "$ref" => "#/components/schemas/UserPayload" }
             }
           },
+          IngredientRef: {
+            type: :object,
+            required: %w[id slug name],
+            properties: {
+              id:   { type: :string, format: :uuid },
+              slug: { type: :string },
+              name: { type: :string }
+            }
+          },
+          TagRef: {
+            type: :object,
+            required: %w[id slug name family],
+            properties: {
+              id:     { type: :string, format: :uuid },
+              slug:   { type: :string },
+              name:   { type: :string },
+              family: { type: :string, enum: %w[diet allergen cuisine prep flavor] }
+            }
+          },
           ProfilePayload: {
             type: :object,
             required: %w[avoid_ingredient_ids avoid_tag_ids prefer_tag_ids
                          liked_ingredient_ids liked_tag_ids
                          disliked_ingredient_ids disliked_tag_ids
+                         avoid_ingredients avoid_tags prefer_tags
+                         liked_ingredients liked_tags
+                         disliked_ingredients disliked_tags
                          strictness primary_dietary_profile
                          disclaimer_acknowledged_at],
             properties: {
@@ -89,6 +111,16 @@ RSpec.configure do |config|
               liked_tag_ids:           { type: :array, items: { type: :string, format: :uuid } },
               disliked_ingredient_ids: { type: :array, items: { type: :string, format: :uuid } },
               disliked_tag_ids:        { type: :array, items: { type: :string, format: :uuid } },
+              # Resolved {id, slug, name(, family)} rows for each id array
+              # above — the account page renders these without a second
+              # ingredient/tag lookup. Stale ids drop out.
+              avoid_ingredients:    { type: :array, items: { "$ref" => "#/components/schemas/IngredientRef" } },
+              avoid_tags:           { type: :array, items: { "$ref" => "#/components/schemas/TagRef" } },
+              prefer_tags:          { type: :array, items: { "$ref" => "#/components/schemas/TagRef" } },
+              liked_ingredients:    { type: :array, items: { "$ref" => "#/components/schemas/IngredientRef" } },
+              liked_tags:           { type: :array, items: { "$ref" => "#/components/schemas/TagRef" } },
+              disliked_ingredients: { type: :array, items: { "$ref" => "#/components/schemas/IngredientRef" } },
+              disliked_tags:        { type: :array, items: { "$ref" => "#/components/schemas/TagRef" } },
               strictness:           { type: :string, enum: %w[relaxed balanced strict] },
               primary_dietary_profile: {
                 type: :object, nullable: true,

--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -1,10 +1,18 @@
 /**
- * Phase 4.1 — `PATCH /api/profile` proxies to Rails with the JWT
- * from the HttpOnly `bw_session` cookie. Lets the onboarding page
- * call `saveProfile` without ever touching the JWT in JS.
+ * `/api/profile` proxies to Rails with the JWT from the HttpOnly
+ * `bw_session` cookie — the client never touches the JWT in JS.
+ *
+ * PATCH (Phase 4.1) is the onboarding save. GET backs the account
+ * page: it reads the caller's current dietary profile (with resolved
+ * ingredient/tag names) so preferences can be shown and edited in
+ * place. `no-store` — a stale profile would render wrong preferences.
  */
 import { type NextRequest } from 'next/server';
 import { proxyAuthed } from '../../../lib/api-proxy';
+
+export async function GET() {
+  return proxyAuthed('/api/v1/profile', { cache: 'no-store' });
+}
 
 export async function PATCH(request: NextRequest) {
   return proxyAuthed('/api/v1/profile', { method: 'PATCH', body: await request.text() });

--- a/apps/web/src/app/profile/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/profile/settings/__tests__/page.test.tsx
@@ -45,7 +45,7 @@ const PROFILE: ProfilePayload = {
   avoid_ingredient_ids: ['ing-cheese', 'ing-wheat'],
   avoid_tag_ids: ['tag-fried'],
   prefer_tag_ids: [],
-  liked_ingredient_ids: [],
+  liked_ingredient_ids: ['ing-basil'],
   liked_tag_ids: ['tag-thai'],
   disliked_ingredient_ids: [],
   disliked_tag_ids: [],
@@ -54,8 +54,7 @@ const PROFILE: ProfilePayload = {
     { id: 'ing-wheat', slug: 'wheat', name: 'Wheat' },
   ],
   avoid_tags: [{ id: 'tag-fried', slug: 'prep-fried', name: 'Fried', family: 'prep' }],
-  prefer_tags: [],
-  liked_ingredients: [],
+  liked_ingredients: [{ id: 'ing-basil', slug: 'herb-basil', name: 'Basil' }],
   liked_tags: [{ id: 'tag-thai', slug: 'cuisine-thai', name: 'Thai', family: 'cuisine' }],
   disliked_ingredients: [],
   disliked_tags: [],
@@ -87,7 +86,9 @@ describe('ProfileSettingsPage — dietary preferences', () => {
     expect(screen.getByText('Wheat')).toBeInTheDocument();
     expect(screen.getByTestId('pref-avoid-tags')).toHaveTextContent('Fried');
     expect(screen.getByTestId('pref-preset')).toHaveTextContent('Vegan');
+    // Taste shows both tag (Thai) and ingredient (Basil) love signals.
     expect(screen.getByTestId('pref-taste')).toHaveTextContent('Thai');
+    expect(screen.getByTestId('pref-taste')).toHaveTextContent('Basil');
     expect(screen.getByTestId('set-strictness-balanced')).toHaveAttribute('aria-pressed', 'true');
   });
 

--- a/apps/web/src/app/profile/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/profile/settings/__tests__/page.test.tsx
@@ -1,17 +1,164 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import ProfileSettingsPage from '../page';
+import type { ProfilePayload } from '../../../../lib/profile';
 import { OPT_OUT_KEY } from '../../../../lib/track';
 
 /**
- * Legal remediation E7a — the analytics opt-out toggle the Privacy
- * Policy promises lives at /profile/settings. It must read + write the
- * same localStorage flag buildWebTracker honors.
+ * The account page shows every dietary preference and edits it in place
+ * (plus the legal-remediation E7a analytics opt-out that already lived
+ * here). The load-bearing correctness property: because the profile
+ * PATCH replaces each array it receives wholesale, an edit must submit
+ * the full remaining set — removing one avoid ingredient must send the
+ * OTHER ids, never an empty/partial array that silently wipes the
+ * safety filter.
+ */
+
+const mockReplace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+const mockFetchProfile = vi.fn();
+const mockUpdateProfile = vi.fn();
+vi.mock('../../../../lib/profile', () => {
+  // Defined inside the hoisted factory — a top-level class can't be
+  // referenced here (only `mock`-prefixed vars are hoist-exempt).
+  class NotSignedInError extends Error {}
+  return {
+    fetchProfile: (...a: unknown[]) => mockFetchProfile(...a),
+    updateProfile: (...a: unknown[]) => mockUpdateProfile(...a),
+    NotSignedInError,
+  };
+});
+import { NotSignedInError } from '../../../../lib/profile';
+
+const mockFetchDietaryProfiles = vi.fn();
+const mockSearchIngredients = vi.fn();
+vi.mock('../../../../lib/onboarding', () => ({
+  fetchDietaryProfiles: (...a: unknown[]) => mockFetchDietaryProfiles(...a),
+  searchIngredients: (...a: unknown[]) => mockSearchIngredients(...a),
+}));
+
+import ProfileSettingsPage from '../page';
+
+const PROFILE: ProfilePayload = {
+  avoid_ingredient_ids: ['ing-cheese', 'ing-wheat'],
+  avoid_tag_ids: ['tag-fried'],
+  prefer_tag_ids: [],
+  liked_ingredient_ids: [],
+  liked_tag_ids: ['tag-thai'],
+  disliked_ingredient_ids: [],
+  disliked_tag_ids: [],
+  avoid_ingredients: [
+    { id: 'ing-cheese', slug: 'dairy-cheese', name: 'Cheese' },
+    { id: 'ing-wheat', slug: 'wheat', name: 'Wheat' },
+  ],
+  avoid_tags: [{ id: 'tag-fried', slug: 'prep-fried', name: 'Fried', family: 'prep' }],
+  prefer_tags: [],
+  liked_ingredients: [],
+  liked_tags: [{ id: 'tag-thai', slug: 'cuisine-thai', name: 'Thai', family: 'cuisine' }],
+  disliked_ingredients: [],
+  disliked_tags: [],
+  strictness: 'balanced',
+  primary_dietary_profile: { id: 'dp-vegan', slug: 'vegan', name: 'Vegan' },
+  disclaimer_acknowledged_at: '2026-07-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  mockReplace.mockReset();
+  mockFetchProfile.mockReset().mockResolvedValue(structuredClone(PROFILE));
+  mockUpdateProfile.mockReset().mockResolvedValue(structuredClone(PROFILE));
+  mockFetchDietaryProfiles.mockReset().mockResolvedValue([
+    { slug: 'vegan', name: 'Vegan', description: 'No animal products' },
+    { slug: 'keto', name: 'Keto', description: 'Low carb' },
+  ]);
+  mockSearchIngredients.mockReset().mockResolvedValue([]);
+});
+
+afterEach(() => localStorage.clear());
+
+describe('ProfileSettingsPage — dietary preferences', () => {
+  it('renders the current preferences with resolved names', async () => {
+    render(<ProfileSettingsPage />);
+
+    // Avoid ingredients by NAME (not UUID), preset, strictness, taste.
+    expect(await screen.findByText('Cheese')).toBeInTheDocument();
+    expect(screen.getByText('Wheat')).toBeInTheDocument();
+    expect(screen.getByTestId('pref-avoid-tags')).toHaveTextContent('Fried');
+    expect(screen.getByTestId('pref-preset')).toHaveTextContent('Vegan');
+    expect(screen.getByTestId('pref-taste')).toHaveTextContent('Thai');
+    expect(screen.getByTestId('set-strictness-balanced')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('changes strictness via a partial patch', async () => {
+    render(<ProfileSettingsPage />);
+    fireEvent.click(await screen.findByTestId('set-strictness-strict'));
+
+    await waitFor(() =>
+      expect(mockUpdateProfile).toHaveBeenCalledWith({ strictness: 'strict' }),
+    );
+  });
+
+  it('removing an avoid ingredient sends the REMAINING ids (never wipes the list)', async () => {
+    render(<ProfileSettingsPage />);
+    fireEvent.click(await screen.findByTestId('remove-avoid-ingredient-dairy-cheese'));
+
+    await waitFor(() =>
+      expect(mockUpdateProfile).toHaveBeenCalledWith({ avoid_ingredient_ids: ['ing-wheat'] }),
+    );
+  });
+
+  it('removing an avoid tag sends the remaining tag ids', async () => {
+    render(<ProfileSettingsPage />);
+    fireEvent.click(await screen.findByTestId('remove-avoid-tag-prep-fried'));
+
+    await waitFor(() => expect(mockUpdateProfile).toHaveBeenCalledWith({ avoid_tag_ids: [] }));
+  });
+
+  it('applies a dietary preset additively by slug', async () => {
+    render(<ProfileSettingsPage />);
+    fireEvent.click(await screen.findByTestId('preset-toggle'));
+    fireEvent.click(await screen.findByTestId('apply-preset-keto'));
+
+    await waitFor(() =>
+      expect(mockUpdateProfile).toHaveBeenCalledWith({ dietary_profile_slug: 'keto' }),
+    );
+  });
+
+  it('adds a searched ingredient onto the existing avoid list', async () => {
+    mockSearchIngredients.mockResolvedValue([
+      { id: 'ing-peanut', slug: 'peanut', name: 'Peanut', path: 'peanut', aliases: [], allergen: true },
+    ]);
+    render(<ProfileSettingsPage />);
+    fireEvent.change(await screen.findByLabelText('avoid-ingredient-search'), {
+      target: { value: 'peanut' },
+    });
+
+    fireEvent.click(await screen.findByTestId('add-avoid-ingredient-peanut'));
+    await waitFor(() =>
+      expect(mockUpdateProfile).toHaveBeenCalledWith({
+        avoid_ingredient_ids: ['ing-cheese', 'ing-wheat', 'ing-peanut'],
+      }),
+    );
+  });
+
+  it('redirects to /login when the profile load is unauthenticated', async () => {
+    mockFetchProfile.mockRejectedValue(new NotSignedInError());
+    render(<ProfileSettingsPage />);
+
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith('/login?next=%2Fprofile%2Fsettings'),
+    );
+  });
+});
+
+/**
+ * Legal remediation E7a — the analytics opt-out toggle must read + write
+ * the same localStorage flag buildWebTracker honors. (Pre-existing
+ * behavior; unchanged by the preferences work.)
  */
 describe('ProfileSettingsPage — analytics toggle', () => {
-  beforeEach(() => localStorage.clear());
-  afterEach(() => localStorage.clear());
-
   it('defaults to analytics-on (no opt-out flag set)', async () => {
     render(<ProfileSettingsPage />);
     const toggle = (await screen.findByLabelText('analytics-opt-in')) as HTMLInputElement;

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -168,7 +168,12 @@ function PreferencesSection() {
         onRemove={(id) => save({ avoid_tag_ids: profile.avoid_tag_ids.filter((x) => x !== id) })}
       />
 
-      <TasteSubsection liked={profile.liked_tags} disliked={profile.disliked_tags} />
+      <TasteSubsection
+        likedTags={profile.liked_tags}
+        likedIngredients={profile.liked_ingredients}
+        dislikedTags={profile.disliked_tags}
+        dislikedIngredients={profile.disliked_ingredients}
+      />
 
       <p className="mt-bw-6 text-bw-xs text-zinc-400" data-testid="disclaimer-status">
         {profile.disclaimer_acknowledged_at
@@ -431,12 +436,20 @@ function AvoidTagsSubsection({
 }
 
 function TasteSubsection({
-  liked,
-  disliked,
+  likedTags,
+  likedIngredients,
+  dislikedTags,
+  dislikedIngredients,
 }: {
-  liked: ProfilePayload['liked_tags'];
-  disliked: ProfilePayload['disliked_tags'];
+  likedTags: ProfilePayload['liked_tags'];
+  likedIngredients: ProfilePayload['liked_ingredients'];
+  dislikedTags: ProfilePayload['disliked_tags'];
+  dislikedIngredients: ProfilePayload['disliked_ingredients'];
 }) {
+  // Taste covers both tags (cuisines/flavors) and specific ingredients;
+  // show them together per love/pass row.
+  const love = [...likedTags, ...likedIngredients];
+  const pass = [...dislikedTags, ...dislikedIngredients];
   return (
     <div className="mt-bw-6" data-testid="pref-taste">
       <SubsectionHeader
@@ -444,8 +457,8 @@ function TasteSubsection({
         hint="Soft signals that rank your Top Picks — they never hide safe food."
       />
       <div className="mt-bw-3 space-y-bw-2">
-        <TasteRow label="Love" tone="text-ok" items={liked} />
-        <TasteRow label="Pass" tone="text-bite" items={disliked} />
+        <TasteRow label="Love" tone="text-ok" items={love} />
+        <TasteRow label="Pass" tone="text-bite" items={pass} />
       </div>
       {/* Editing taste reuses the existing "Improve my picks" flow so the
           love/pass cycling logic lives in one place. */}
@@ -467,7 +480,7 @@ function TasteRow({
 }: {
   label: string;
   tone: string;
-  items: ProfilePayload['liked_tags'];
+  items: Array<{ id: string; name: string }>;
 }) {
   return (
     <div className="flex flex-wrap items-center gap-bw-2">

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -1,7 +1,494 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { DietaryPreset, Strictness } from '@biteworthy/filter-engine';
 import { OPT_OUT_KEY } from '../../../lib/track';
+import {
+  fetchProfile,
+  updateProfile,
+  NotSignedInError,
+  type ProfilePatch,
+  type ProfilePayload,
+} from '../../../lib/profile';
+import {
+  fetchDietaryProfiles,
+  searchIngredients,
+  type IngredientSearchResult,
+} from '../../../lib/onboarding';
+
+/**
+ * The account page. Shows every dietary preference the profile stores
+ * — presets, strictness, avoid lists, taste signals — and lets the
+ * user change them in place (previously they could only be set once,
+ * in the onboarding wizard). Plus the legal-remediation analytics
+ * opt-out that already lived here.
+ *
+ * Every edit is a partial PATCH: the Rails endpoint replaces only the
+ * arrays it receives, so changing one preference never disturbs the
+ * others. Each array we send IS replaced wholesale, so we send the
+ * full canonical array rebuilt from the loaded profile.
+ */
+export default function ProfileSettingsPage() {
+  return (
+    <main className="mx-auto max-w-2xl px-bw-6 pt-bw-12 pb-bw-16">
+      <h1 className="text-bw-2xl font-bold text-zinc-900">Account</h1>
+      <PreferencesSection />
+      <AnalyticsSection />
+    </main>
+  );
+}
+
+const STRICTNESSES: Strictness[] = ['relaxed', 'balanced', 'strict'];
+const STRICTNESS_BLURB: Record<Strictness, string> = {
+  relaxed: 'Show items even if some ingredients are inferred.',
+  balanced: 'Hide items where the avoid match is confident.',
+  strict: 'Also hide items the AI marked suggested or inferred.',
+};
+
+function PreferencesSection() {
+  const router = useRouter();
+  const [profile, setProfile] = useState<ProfilePayload | null>(null);
+  const [presets, setPresets] = useState<DietaryPreset[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchProfile()
+      .then(setProfile)
+      .catch((e) => {
+        if (e instanceof NotSignedInError) {
+          router.replace(`/login?next=${encodeURIComponent('/profile/settings')}`);
+          return;
+        }
+        setLoadError((e as Error).message);
+      });
+  }, [router]);
+
+  useEffect(() => {
+    fetchDietaryProfiles()
+      .then(setPresets)
+      .catch(() => {
+        // Presets are optional sugar — a load failure just hides the picker.
+      });
+  }, []);
+
+  // Persist a partial patch, then adopt the returned payload so the
+  // resolved names (e.g. a just-added ingredient) stay in sync.
+  const save = async (patch: ProfilePatch) => {
+    try {
+      setSaving(true);
+      setSaveError(null);
+      const updated = await updateProfile(patch);
+      setProfile(updated);
+    } catch (e) {
+      if (e instanceof NotSignedInError) {
+        router.replace(`/login?next=${encodeURIComponent('/profile/settings')}`);
+        return;
+      }
+      setSaveError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <section className="mt-bw-8" data-testid="preferences-error">
+        <h2 className="text-bw-lg font-bold text-zinc-900">Dietary preferences</h2>
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          Could not load your preferences — {loadError}
+        </p>
+      </section>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <section className="mt-bw-8">
+        <h2 className="text-bw-lg font-bold text-zinc-900">Dietary preferences</h2>
+        <p className="mt-bw-3 text-bw-sm text-zinc-500" data-testid="preferences-loading">
+          Loading your preferences…
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mt-bw-8" data-testid="preferences">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-bw-lg font-bold text-zinc-900">Dietary preferences</h2>
+        <span
+          className="text-bw-xs text-zinc-400"
+          data-testid="preferences-saving"
+          aria-live="polite"
+        >
+          {saving ? 'Saving…' : ''}
+        </span>
+      </div>
+
+      {saveError && (
+        <p
+          className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark"
+          data-testid="preferences-save-error"
+        >
+          {saveError}
+        </p>
+      )}
+
+      <PresetSubsection
+        current={profile.primary_dietary_profile}
+        presets={presets}
+        disabled={saving}
+        onApply={(slug) => save({ dietary_profile_slug: slug })}
+      />
+
+      <StrictnessSubsection
+        active={profile.strictness}
+        disabled={saving}
+        onPick={(strictness) => save({ strictness })}
+      />
+
+      <AvoidIngredientsSubsection
+        items={profile.avoid_ingredients}
+        disabled={saving}
+        onRemove={(id) =>
+          save({ avoid_ingredient_ids: profile.avoid_ingredient_ids.filter((x) => x !== id) })
+        }
+        onAdd={(id) => {
+          if (profile.avoid_ingredient_ids.includes(id)) return;
+          save({ avoid_ingredient_ids: [...profile.avoid_ingredient_ids, id] });
+        }}
+      />
+
+      <AvoidTagsSubsection
+        items={profile.avoid_tags}
+        disabled={saving}
+        onRemove={(id) => save({ avoid_tag_ids: profile.avoid_tag_ids.filter((x) => x !== id) })}
+      />
+
+      <TasteSubsection liked={profile.liked_tags} disliked={profile.disliked_tags} />
+
+      <p className="mt-bw-6 text-bw-xs text-zinc-400" data-testid="disclaimer-status">
+        {profile.disclaimer_acknowledged_at
+          ? `Allergen disclaimer accepted on ${new Date(profile.disclaimer_acknowledged_at).toLocaleDateString()}.`
+          : 'You have not accepted the allergen disclaimer yet.'}
+      </p>
+    </section>
+  );
+}
+
+// ─── Subsections ──────────────────────────────────────────────────
+
+function SubsectionHeader({ title, hint }: { title: string; hint: string }) {
+  return (
+    <>
+      <h3 className="text-bw-base font-semibold text-zinc-800">{title}</h3>
+      <p className="mt-bw-1 text-bw-sm text-zinc-500">{hint}</p>
+    </>
+  );
+}
+
+function RemovableChip({
+  label,
+  onRemove,
+  disabled,
+  testId,
+}: {
+  label: string;
+  onRemove: () => void;
+  disabled: boolean;
+  testId: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-bw-2 rounded-bw-pill border border-zinc-200 bg-white py-bw-1 pl-bw-3 pr-bw-2 text-bw-sm text-zinc-800">
+      {label}
+      <button
+        type="button"
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label={`Remove ${label}`}
+        data-testid={testId}
+        className="text-zinc-400 hover:text-bite disabled:opacity-40"
+      >
+        ✕
+      </button>
+    </span>
+  );
+}
+
+function PresetSubsection({
+  current,
+  presets,
+  disabled,
+  onApply,
+}: {
+  current: ProfilePayload['primary_dietary_profile'];
+  presets: DietaryPreset[];
+  disabled: boolean;
+  onApply: (slug: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-bw-6" data-testid="pref-preset">
+      <SubsectionHeader
+        title="Diet preset"
+        hint="Applying a preset adds its avoid rules on top of your lists — it never removes what you already chose."
+      />
+      <p className="mt-bw-2 text-bw-sm text-zinc-700">
+        Current: <span className="font-semibold">{current ? current.name : 'None'}</span>
+      </p>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        data-testid="preset-toggle"
+        className="mt-bw-2 text-bw-sm font-semibold text-bite hover:text-bite-dark"
+      >
+        {open ? 'Hide presets' : 'Apply a preset'}
+      </button>
+      {open && presets.length > 0 && (
+        <div className="mt-bw-3 grid grid-cols-1 gap-bw-2 sm:grid-cols-2">
+          {presets.map((p) => (
+            <button
+              key={p.slug}
+              type="button"
+              disabled={disabled}
+              data-testid={`apply-preset-${p.slug}`}
+              onClick={() => onApply(p.slug)}
+              className="rounded-bw-md border border-zinc-200 bg-white p-bw-3 text-left transition hover:border-zinc-300 disabled:opacity-50"
+            >
+              <p className="font-bold text-zinc-900">{p.name}</p>
+              <p className="mt-1 text-bw-sm text-zinc-500">{p.description}</p>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StrictnessSubsection({
+  active,
+  disabled,
+  onPick,
+}: {
+  active: Strictness;
+  disabled: boolean;
+  onPick: (s: Strictness) => void;
+}) {
+  return (
+    <div className="mt-bw-6" data-testid="pref-strictness">
+      <SubsectionHeader title="Strictness" hint="How aggressively we hide items we're unsure about." />
+      <div className="mt-bw-3 flex flex-col gap-bw-2">
+        {STRICTNESSES.map((s) => {
+          const selected = active === s;
+          return (
+            <button
+              key={s}
+              type="button"
+              disabled={disabled}
+              aria-pressed={selected}
+              data-testid={`set-strictness-${s}`}
+              onClick={() => onPick(s)}
+              className={[
+                'rounded-bw-md border p-bw-3 text-left transition disabled:opacity-50',
+                selected ? 'border-bite bg-bite-light' : 'border-zinc-200 bg-white hover:border-zinc-300',
+              ].join(' ')}
+            >
+              <p className={['font-bold', selected ? 'text-bite-dark' : 'text-zinc-900'].join(' ')}>
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </p>
+              <p className={['mt-1 text-bw-sm', selected ? 'text-bite-dark' : 'text-zinc-500'].join(' ')}>
+                {STRICTNESS_BLURB[s]}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function AvoidIngredientsSubsection({
+  items,
+  disabled,
+  onRemove,
+  onAdd,
+}: {
+  items: ProfilePayload['avoid_ingredients'];
+  disabled: boolean;
+  onRemove: (id: string) => void;
+  onAdd: (id: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<IngredientSearchResult[]>([]);
+
+  useEffect(() => {
+    if (query.trim().length === 0) {
+      setResults([]);
+      return;
+    }
+    const handle = setTimeout(() => {
+      searchIngredients(query)
+        .then(setResults)
+        .catch(() => setResults([]));
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const addedIds = new Set(items.map((i) => i.id));
+
+  return (
+    <div className="mt-bw-6" data-testid="pref-avoid-ingredients">
+      <SubsectionHeader
+        title="Avoid ingredients"
+        hint="Items containing these are hidden. This is your hard safety filter."
+      />
+      {items.length > 0 ? (
+        <div className="mt-bw-3 flex flex-wrap gap-bw-2">
+          {items.map((i) => (
+            <RemovableChip
+              key={i.id}
+              label={i.name}
+              disabled={disabled}
+              onRemove={() => onRemove(i.id)}
+              testId={`remove-avoid-ingredient-${i.slug}`}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-bw-3 text-bw-sm text-zinc-400">None yet.</p>
+      )}
+
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search ingredients to avoid (e.g. 'cilantro')"
+        aria-label="avoid-ingredient-search"
+        className="mt-bw-3 w-full rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-base"
+      />
+      {results.length > 0 && (
+        <ul className="mt-bw-2 divide-y divide-zinc-100">
+          {results.map((r) => {
+            const added = addedIds.has(r.id);
+            return (
+              <li key={r.id}>
+                <button
+                  type="button"
+                  disabled={disabled || added}
+                  onClick={() => onAdd(r.id)}
+                  data-testid={`add-avoid-ingredient-${r.slug}`}
+                  className="flex w-full items-center justify-between py-bw-2 text-left disabled:opacity-50"
+                >
+                  <span className="text-bw-base text-zinc-900">{r.name}</span>
+                  <span className={['font-semibold', added ? 'text-ok' : 'text-bite'].join(' ')}>
+                    {added ? '✓ added' : '+ add'}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function AvoidTagsSubsection({
+  items,
+  disabled,
+  onRemove,
+}: {
+  items: ProfilePayload['avoid_tags'];
+  disabled: boolean;
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <div className="mt-bw-6" data-testid="pref-avoid-tags">
+      <SubsectionHeader
+        title="Avoid categories"
+        hint="Whole tags you avoid (e.g. a preparation or allergen group). Usually added by presets."
+      />
+      {items.length > 0 ? (
+        <div className="mt-bw-3 flex flex-wrap gap-bw-2">
+          {items.map((t) => (
+            <RemovableChip
+              key={t.id}
+              label={t.name}
+              disabled={disabled}
+              onRemove={() => onRemove(t.id)}
+              testId={`remove-avoid-tag-${t.slug}`}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-bw-3 text-bw-sm text-zinc-400">None yet.</p>
+      )}
+    </div>
+  );
+}
+
+function TasteSubsection({
+  liked,
+  disliked,
+}: {
+  liked: ProfilePayload['liked_tags'];
+  disliked: ProfilePayload['disliked_tags'];
+}) {
+  return (
+    <div className="mt-bw-6" data-testid="pref-taste">
+      <SubsectionHeader
+        title="Taste"
+        hint="Soft signals that rank your Top Picks — they never hide safe food."
+      />
+      <div className="mt-bw-3 space-y-bw-2">
+        <TasteRow label="Love" tone="text-ok" items={liked} />
+        <TasteRow label="Pass" tone="text-bite" items={disliked} />
+      </div>
+      {/* Editing taste reuses the existing "Improve my picks" flow so the
+          love/pass cycling logic lives in one place. */}
+      <a
+        href="/onboarding?step=taste"
+        data-testid="edit-taste-link"
+        className="mt-bw-3 inline-block text-bw-sm font-semibold text-bite hover:text-bite-dark"
+      >
+        Edit taste →
+      </a>
+    </div>
+  );
+}
+
+function TasteRow({
+  label,
+  tone,
+  items,
+}: {
+  label: string;
+  tone: string;
+  items: ProfilePayload['liked_tags'];
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-bw-2">
+      <span className={['text-bw-sm font-semibold', tone].join(' ')}>{label}:</span>
+      {items.length > 0 ? (
+        items.map((t) => (
+          <span
+            key={t.id}
+            className="rounded-bw-pill border border-zinc-200 bg-white px-bw-3 py-bw-1 text-bw-sm text-zinc-700"
+          >
+            {t.name}
+          </span>
+        ))
+      ) : (
+        <span className="text-bw-sm text-zinc-400">none</span>
+      )}
+    </div>
+  );
+}
+
+// ─── Analytics opt-out (legal remediation E7a — pre-existing) ──────
 
 /**
  * Legal remediation E7a — the analytics opt-out the Privacy Policy
@@ -15,7 +502,7 @@ import { OPT_OUT_KEY } from '../../../lib/track';
  * regardless (see packages/analytics — profile_set carries no health
  * fields).
  */
-export default function ProfileSettingsPage() {
+function AnalyticsSection() {
   // null until we've read localStorage (avoids an SSR/client mismatch).
   const [optedOut, setOptedOut] = useState<boolean | null>(null);
 
@@ -40,40 +527,36 @@ export default function ProfileSettingsPage() {
   const analyticsOn = optedOut === false;
 
   return (
-    <main className="mx-auto max-w-2xl px-bw-6 pt-bw-12 pb-bw-16">
-      <h1 className="text-bw-2xl font-bold text-zinc-900">Settings</h1>
+    <section className="mt-bw-8 border-t border-zinc-100 pt-bw-8">
+      <h2 className="text-bw-lg font-bold text-zinc-900">Product analytics</h2>
+      <p className="mt-bw-2 text-bw-sm text-zinc-600">
+        We use privacy-respecting product analytics to understand the launch funnel. Events are
+        never tied to your dietary profile — we don’t send what you avoid, your presets, or your
+        strictness. We also honor your browser’s Do-Not-Track signal automatically.
+      </p>
 
-      <section className="mt-bw-8">
-        <h2 className="text-bw-lg font-bold text-zinc-900">Product analytics</h2>
-        <p className="mt-bw-2 text-bw-sm text-zinc-600">
-          We use privacy-respecting product analytics to understand the launch funnel. Events are
-          never tied to your dietary profile — we don’t send what you avoid, your presets, or your
-          strictness. We also honor your browser’s Do-Not-Track signal automatically.
-        </p>
+      <label className="mt-bw-4 flex items-center justify-between rounded-bw-md border border-zinc-200 p-bw-4">
+        <span className="text-bw-base font-semibold text-zinc-800">
+          Allow anonymous product analytics
+        </span>
+        <input
+          type="checkbox"
+          role="switch"
+          aria-label="analytics-opt-in"
+          disabled={optedOut === null}
+          checked={analyticsOn}
+          onChange={(e) => setOptOut(!e.target.checked)}
+          className="h-5 w-5"
+        />
+      </label>
 
-        <label className="mt-bw-4 flex items-center justify-between rounded-bw-md border border-zinc-200 p-bw-4">
-          <span className="text-bw-base font-semibold text-zinc-800">
-            Allow anonymous product analytics
-          </span>
-          <input
-            type="checkbox"
-            role="switch"
-            aria-label="analytics-opt-in"
-            disabled={optedOut === null}
-            checked={analyticsOn}
-            onChange={(e) => setOptOut(!e.target.checked)}
-            className="h-5 w-5"
-          />
-        </label>
-
-        <p className="mt-bw-2 text-bw-xs text-zinc-500" data-testid="analytics-state">
-          {optedOut === null
-            ? 'Loading…'
-            : analyticsOn
-              ? 'Analytics are on. Turning this off takes effect on your next page load.'
-              : 'Analytics are off. You’ve opted out on this device.'}
-        </p>
-      </section>
-    </main>
+      <p className="mt-bw-2 text-bw-xs text-zinc-500" data-testid="analytics-state">
+        {optedOut === null
+          ? 'Loading…'
+          : analyticsOn
+            ? 'Analytics are on. Turning this off takes effect on your next page load.'
+            : 'Analytics are off. You’ve opted out on this device.'}
+      </p>
+    </section>
   );
 }

--- a/apps/web/src/lib/profile.ts
+++ b/apps/web/src/lib/profile.ts
@@ -1,0 +1,78 @@
+/**
+ * Read + write helpers for the account page's dietary preferences.
+ *
+ * Both go through the Next `/api/profile` proxy (not the direct `api`
+ * helper), so the HttpOnly `bw_session` JWT is attached server-side
+ * and never reaches JS — same path as `saveProfile` in `./onboarding`.
+ *
+ * `updateProfile` sends a PARTIAL patch: the Rails endpoint only
+ * replaces the arrays present in the body, so changing strictness or
+ * one avoid list never touches the others. Each array it DOES send is
+ * replaced wholesale, so callers pass the full canonical array (built
+ * from the current profile loaded via `fetchProfile`).
+ */
+import type { ProfilePayload } from '@biteworthy/api-types';
+import type { Strictness } from '@biteworthy/filter-engine';
+
+export type { ProfilePayload };
+
+/** The fields the account page can patch. All optional; omit to leave untouched. */
+export interface ProfilePatch {
+  strictness?: Strictness;
+  avoid_ingredient_ids?: string[];
+  avoid_tag_ids?: string[];
+  prefer_tag_ids?: string[];
+  liked_ingredient_ids?: string[];
+  liked_tag_ids?: string[];
+  disliked_ingredient_ids?: string[];
+  disliked_tag_ids?: string[];
+  /** Additive — unions the preset's avoid lists onto the stored ones. */
+  dietary_profile_slug?: string;
+}
+
+/** Raised on a 401 so callers can bounce to /login. */
+export class NotSignedInError extends Error {
+  constructor() {
+    super('not signed in');
+    this.name = 'NotSignedInError';
+  }
+}
+
+async function readJsonOrThrow(res: Response, action: string): Promise<ProfilePayload> {
+  if (res.status === 401) throw new NotSignedInError();
+  if (!res.ok) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // ignore — non-JSON error body
+    }
+    throw new Error(`${action} failed: ${res.status} ${JSON.stringify(body)}`);
+  }
+  return (await res.json()) as ProfilePayload;
+}
+
+export async function fetchProfile(
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<ProfilePayload> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/profile', {
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+  return readJsonOrThrow(res, 'fetchProfile');
+}
+
+export async function updateProfile(
+  patch: ProfilePatch,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<ProfilePayload> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/profile', {
+    method: 'PATCH',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  return readJsonOrThrow(res, 'updateProfile');
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -885,6 +885,57 @@
           }
         }
       },
+      "IngredientRef": {
+        "type": "object",
+        "required": [
+          "id",
+          "slug",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "TagRef": {
+        "type": "object",
+        "required": [
+          "id",
+          "slug",
+          "name",
+          "family"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "family": {
+            "type": "string",
+            "enum": [
+              "diet",
+              "allergen",
+              "cuisine",
+              "prep",
+              "flavor"
+            ]
+          }
+        }
+      },
       "ProfilePayload": {
         "type": "object",
         "required": [
@@ -895,6 +946,13 @@
           "liked_tag_ids",
           "disliked_ingredient_ids",
           "disliked_tag_ids",
+          "avoid_ingredients",
+          "avoid_tags",
+          "prefer_tags",
+          "liked_ingredients",
+          "liked_tags",
+          "disliked_ingredients",
+          "disliked_tags",
           "strictness",
           "primary_dietary_profile",
           "disclaimer_acknowledged_at"
@@ -947,6 +1005,48 @@
             "items": {
               "type": "string",
               "format": "uuid"
+            }
+          },
+          "avoid_ingredients": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IngredientRef"
+            }
+          },
+          "avoid_tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            }
+          },
+          "prefer_tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            }
+          },
+          "liked_ingredients": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IngredientRef"
+            }
+          },
+          "liked_tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            }
+          },
+          "disliked_ingredients": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IngredientRef"
+            }
+          },
+          "disliked_tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
             }
           },
           "strictness": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -948,7 +948,6 @@
           "disliked_tag_ids",
           "avoid_ingredients",
           "avoid_tags",
-          "prefer_tags",
           "liked_ingredients",
           "liked_tags",
           "disliked_ingredients",
@@ -1014,12 +1013,6 @@
             }
           },
           "avoid_tags": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TagRef"
-            }
-          },
-          "prefer_tags": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/TagRef"

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,26 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Account page PR-1: dietary preferences (show + edit). Branch `feat/account-preferences`.
+
+- User-requested rework of `/profile/settings` (the "Account" nav link): it now
+  shows **all** dietary preferences with resolved names — diet preset, strictness,
+  avoid ingredients/tags, taste love/pass — and edits them in place. Previously
+  they could only be set once, in the onboarding wizard.
+- API: `GET /api/v1/profile` now returns resolved `{id, slug, name}` rows
+  (`avoid_ingredients`, `avoid_tags`, `liked_tags`, …) alongside the raw id arrays
+  the mobile/onboarding clients still read. New `IngredientRef`/`TagRef` swagger
+  components; openapi + api-types regenerated. Web: added the `GET /api/profile`
+  proxy (was PATCH-only) + `lib/profile.ts` (`fetchProfile`/`updateProfile`).
+- Each edit is a **partial** PATCH; the load-bearing property (tested) is that
+  removing one avoid item submits the *remaining* ids, never a wipe — the endpoint
+  replaces each array it receives wholesale. Taste editing links to the existing
+  "Improve my picks" flow. Web vitest 223 (+9); typecheck/lint/codegen green.
+- Part of a 3-PR arc (favorites = restaurants + dishes, and a "my reviews" list are
+  PR-2/PR-3, still to come). ⚠️ Found a local-dev footgun: `apps/api/.env` sets
+  `DATABASE_URL` to production Neon, so `RAILS_ENV=test` rails tasks hit prod — ran
+  specs against a LOCAL `biteworthy_test` via an explicit localhost `DATABASE_URL`.
+
 2026-07-21 — Verify-flow redesign PR-3: verify page UI. Branch `feat/verify-page-redesign`.
 
 - Surfaces the PR-1/PR-2 backend to users. The verify page now shows dishes from

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -537,6 +537,20 @@ export interface components {
         AuthResponse: {
             user: components["schemas"]["UserPayload"];
         };
+        IngredientRef: {
+            /** Format: uuid */
+            id: string;
+            slug: string;
+            name: string;
+        };
+        TagRef: {
+            /** Format: uuid */
+            id: string;
+            slug: string;
+            name: string;
+            /** @enum {string} */
+            family: "diet" | "allergen" | "cuisine" | "prep" | "flavor";
+        };
         ProfilePayload: {
             avoid_ingredient_ids: string[];
             avoid_tag_ids: string[];
@@ -545,6 +559,13 @@ export interface components {
             liked_tag_ids: string[];
             disliked_ingredient_ids: string[];
             disliked_tag_ids: string[];
+            avoid_ingredients: components["schemas"]["IngredientRef"][];
+            avoid_tags: components["schemas"]["TagRef"][];
+            prefer_tags: components["schemas"]["TagRef"][];
+            liked_ingredients: components["schemas"]["IngredientRef"][];
+            liked_tags: components["schemas"]["TagRef"][];
+            disliked_ingredients: components["schemas"]["IngredientRef"][];
+            disliked_tags: components["schemas"]["TagRef"][];
             /** @enum {string} */
             strictness: "relaxed" | "balanced" | "strict";
             primary_dietary_profile: {

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -561,7 +561,6 @@ export interface components {
             disliked_tag_ids: string[];
             avoid_ingredients: components["schemas"]["IngredientRef"][];
             avoid_tags: components["schemas"]["TagRef"][];
-            prefer_tags: components["schemas"]["TagRef"][];
             liked_ingredients: components["schemas"]["IngredientRef"][];
             liked_tags: components["schemas"]["TagRef"][];
             disliked_ingredients: components["schemas"]["IngredientRef"][];

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -25,6 +25,8 @@ import type { components } from './generated';
 export type UserPayload    = components['schemas']['UserPayload'];
 export type AuthResponse   = components['schemas']['AuthResponse'];
 export type ProfilePayload = components['schemas']['ProfilePayload'];
+export type IngredientRef  = components['schemas']['IngredientRef'];
+export type TagRef         = components['schemas']['TagRef'];
 
 /**
  * The shape `filter-engine` cares about — a subset of ProfilePayload


### PR DESCRIPTION
## Summary

- Reworks `/profile/settings` (the "Account" nav link) into a real account page: shows **every** dietary preference with resolved names — diet preset, strictness, avoid ingredients/tags, taste love/pass — and edits them in place. Previously preferences could only be set once, in the onboarding wizard.
- `GET /api/v1/profile` now returns resolved `{id, slug, name}` rows alongside the raw id arrays, so the page renders names without a second lookup (new `IngredientRef`/`TagRef` swagger components; openapi + api-types regenerated).
- Each edit is a **partial** PATCH; the endpoint replaces each array it receives wholesale, so an edit submits the full remaining set — removing one avoid item sends the *remaining* ids, never a wipe (covered by a test). Taste editing reuses the existing "Improve my picks" flow.

First of a 3-PR arc — favorites (restaurants + dishes) and a "my reviews" list follow.
