### PR TITLE
feat(web): account page — "My reviews" list (PR-2)

### DIFF
--- a/apps/api/app/controllers/api/v1/profile_reviews_controller.rb
+++ b/apps/api/app/controllers/api/v1/profile_reviews_controller.rb
@@ -39,6 +39,10 @@ module Api
           item: {
             id:   item.id,
             name: item.name,
+            # Lets the account page skip the link when the dish is no
+            # longer viewable — the public item page is published-only,
+            # so linking a removed/draft item would 404 the author.
+            status: item.status,
             restaurant: {
               id:   item.restaurant_id,
               slug: item.restaurant.slug,

--- a/apps/api/app/controllers/api/v1/profile_reviews_controller.rb
+++ b/apps/api/app/controllers/api/v1/profile_reviews_controller.rb
@@ -1,0 +1,59 @@
+module Api
+  module V1
+    # GET /api/v1/profile/reviews — the caller's own reviews for the
+    # account page, newest first, paginated.
+    #
+    # Unlike the public by-handle feed (UsersController#show, visible
+    # only, capped at 10), this includes the user's HIDDEN reviews and
+    # tells them why (hidden_reason) — it's their own data, and a review
+    # a moderator hid should still be visible to its author. Each row
+    # carries item + restaurant context so the page can link back.
+    #
+    # Authenticated only — private data.
+    class ProfileReviewsController < BaseController
+      DEFAULT_LIMIT = 20
+      MAX_LIMIT     = 100
+
+      def index
+        limit  = page_limit(default: DEFAULT_LIMIT, max: MAX_LIMIT)
+        offset = page_offset
+
+        scope = current_user.reviews
+                            .newest_first
+                            .includes(item: :restaurant, photo_attachment: :blob)
+                            .offset(offset)
+                            .limit(limit)
+
+        render json: {
+          reviews: scope.map { |r| serialize(r) },
+          total:   current_user.reviews.count
+        }
+      end
+
+      private
+
+      def serialize(review)
+        item = review.item
+        {
+          id:   review.id,
+          item: {
+            id:   item.id,
+            name: item.name,
+            restaurant: {
+              id:   item.restaurant_id,
+              slug: item.restaurant.slug,
+              name: item.restaurant.name
+            }
+          },
+          rating:        review.rating,
+          body:          review.body,
+          photo_url:     photo_url_for(review),
+          hidden:        review.hidden?,
+          hidden_reason: review.hidden_reason,
+          created_at:    review.created_at,
+          updated_at:    review.updated_at
+        }
+      end
+    end
+  end
+end

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -54,6 +54,9 @@ Rails.application.routes.draw do
         # Phase 4.8 — "My filtered menus" history (recent restaurant
         # visits with the visible/hidden item counts at view time).
         get :history, to: "profile_history#index"
+        # The caller's own reviews for the account page — includes their
+        # hidden reviews (unlike the public by-handle feed), newest first.
+        get :reviews, to: "profile_reviews#index"
       end
       # Legal remediation E3 — JSON archive of the caller's personal
       # data (Privacy Policy "Access / export your data").

--- a/apps/api/spec/requests/api/v1/profile_reviews_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_reviews_spec.rb
@@ -26,9 +26,21 @@ RSpec.describe "GET /api/v1/profile/reviews", type: :request do
 
     first = body["reviews"].first
     expect(first).to include("rating" => 3, "body" => "Fine.", "hidden" => false, "hidden_reason" => nil)
+    expect(first["item"]).to include("name" => "Bean Burrito", "status" => "published")
     expect(first["item"]["restaurant"]).to include(
       "slug" => restaurant.slug, "name" => "Ninis Taqueria"
     )
+  end
+
+  it "still lists a review whose item was later removed, exposing the item status" do
+    create(:review, user: user, item: taco, rating: 4, body: "was great")
+    taco.update!(status: "removed")
+
+    get "/api/v1/profile/reviews", headers: headers
+
+    body = response.parsed_body
+    expect(body["total"]).to eq(1)
+    expect(body["reviews"].first["item"]).to include("status" => "removed")
   end
 
   it "includes the caller's own HIDDEN reviews and says why (unlike the public feed)" do

--- a/apps/api/spec/requests/api/v1/profile_reviews_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_reviews_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/profile/reviews", type: :request do
+  let(:user)    { create(:user) }
+  let(:headers) { auth_headers_for(user) }
+
+  let(:restaurant) { create(:restaurant, :published, name: "Ninis Taqueria") }
+  let(:taco)   { create(:item, :published, restaurant: restaurant, name: "Carne Asada Taco") }
+  let(:burrito) { create(:item, :published, restaurant: restaurant, name: "Bean Burrito") }
+
+  it "401s anonymously" do
+    get "/api/v1/profile/reviews"
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns the caller's reviews newest-first with item + restaurant context" do
+    create(:review, user: user, item: taco, rating: 5, body: "Best in town.", created_at: 2.days.ago)
+    create(:review, user: user, item: burrito, rating: 3, body: "Fine.", created_at: 1.day.ago)
+
+    get "/api/v1/profile/reviews", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+    expect(body["total"]).to eq(2)
+    expect(body["reviews"].map { |r| r["item"]["name"] }).to eq(["Bean Burrito", "Carne Asada Taco"])
+
+    first = body["reviews"].first
+    expect(first).to include("rating" => 3, "body" => "Fine.", "hidden" => false, "hidden_reason" => nil)
+    expect(first["item"]["restaurant"]).to include(
+      "slug" => restaurant.slug, "name" => "Ninis Taqueria"
+    )
+  end
+
+  it "includes the caller's own HIDDEN reviews and says why (unlike the public feed)" do
+    review = create(:review, user: user, item: taco, body: "hidden one")
+    review.hide!(reason: "spam")
+
+    get "/api/v1/profile/reviews", headers: headers
+
+    body = response.parsed_body
+    expect(body["total"]).to eq(1)
+    expect(body["reviews"].first).to include("hidden" => true, "hidden_reason" => "spam")
+  end
+
+  it "scopes to the current user (no leak across users)" do
+    create(:review, user: user, item: taco)
+    create(:review, user: create(:user), item: burrito)
+
+    get "/api/v1/profile/reviews", headers: headers
+    expect(response.parsed_body["total"]).to eq(1)
+  end
+
+  it "respects limit + offset" do
+    [taco, burrito, create(:item, :published, restaurant: restaurant)].each_with_index do |item, i|
+      create(:review, user: user, item: item, created_at: i.days.ago)
+    end
+
+    get "/api/v1/profile/reviews?limit=1&offset=1", headers: headers
+    expect(response.parsed_body["reviews"].length).to eq(1)
+    expect(response.parsed_body["total"]).to eq(3)
+  end
+end

--- a/apps/web/src/app/api/profile/reviews/route.ts
+++ b/apps/web/src/app/api/profile/reviews/route.ts
@@ -1,0 +1,14 @@
+/**
+ * Proxy GET /api/profile/reviews to Rails with the bw_session cookie's
+ * JWT. Backs the account page's "My reviews" list (the caller's own
+ * reviews, including hidden ones). `no-store` — a stale list would show
+ * a review the user just deleted, or miss one they just wrote.
+ */
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../lib/api-proxy';
+
+export async function GET(request: NextRequest) {
+  return proxyAuthed(`/api/v1/profile/reviews${request.nextUrl.search ?? ''}`, {
+    cache: 'no-store',
+  });
+}

--- a/apps/web/src/app/profile/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/profile/settings/__tests__/page.test.tsx
@@ -20,6 +20,7 @@ vi.mock('next/navigation', () => ({
 
 const mockFetchProfile = vi.fn();
 const mockUpdateProfile = vi.fn();
+const mockFetchMyReviews = vi.fn();
 vi.mock('../../../../lib/profile', () => {
   // Defined inside the hoisted factory — a top-level class can't be
   // referenced here (only `mock`-prefixed vars are hoist-exempt).
@@ -27,6 +28,7 @@ vi.mock('../../../../lib/profile', () => {
   return {
     fetchProfile: (...a: unknown[]) => mockFetchProfile(...a),
     updateProfile: (...a: unknown[]) => mockUpdateProfile(...a),
+    fetchMyReviews: (...a: unknown[]) => mockFetchMyReviews(...a),
     NotSignedInError,
   };
 });
@@ -73,6 +75,7 @@ beforeEach(() => {
     { slug: 'keto', name: 'Keto', description: 'Low carb' },
   ]);
   mockSearchIngredients.mockReset().mockResolvedValue([]);
+  mockFetchMyReviews.mockReset().mockResolvedValue({ reviews: [], total: 0 });
 });
 
 afterEach(() => localStorage.clear());
@@ -151,6 +154,50 @@ describe('ProfileSettingsPage — dietary preferences', () => {
     await waitFor(() =>
       expect(mockReplace).toHaveBeenCalledWith('/login?next=%2Fprofile%2Fsettings'),
     );
+  });
+});
+
+describe('ProfileSettingsPage — my reviews', () => {
+  it('shows an empty state when the user has no reviews', async () => {
+    render(<ProfileSettingsPage />);
+    expect(await screen.findByTestId('my-reviews-empty')).toBeInTheDocument();
+  });
+
+  it('lists the user reviews with restaurant/item context and a hidden badge', async () => {
+    mockFetchMyReviews.mockResolvedValue({
+      total: 2,
+      reviews: [
+        {
+          id: 'rev-1',
+          item: { id: 'item-1', name: 'Carne Asada Taco', restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' } },
+          rating: 5,
+          body: 'Best in town.',
+          photo_url: null,
+          hidden: false,
+          hidden_reason: null,
+          created_at: '2026-07-01T00:00:00Z',
+          updated_at: '2026-07-01T00:00:00Z',
+        },
+        {
+          id: 'rev-2',
+          item: { id: 'item-2', name: 'Bean Burrito', restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' } },
+          rating: 2,
+          body: 'spammy',
+          photo_url: null,
+          hidden: true,
+          hidden_reason: 'spam',
+          created_at: '2026-06-01T00:00:00Z',
+          updated_at: '2026-06-01T00:00:00Z',
+        },
+      ],
+    });
+    render(<ProfileSettingsPage />);
+
+    const first = await screen.findByTestId('my-review-rev-1');
+    expect(first).toHaveTextContent('Carne Asada Taco');
+    expect(first.querySelector('a')).toHaveAttribute('href', '/restaurants/ninis/items/item-1');
+    // The hidden review tells the author why it's hidden.
+    expect(screen.getByTestId('my-review-hidden-rev-2')).toHaveTextContent(/spam/i);
   });
 });
 

--- a/apps/web/src/app/profile/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/profile/settings/__tests__/page.test.tsx
@@ -14,8 +14,11 @@ import { OPT_OUT_KEY } from '../../../../lib/track';
  */
 
 const mockReplace = vi.fn();
+// Stable router object — the real useRouter is referentially stable, so a
+// fresh object per render would spuriously re-fire the [router]-dep effects.
+const mockRouter = { replace: mockReplace };
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: mockReplace }),
+  useRouter: () => mockRouter,
 }));
 
 const mockFetchProfile = vi.fn();
@@ -169,7 +172,12 @@ describe('ProfileSettingsPage — my reviews', () => {
       reviews: [
         {
           id: 'rev-1',
-          item: { id: 'item-1', name: 'Carne Asada Taco', restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' } },
+          item: {
+            id: 'item-1',
+            name: 'Carne Asada Taco',
+            status: 'published',
+            restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+          },
           rating: 5,
           body: 'Best in town.',
           photo_url: null,
@@ -180,7 +188,12 @@ describe('ProfileSettingsPage — my reviews', () => {
         },
         {
           id: 'rev-2',
-          item: { id: 'item-2', name: 'Bean Burrito', restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' } },
+          item: {
+            id: 'item-2',
+            name: 'Bean Burrito',
+            status: 'published',
+            restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+          },
           rating: 2,
           body: 'spammy',
           photo_url: null,
@@ -198,6 +211,68 @@ describe('ProfileSettingsPage — my reviews', () => {
     expect(first.querySelector('a')).toHaveAttribute('href', '/restaurants/ninis/items/item-1');
     // The hidden review tells the author why it's hidden.
     expect(screen.getByTestId('my-review-hidden-rev-2')).toHaveTextContent(/spam/i);
+  });
+
+  it('renders a removed dish as plain text (no dead link) with a note', async () => {
+    mockFetchMyReviews.mockResolvedValue({
+      total: 1,
+      reviews: [
+        {
+          id: 'rev-x',
+          item: {
+            id: 'item-x',
+            name: 'Old Taco',
+            status: 'removed',
+            restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+          },
+          rating: 3,
+          body: null,
+          photo_url: null,
+          hidden: false,
+          hidden_reason: null,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+    });
+    render(<ProfileSettingsPage />);
+
+    const row = await screen.findByTestId('my-review-rev-x');
+    expect(row.querySelector('a')).toBeNull(); // no dead link to a 404
+    expect(row).toHaveTextContent('Old Taco');
+    expect(row).toHaveTextContent(/no longer on the menu/i);
+  });
+
+  it('paginates: a Show more control loads the next page and shows the total', async () => {
+    const mk = (id: string) => ({
+      id,
+      item: {
+        id: `i-${id}`,
+        name: `Dish ${id}`,
+        status: 'published',
+        restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+      },
+      rating: 4,
+      body: null,
+      photo_url: null,
+      hidden: false,
+      hidden_reason: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    mockFetchMyReviews
+      .mockResolvedValueOnce({ reviews: [mk('a')], total: 3 })
+      .mockResolvedValueOnce({ reviews: [mk('b'), mk('c')], total: 3 });
+    render(<ProfileSettingsPage />);
+
+    const more = await screen.findByTestId('my-reviews-load-more');
+    expect(more).toHaveTextContent('Show more (2)');
+    expect(screen.getByTestId('my-reviews').querySelector('h2')).toHaveTextContent('My reviews (3)');
+
+    fireEvent.click(more);
+    await waitFor(() => expect(screen.getByTestId('my-review-c')).toBeInTheDocument());
+    // All three loaded → the control is gone.
+    expect(screen.queryByTestId('my-reviews-load-more')).toBeNull();
   });
 });
 

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -506,26 +506,54 @@ function TasteRow({
 
 // ─── My reviews ───────────────────────────────────────────────────
 
+const MY_REVIEWS_PAGE = 20;
+
 function MyReviewsSection() {
   const router = useRouter();
   const [reviews, setReviews] = useState<MyReview[] | null>(null);
+  const [total, setTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const onError = (e: unknown) => {
+    if (e instanceof NotSignedInError) {
+      router.replace(`/login?next=${encodeURIComponent('/profile/settings')}`);
+      return;
+    }
+    setError((e as Error).message);
+  };
 
   useEffect(() => {
-    fetchMyReviews()
-      .then((r) => setReviews(r.reviews))
-      .catch((e) => {
-        if (e instanceof NotSignedInError) {
-          router.replace(`/login?next=${encodeURIComponent('/profile/settings')}`);
-          return;
-        }
-        setError((e as Error).message);
-      });
+    fetchMyReviews({ limit: MY_REVIEWS_PAGE, offset: 0 })
+      .then((r) => {
+        setReviews(r.reviews);
+        setTotal(r.total);
+      })
+      .catch(onError);
+    // onError closes over `router` only; re-running on router change is fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router]);
+
+  // Offset pagination so a prolific reviewer isn't capped at the first page.
+  const loadMore = async () => {
+    if (!reviews) return;
+    try {
+      setLoadingMore(true);
+      const r = await fetchMyReviews({ limit: MY_REVIEWS_PAGE, offset: reviews.length });
+      setReviews((prev) => [...(prev ?? []), ...r.reviews]);
+      setTotal(r.total);
+    } catch (e) {
+      onError(e);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
 
   return (
     <section className="mt-bw-8 border-t border-zinc-100 pt-bw-8" data-testid="my-reviews">
-      <h2 className="text-bw-lg font-bold text-zinc-900">My reviews</h2>
+      <h2 className="text-bw-lg font-bold text-zinc-900">
+        My reviews{reviews && total > 0 ? ` (${total})` : ''}
+      </h2>
       {error ? (
         <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
           Could not load your reviews — {error}
@@ -539,11 +567,24 @@ function MyReviewsSection() {
           You haven’t written any reviews yet.
         </p>
       ) : (
-        <ul className="mt-bw-4 space-y-bw-3">
-          {reviews.map((r) => (
-            <MyReviewRow key={r.id} review={r} />
-          ))}
-        </ul>
+        <>
+          <ul className="mt-bw-4 space-y-bw-3">
+            {reviews.map((r) => (
+              <MyReviewRow key={r.id} review={r} />
+            ))}
+          </ul>
+          {reviews.length < total && (
+            <button
+              type="button"
+              onClick={loadMore}
+              disabled={loadingMore}
+              data-testid="my-reviews-load-more"
+              className="mt-bw-4 w-full rounded-bw-md border border-zinc-200 py-bw-2 text-bw-sm font-semibold text-zinc-700 hover:border-zinc-300 disabled:opacity-50"
+            >
+              {loadingMore ? 'Loading…' : `Show more (${total - reviews.length})`}
+            </button>
+          )}
+        </>
       )}
     </section>
   );
@@ -551,25 +592,35 @@ function MyReviewsSection() {
 
 function MyReviewRow({ review }: { review: MyReview }) {
   const { item } = review;
+  // The public item page is published-only, so only link a dish that
+  // still resolves — otherwise the author lands on a 404 for their own
+  // review. Encode both segments like every sibling link (slugs are
+  // only presence/uniqueness-validated, not auto-parameterized).
+  const linkable = item.status === 'published';
+  const href = `/restaurants/${encodeURIComponent(item.restaurant.slug)}/items/${encodeURIComponent(item.id)}`;
   return (
     <li
       className="rounded-bw-md border border-zinc-200 p-bw-4"
       data-testid={`my-review-${review.id}`}
     >
       <div className="flex items-baseline justify-between gap-bw-3">
-        <a
-          href={`/restaurants/${item.restaurant.slug}/items/${item.id}`}
-          className="font-semibold text-zinc-900 hover:text-bite"
-        >
-          {item.name}
-        </a>
-        <span className="shrink-0 text-bw-sm text-warn" aria-label={`${review.rating} out of 5`}>
-          {'★'.repeat(review.rating)}
-          {'☆'.repeat(5 - review.rating)}
+        {linkable ? (
+          <a href={href} className="font-semibold text-zinc-900 hover:text-bite">
+            {item.name}
+          </a>
+        ) : (
+          <span className="font-semibold text-zinc-900">{item.name}</span>
+        )}
+        <span className="shrink-0 text-bw-sm" aria-label={`${review.rating} out of 5`}>
+          <span className="text-warn">{'★'.repeat(review.rating)}</span>
+          <span className="text-zinc-300">{'☆'.repeat(5 - review.rating)}</span>
         </span>
       </div>
       <p className="text-bw-sm text-zinc-500">{item.restaurant.name}</p>
       {review.body && <p className="mt-bw-2 text-bw-sm text-zinc-700">{review.body}</p>}
+      {!linkable && (
+        <p className="mt-bw-1 text-bw-xs text-zinc-400">This dish is no longer on the menu.</p>
+      )}
       {review.hidden && (
         <p
           className="mt-bw-2 text-bw-xs font-semibold text-hide"

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -7,9 +7,11 @@ import { OPT_OUT_KEY } from '../../../lib/track';
 import {
   fetchProfile,
   updateProfile,
+  fetchMyReviews,
   NotSignedInError,
   type ProfilePatch,
   type ProfilePayload,
+  type MyReview,
 } from '../../../lib/profile';
 import {
   fetchDietaryProfiles,
@@ -34,6 +36,7 @@ export default function ProfileSettingsPage() {
     <main className="mx-auto max-w-2xl px-bw-6 pt-bw-12 pb-bw-16">
       <h1 className="text-bw-2xl font-bold text-zinc-900">Account</h1>
       <PreferencesSection />
+      <MyReviewsSection />
       <AnalyticsSection />
     </main>
   );
@@ -498,6 +501,84 @@ function TasteRow({
         <span className="text-bw-sm text-zinc-400">none</span>
       )}
     </div>
+  );
+}
+
+// ─── My reviews ───────────────────────────────────────────────────
+
+function MyReviewsSection() {
+  const router = useRouter();
+  const [reviews, setReviews] = useState<MyReview[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchMyReviews()
+      .then((r) => setReviews(r.reviews))
+      .catch((e) => {
+        if (e instanceof NotSignedInError) {
+          router.replace(`/login?next=${encodeURIComponent('/profile/settings')}`);
+          return;
+        }
+        setError((e as Error).message);
+      });
+  }, [router]);
+
+  return (
+    <section className="mt-bw-8 border-t border-zinc-100 pt-bw-8" data-testid="my-reviews">
+      <h2 className="text-bw-lg font-bold text-zinc-900">My reviews</h2>
+      {error ? (
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          Could not load your reviews — {error}
+        </p>
+      ) : reviews === null ? (
+        <p className="mt-bw-3 text-bw-sm text-zinc-500" data-testid="my-reviews-loading">
+          Loading your reviews…
+        </p>
+      ) : reviews.length === 0 ? (
+        <p className="mt-bw-3 text-bw-sm text-zinc-400" data-testid="my-reviews-empty">
+          You haven’t written any reviews yet.
+        </p>
+      ) : (
+        <ul className="mt-bw-4 space-y-bw-3">
+          {reviews.map((r) => (
+            <MyReviewRow key={r.id} review={r} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function MyReviewRow({ review }: { review: MyReview }) {
+  const { item } = review;
+  return (
+    <li
+      className="rounded-bw-md border border-zinc-200 p-bw-4"
+      data-testid={`my-review-${review.id}`}
+    >
+      <div className="flex items-baseline justify-between gap-bw-3">
+        <a
+          href={`/restaurants/${item.restaurant.slug}/items/${item.id}`}
+          className="font-semibold text-zinc-900 hover:text-bite"
+        >
+          {item.name}
+        </a>
+        <span className="shrink-0 text-bw-sm text-warn" aria-label={`${review.rating} out of 5`}>
+          {'★'.repeat(review.rating)}
+          {'☆'.repeat(5 - review.rating)}
+        </span>
+      </div>
+      <p className="text-bw-sm text-zinc-500">{item.restaurant.name}</p>
+      {review.body && <p className="mt-bw-2 text-bw-sm text-zinc-700">{review.body}</p>}
+      {review.hidden && (
+        <p
+          className="mt-bw-2 text-bw-xs font-semibold text-hide"
+          data-testid={`my-review-hidden-${review.id}`}
+        >
+          Hidden by moderation{review.hidden_reason ? ` — ${review.hidden_reason}` : ''}
+        </p>
+      )}
+    </li>
   );
 }
 

--- a/apps/web/src/lib/profile.ts
+++ b/apps/web/src/lib/profile.ts
@@ -13,6 +13,7 @@
  */
 import type { ProfilePayload } from '@biteworthy/api-types';
 import type { Strictness } from '@biteworthy/filter-engine';
+import type { UserReviewItem } from './users';
 
 export type { ProfilePayload };
 
@@ -38,7 +39,7 @@ export class NotSignedInError extends Error {
   }
 }
 
-async function readJsonOrThrow(res: Response, action: string): Promise<ProfilePayload> {
+async function readJsonOrThrow<T>(res: Response, action: string): Promise<T> {
   if (res.status === 401) throw new NotSignedInError();
   if (!res.ok) {
     let body: unknown = null;
@@ -49,7 +50,7 @@ async function readJsonOrThrow(res: Response, action: string): Promise<ProfilePa
     }
     throw new Error(`${action} failed: ${res.status} ${JSON.stringify(body)}`);
   }
-  return (await res.json()) as ProfilePayload;
+  return (await res.json()) as T;
 }
 
 export async function fetchProfile(
@@ -60,7 +61,7 @@ export async function fetchProfile(
     credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
-  return readJsonOrThrow(res, 'fetchProfile');
+  return readJsonOrThrow<ProfilePayload>(res, 'fetchProfile');
 }
 
 export async function updateProfile(
@@ -74,19 +75,20 @@ export async function updateProfile(
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify(patch),
   });
-  return readJsonOrThrow(res, 'updateProfile');
+  return readJsonOrThrow<ProfilePayload>(res, 'updateProfile');
 }
 
 // ─── My reviews (account page) ────────────────────────────────────
 
-/** A row from GET /api/profile/reviews — the caller's own review. */
+/**
+ * A row from GET /api/profile/reviews — the caller's own review. The
+ * item shape is the public `UserReviewItem` plus `status`, which the
+ * account page uses to skip the link for a dish that's no longer
+ * viewable (the public item page is published-only).
+ */
 export interface MyReview {
   id: string;
-  item: {
-    id: string;
-    name: string;
-    restaurant: { id: string; slug: string; name: string };
-  };
+  item: UserReviewItem & { status: string };
   rating: number;
   body: string | null;
   photo_url: string | null;
@@ -103,14 +105,15 @@ export interface MyReviewsResponse {
 }
 
 export async function fetchMyReviews(
-  opts: { fetchImpl?: typeof fetch } = {},
+  opts: { limit?: number; offset?: number; fetchImpl?: typeof fetch } = {},
 ): Promise<MyReviewsResponse> {
-  const { fetchImpl = fetch } = opts;
-  const res = await fetchImpl('/api/profile/reviews', {
+  const { fetchImpl = fetch, limit, offset } = opts;
+  const url = new URL('/api/profile/reviews', 'http://placeholder');
+  if (typeof limit === 'number') url.searchParams.set('limit', String(limit));
+  if (typeof offset === 'number') url.searchParams.set('offset', String(offset));
+  const res = await fetchImpl(`${url.pathname}${url.search}`, {
     credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   });
-  if (res.status === 401) throw new NotSignedInError();
-  if (!res.ok) throw new Error(`fetchMyReviews failed: ${res.status}`);
-  return (await res.json()) as MyReviewsResponse;
+  return readJsonOrThrow<MyReviewsResponse>(res, 'fetchMyReviews');
 }

--- a/apps/web/src/lib/profile.ts
+++ b/apps/web/src/lib/profile.ts
@@ -76,3 +76,41 @@ export async function updateProfile(
   });
   return readJsonOrThrow(res, 'updateProfile');
 }
+
+// ─── My reviews (account page) ────────────────────────────────────
+
+/** A row from GET /api/profile/reviews — the caller's own review. */
+export interface MyReview {
+  id: string;
+  item: {
+    id: string;
+    name: string;
+    restaurant: { id: string; slug: string; name: string };
+  };
+  rating: number;
+  body: string | null;
+  photo_url: string | null;
+  /** True when a moderator hid it; the author still sees it here. */
+  hidden: boolean;
+  hidden_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MyReviewsResponse {
+  reviews: MyReview[];
+  total: number;
+}
+
+export async function fetchMyReviews(
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<MyReviewsResponse> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/profile/reviews', {
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+  if (res.status === 401) throw new NotSignedInError();
+  if (!res.ok) throw new Error(`fetchMyReviews failed: ${res.status}`);
+  return (await res.json()) as MyReviewsResponse;
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,19 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Account page PR-2: "My reviews" list. Branch `feat/account-my-reviews`.
+
+- Adds a **My reviews** section to `/profile/settings`: the caller's own reviews,
+  newest first, each linking back to the dish, with the star rating and — unlike the
+  public by-handle feed — the user's **hidden** reviews shown with the moderation
+  reason. New authed `GET /api/v1/profile/reviews` (`ProfileReviewsController`,
+  paginated, includes hidden own reviews) mirroring `profile/history`'s shape; route
+  under the `resource :profile` block. Hand-written web type (`MyReview` in
+  `lib/profile.ts`) + `GET /api/profile/reviews` proxy, matching the history/users
+  sibling precedent (no rswag — those siblings hand-write too).
+- API request spec 5 ex green; web vitest 225 (+2); typecheck/lint green. PR-3
+  (favorites: restaurants + dishes) is the remaining item.
+
 2026-07-21 — Account page PR-1: dietary preferences (show + edit). Branch `feat/account-preferences`.
 
 - User-requested rework of `/profile/settings` (the "Account" nav link): it now


### PR DESCRIPTION
## Summary

- Adds a **My reviews** section to `/profile/settings`: the caller's own reviews, newest first, each linking back to the dish with its star rating.
- Unlike the public by-handle feed, this includes the user's **hidden** reviews and shows the moderation reason — it's their own data.
- New authed `GET /api/v1/profile/reviews` (paginated, scoped to `current_user`, includes hidden own reviews, item + restaurant context), mirroring `profile/history`.

Second of the 3-PR account-page arc; favorites (restaurants + dishes) is next.
