### PR TITLE
feat(web): account page — favorites for restaurants + dishes (PR-3)

### DIFF
--- a/apps/api/app/controllers/api/v1/favorite_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/favorite_items_controller.rb
@@ -8,6 +8,10 @@ module Api
       def create
         FavoriteItem.find_or_create_by!(user: current_user, item: @item)
         render json: serialize(true), status: :ok
+      rescue ActiveRecord::RecordNotUnique
+        # A concurrent duplicate POST lost the race to the unique index.
+        # The favorite exists either way — stay idempotent (200), not 500.
+        render json: serialize(true), status: :ok
       end
 
       def destroy

--- a/apps/api/app/controllers/api/v1/favorite_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/favorite_items_controller.rb
@@ -1,0 +1,29 @@
+module Api
+  module V1
+    # POST/DELETE /api/v1/items/:id/favorite — toggle a saved dish for
+    # the current user. Mirror of FavoriteRestaurantsController.
+    class FavoriteItemsController < BaseController
+      before_action :load_item
+
+      def create
+        FavoriteItem.find_or_create_by!(user: current_user, item: @item)
+        render json: serialize(true), status: :ok
+      end
+
+      def destroy
+        FavoriteItem.where(user: current_user, item: @item).destroy_all
+        render json: serialize(false), status: :ok
+      end
+
+      private
+
+      def load_item
+        @item = Item.published.find(params[:id])
+      end
+
+      def serialize(active)
+        { item_id: @item.id, favorited: active }
+      end
+    end
+  end
+end

--- a/apps/api/app/controllers/api/v1/favorite_restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/favorite_restaurants_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module V1
+    # POST/DELETE /api/v1/restaurants/:restaurant_id/favorite — toggle a
+    # saved restaurant for the current user. Mirrors
+    # ItemOverridesController: create is idempotent (find_or_create_by!),
+    # destroy is a no-op when absent (where...destroy_all), both echo the
+    # resulting favorited state at 200. Auth + 404 come from BaseController.
+    class FavoriteRestaurantsController < BaseController
+      before_action :load_restaurant
+
+      def create
+        FavoriteRestaurant.find_or_create_by!(user: current_user, restaurant: @restaurant)
+        render json: serialize(true), status: :ok
+      end
+
+      def destroy
+        FavoriteRestaurant.where(user: current_user, restaurant: @restaurant).destroy_all
+        render json: serialize(false), status: :ok
+      end
+
+      private
+
+      def load_restaurant
+        @restaurant = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id])
+      end
+
+      def serialize(active)
+        { restaurant_id: @restaurant.id, favorited: active }
+      end
+    end
+  end
+end

--- a/apps/api/app/controllers/api/v1/favorite_restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/favorite_restaurants_controller.rb
@@ -11,6 +11,10 @@ module Api
       def create
         FavoriteRestaurant.find_or_create_by!(user: current_user, restaurant: @restaurant)
         render json: serialize(true), status: :ok
+      rescue ActiveRecord::RecordNotUnique
+        # A concurrent duplicate POST lost the race to the unique index.
+        # The favorite exists either way — stay idempotent (200), not 500.
+        render json: serialize(true), status: :ok
       end
 
       def destroy

--- a/apps/api/app/controllers/api/v1/items_controller.rb
+++ b/apps/api/app/controllers/api/v1/items_controller.rb
@@ -64,7 +64,9 @@ module Api
         item = Restaurant.published.find_by_id_or_slug!(params[:restaurant_id])
                           .items.published.includes(photo_attachment: :blob).find(params[:id])
         filter = build_filter
-        render json: serialize_item(item, filter, build_label_lookup([item], filter), current_user_override_item_ids([item]), review_counts_for([item]))
+        payload = serialize_item(item, filter, build_label_lookup([item], filter), current_user_override_item_ids([item]), review_counts_for([item]))
+        # `favorited` seeds the detail page's save button. Anonymous → false.
+        render json: payload.merge(favorited: current_user_favorited_item?(item))
       end
 
       private
@@ -285,6 +287,12 @@ module Api
         Set.new(
           UserItemOverride.where(user_id: current_user.id, item_id: ids, never_hide: true).pluck(:item_id)
         )
+      end
+
+      # Whether the signed-in caller has saved this dish (false anonymously).
+      def current_user_favorited_item?(item)
+        return false unless current_user
+        FavoriteItem.exists?(user_id: current_user.id, item_id: item.id)
       end
 
       def filter_summary(filter)

--- a/apps/api/app/controllers/api/v1/profile_favorites_controller.rb
+++ b/apps/api/app/controllers/api/v1/profile_favorites_controller.rb
@@ -1,0 +1,52 @@
+module Api
+  module V1
+    # GET /api/v1/profile/favorites — the caller's saved restaurants and
+    # dishes for the account page, newest first.
+    #
+    # Returns everything (no pagination) — a favorites list is small and
+    # silently capping it would hide saves. Each row carries `status` so
+    # the page can skip the link when the restaurant/dish is no longer
+    # viewable (the public pages are published-only), same as My reviews.
+    #
+    # Authenticated only — private data.
+    class ProfileFavoritesController < BaseController
+      def index
+        restaurants = current_user.favorite_restaurants
+                                  .includes(:restaurant)
+                                  .order(created_at: :desc)
+                                  .map { |f| serialize_restaurant(f.restaurant) }
+
+        items = current_user.favorite_items
+                            .includes(item: :restaurant)
+                            .order(created_at: :desc)
+                            .map { |f| serialize_item(f.item) }
+
+        render json: { restaurants: restaurants, items: items }
+      end
+
+      private
+
+      def serialize_restaurant(restaurant)
+        {
+          id:     restaurant.id,
+          slug:   restaurant.slug,
+          name:   restaurant.name,
+          status: restaurant.status
+        }
+      end
+
+      def serialize_item(item)
+        {
+          id:     item.id,
+          name:   item.name,
+          status: item.status,
+          restaurant: {
+            id:   item.restaurant_id,
+            slug: item.restaurant.slug,
+            name: item.restaurant.name
+          }
+        }
+      end
+    end
+  end
+end

--- a/apps/api/app/controllers/api/v1/profile_favorites_controller.rb
+++ b/apps/api/app/controllers/api/v1/profile_favorites_controller.rb
@@ -41,9 +41,14 @@ module Api
           name:   item.name,
           status: item.status,
           restaurant: {
-            id:   item.restaurant_id,
-            slug: item.restaurant.slug,
-            name: item.restaurant.name
+            id:     item.restaurant_id,
+            slug:   item.restaurant.slug,
+            name:   item.restaurant.name,
+            # The dish page is published-only AND resolves through the
+            # restaurant, so the web needs the restaurant's status too to
+            # decide whether the dish link is safe (a dish stays
+            # 'published' when its restaurant is later closed/unpublished).
+            status: item.restaurant.status
           }
         }
       end

--- a/apps/api/app/controllers/api/v1/restaurants_controller.rb
+++ b/apps/api/app/controllers/api/v1/restaurants_controller.rb
@@ -51,7 +51,8 @@ module Api
 
       def show
         restaurant = Restaurant.published.includes(:city).find_by_id_or_slug!(params[:id])
-        render json: serialize(restaurant)
+        # `favorited` seeds the detail page's save button. Anonymous → false.
+        render json: serialize(restaurant).merge(favorited: current_user_favorited_restaurant?(restaurant))
       end
 
       def create
@@ -144,6 +145,12 @@ module Api
           city:        city.name,
           region:      city.region
         )
+      end
+
+      # Whether the signed-in caller has saved this restaurant (false anonymously).
+      def current_user_favorited_restaurant?(restaurant)
+        return false unless current_user
+        FavoriteRestaurant.exists?(user_id: current_user.id, restaurant_id: restaurant.id)
       end
 
       def serialize(r)

--- a/apps/api/app/models/favorite_item.rb
+++ b/apps/api/app/models/favorite_item.rb
@@ -1,0 +1,6 @@
+class FavoriteItem < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+
+  validates :user_id, uniqueness: { scope: :item_id }
+end

--- a/apps/api/app/models/favorite_restaurant.rb
+++ b/apps/api/app/models/favorite_restaurant.rb
@@ -1,0 +1,6 @@
+class FavoriteRestaurant < ApplicationRecord
+  belongs_to :user
+  belongs_to :restaurant
+
+  validates :user_id, uniqueness: { scope: :restaurant_id }
+end

--- a/apps/api/app/models/item.rb
+++ b/apps/api/app/models/item.rb
@@ -16,6 +16,7 @@ class Item < ApplicationRecord
   has_many :tags,        through: :item_tags
   has_many :reviews,          dependent: :destroy
   has_many :user_item_overrides, dependent: :destroy
+  has_many :favorite_items,   dependent: :destroy
 
   has_one_attached :photo
 

--- a/apps/api/app/models/restaurant.rb
+++ b/apps/api/app/models/restaurant.rb
@@ -12,6 +12,7 @@ class Restaurant < ApplicationRecord
   has_many :menus,         dependent: :destroy
   has_many :menu_sections, through: :menus
   has_many :items,         dependent: :destroy
+  has_many :favorite_restaurants, dependent: :destroy
 
   validates :slug, :name, presence: true
   validates :slug, uniqueness: true

--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -18,6 +18,10 @@ class User < ApplicationRecord
   has_many :user_item_overrides, dependent: :destroy
   has_many :overridden_items, through: :user_item_overrides, source: :item
   has_many :restaurant_visits, dependent: :destroy
+  has_many :favorite_restaurants, dependent: :destroy
+  has_many :favorited_restaurants, through: :favorite_restaurants, source: :restaurant
+  has_many :favorite_items, dependent: :destroy
+  has_many :favorited_items, through: :favorite_items, source: :item
 
   # Legal remediation E2 — back-references with no ON DELETE rule at the
   # DB level. Account deletion would hit a foreign-key violation unless

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -57,6 +57,8 @@ Rails.application.routes.draw do
         # The caller's own reviews for the account page — includes their
         # hidden reviews (unlike the public by-handle feed), newest first.
         get :reviews, to: "profile_reviews#index"
+        # The caller's saved restaurants + dishes for the account page.
+        get :favorites, to: "profile_favorites#index"
       end
       # Legal remediation E3 — JSON archive of the caller's personal
       # data (Privacy Policy "Access / export your data").
@@ -75,6 +77,9 @@ Rails.application.routes.draw do
         # Phase 4.9 — restaurant claim flow.
         post   "claim",        to: "restaurant_claims#create"
         get    "claim/verify", to: "restaurant_claims#verify"
+        # Save/unsave a restaurant (authed).
+        post   "favorite", to: "favorite_restaurants#create"
+        delete "favorite", to: "favorite_restaurants#destroy"
         # Phase 4.10 — owner's pending-suggestion queue.
         resources :suggestions, only: [:index]
       end
@@ -85,6 +90,9 @@ Rails.application.routes.draw do
         member do
           post   :never_hide, to: "item_overrides#create"
           delete :never_hide, to: "item_overrides#destroy"
+          # Save/unsave a dish (authed).
+          post   :favorite, to: "favorite_items#create"
+          delete :favorite, to: "favorite_items#destroy"
         end
         resources :reviews, only: [:index, :create]
         # Phase 4.10 — anyone can suggest a fix.

--- a/apps/api/db/migrate/20260721130000_create_favorite_restaurants.rb
+++ b/apps/api/db/migrate/20260721130000_create_favorite_restaurants.rb
@@ -1,0 +1,14 @@
+class CreateFavoriteRestaurants < ActiveRecord::Migration[8.1]
+  # A user's saved restaurants. Presence of a row = favorited; there is
+  # no mode column (unlike user_item_overrides), so unfavoriting just
+  # deletes the row. Real FKs so restaurant/user deletion cascades at
+  # the DB level (see the E2 integrity note in user.rb).
+  def change
+    create_table :favorite_restaurants, id: :uuid do |t|
+      t.references :user,       type: :uuid, null: false, foreign_key: true
+      t.references :restaurant, type: :uuid, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :favorite_restaurants, [:user_id, :restaurant_id], unique: true
+  end
+end

--- a/apps/api/db/migrate/20260721130001_create_favorite_items.rb
+++ b/apps/api/db/migrate/20260721130001_create_favorite_items.rb
@@ -1,0 +1,12 @@
+class CreateFavoriteItems < ActiveRecord::Migration[8.1]
+  # A user's saved dishes. Mirror of favorite_restaurants — presence of
+  # a row = favorited, real FKs so item/user deletion cascades.
+  def change
+    create_table :favorite_items, id: :uuid do |t|
+      t.references :user, type: :uuid, null: false, foreign_key: true
+      t.references :item, type: :uuid, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :favorite_items, [:user_id, :item_id], unique: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_130001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -113,6 +113,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
     t.text "work_description", null: false
     t.index ["created_at"], name: "index_dmca_notices_on_created_at"
     t.index ["status"], name: "index_dmca_notices_on_status"
+  end
+
+  create_table "favorite_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "item_id", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["item_id"], name: "index_favorite_items_on_item_id"
+    t.index ["user_id", "item_id"], name: "index_favorite_items_on_user_id_and_item_id", unique: true
+    t.index ["user_id"], name: "index_favorite_items_on_user_id"
+  end
+
+  create_table "favorite_restaurants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "restaurant_id", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["restaurant_id"], name: "index_favorite_restaurants_on_restaurant_id"
+    t.index ["user_id", "restaurant_id"], name: "index_favorite_restaurants_on_user_id_and_restaurant_id", unique: true
+    t.index ["user_id"], name: "index_favorite_restaurants_on_user_id"
   end
 
   create_table "hours", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -573,6 +593,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
   add_foreign_key "dietary_profile_ingredients", "ingredients"
   add_foreign_key "dietary_profile_tags", "dietary_profiles"
   add_foreign_key "dietary_profile_tags", "tags"
+  add_foreign_key "favorite_items", "items"
+  add_foreign_key "favorite_items", "users"
+  add_foreign_key "favorite_restaurants", "restaurants"
+  add_foreign_key "favorite_restaurants", "users"
   add_foreign_key "hours", "restaurants"
   add_foreign_key "ingestion_items", "ingestion_runs"
   add_foreign_key "ingestion_items", "items"

--- a/apps/api/spec/factories/favorite_items.rb
+++ b/apps/api/spec/factories/favorite_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite_item do
+    user
+    item
+  end
+end

--- a/apps/api/spec/factories/favorite_restaurants.rb
+++ b/apps/api/spec/factories/favorite_restaurants.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite_restaurant do
+    user
+    restaurant
+  end
+end

--- a/apps/api/spec/models/favorite_item_spec.rb
+++ b/apps/api/spec/models/favorite_item_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe FavoriteItem, type: :model do
+  it "is valid with a user and item" do
+    expect(build(:favorite_item)).to be_valid
+  end
+
+  it "enforces one favorite per (user, item)" do
+    fav = create(:favorite_item)
+    dup = build(:favorite_item, user: fav.user, item: fav.item)
+    expect(dup).not_to be_valid
+  end
+
+  it "lets two users favorite the same item" do
+    item = create(:item, :published)
+    create(:favorite_item, user: create(:user), item: item)
+    expect(build(:favorite_item, user: create(:user), item: item)).to be_valid
+  end
+
+  it "is reachable via user.favorited_items and destroyed with the user" do
+    fav = create(:favorite_item)
+    expect(fav.user.favorited_items).to include(fav.item)
+    expect { fav.user.destroy }.to change(FavoriteItem, :count).by(-1)
+  end
+end

--- a/apps/api/spec/models/favorite_restaurant_spec.rb
+++ b/apps/api/spec/models/favorite_restaurant_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe FavoriteRestaurant, type: :model do
+  it "is valid with a user and restaurant" do
+    expect(build(:favorite_restaurant)).to be_valid
+  end
+
+  it "enforces one favorite per (user, restaurant)" do
+    fav = create(:favorite_restaurant)
+    dup = build(:favorite_restaurant, user: fav.user, restaurant: fav.restaurant)
+    expect(dup).not_to be_valid
+  end
+
+  it "lets two users favorite the same restaurant" do
+    restaurant = create(:restaurant, :published)
+    create(:favorite_restaurant, user: create(:user), restaurant: restaurant)
+    expect(build(:favorite_restaurant, user: create(:user), restaurant: restaurant)).to be_valid
+  end
+
+  it "is reachable via user.favorited_restaurants and destroyed with the user" do
+    fav = create(:favorite_restaurant)
+    expect(fav.user.favorited_restaurants).to include(fav.restaurant)
+    expect { fav.user.destroy }.to change(FavoriteRestaurant, :count).by(-1)
+  end
+end

--- a/apps/api/spec/requests/api/v1/favorite_items_spec.rb
+++ b/apps/api/spec/requests/api/v1/favorite_items_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe "POST/DELETE /api/v1/items/:id/favorite", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
+    it "stays idempotent (200, not 500) when a concurrent insert wins the race" do
+      allow(FavoriteItem).to receive(:find_or_create_by!)
+        .and_raise(ActiveRecord::RecordNotUnique)
+
+      post "/api/v1/items/#{item.id}/favorite", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("item_id" => item.id, "favorited" => true)
+    end
+
     it "404s for an unpublished item" do
       draft_item = create(:item, restaurant: restaurant) # default :draft
       post "/api/v1/items/#{draft_item.id}/favorite", headers: headers

--- a/apps/api/spec/requests/api/v1/favorite_items_spec.rb
+++ b/apps/api/spec/requests/api/v1/favorite_items_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "POST/DELETE /api/v1/items/:id/favorite", type: :request do
+  let(:user)       { create(:user) }
+  let(:headers)    { auth_headers_for(user) }
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:item)       { create(:item, :published, restaurant: restaurant) }
+
+  describe "POST" do
+    it "favorites the dish and echoes the new state" do
+      expect {
+        post "/api/v1/items/#{item.id}/favorite", headers: headers
+      }.to change(FavoriteItem, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("item_id" => item.id, "favorited" => true)
+    end
+
+    it "is idempotent (repeat calls don't dup rows)" do
+      post "/api/v1/items/#{item.id}/favorite", headers: headers
+      expect {
+        post "/api/v1/items/#{item.id}/favorite", headers: headers
+      }.not_to change(FavoriteItem, :count)
+    end
+
+    it "401s anonymously" do
+      post "/api/v1/items/#{item.id}/favorite"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "404s for an unpublished item" do
+      draft_item = create(:item, restaurant: restaurant) # default :draft
+      post "/api/v1/items/#{draft_item.id}/favorite", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE" do
+    before { create(:favorite_item, user: user, item: item) }
+
+    it "unfavorites the dish and echoes the new state" do
+      expect {
+        delete "/api/v1/items/#{item.id}/favorite", headers: headers
+      }.to change(FavoriteItem, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("item_id" => item.id, "favorited" => false)
+    end
+
+    it "is idempotent (unfavoriting an absent row returns ok)" do
+      delete "/api/v1/items/#{item.id}/favorite", headers: headers # first call
+      expect {
+        delete "/api/v1/items/#{item.id}/favorite", headers: headers
+      }.not_to change(FavoriteItem, :count)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/favorite_restaurants_spec.rb
+++ b/apps/api/spec/requests/api/v1/favorite_restaurants_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "POST/DELETE /api/v1/restaurants/:restaurant_id/favorite", type: :request do
+  let(:user)       { create(:user) }
+  let(:headers)    { auth_headers_for(user) }
+  let(:restaurant) { create(:restaurant, :published) }
+
+  describe "POST" do
+    it "favorites the restaurant and echoes the new state" do
+      expect {
+        post "/api/v1/restaurants/#{restaurant.id}/favorite", headers: headers
+      }.to change(FavoriteRestaurant, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("restaurant_id" => restaurant.id, "favorited" => true)
+    end
+
+    it "accepts the slug as well as the id" do
+      post "/api/v1/restaurants/#{restaurant.slug}/favorite", headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["favorited"]).to be(true)
+    end
+
+    it "is idempotent (repeat calls don't dup rows)" do
+      post "/api/v1/restaurants/#{restaurant.id}/favorite", headers: headers
+      expect {
+        post "/api/v1/restaurants/#{restaurant.id}/favorite", headers: headers
+      }.not_to change(FavoriteRestaurant, :count)
+    end
+
+    it "401s anonymously" do
+      post "/api/v1/restaurants/#{restaurant.id}/favorite"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "404s for an unpublished restaurant" do
+      draft = create(:restaurant) # default :draft
+      post "/api/v1/restaurants/#{draft.id}/favorite", headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE" do
+    before { create(:favorite_restaurant, user: user, restaurant: restaurant) }
+
+    it "unfavorites the restaurant and echoes the new state" do
+      expect {
+        delete "/api/v1/restaurants/#{restaurant.id}/favorite", headers: headers
+      }.to change(FavoriteRestaurant, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("restaurant_id" => restaurant.id, "favorited" => false)
+    end
+
+    it "is idempotent (unfavoriting an absent row returns ok)" do
+      delete "/api/v1/restaurants/#{restaurant.id}/favorite", headers: headers # first call
+      expect {
+        delete "/api/v1/restaurants/#{restaurant.id}/favorite", headers: headers
+      }.not_to change(FavoriteRestaurant, :count)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/profile_favorites_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_favorites_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe "GET /api/v1/profile/favorites", type: :request do
       hash_including("slug" => restaurant.slug, "name" => "Ninis Taqueria", "status" => "published")
     )
     expect(body["items"].first).to include("name" => "Carne Asada Taco", "status" => "published")
-    expect(body["items"].first["restaurant"]).to include("slug" => restaurant.slug)
+    expect(body["items"].first["restaurant"]).to include(
+      "slug" => restaurant.slug, "status" => "published"
+    )
   end
 
   it "scopes to the current user (no leak across users)" do

--- a/apps/api/spec/requests/api/v1/profile_favorites_spec.rb
+++ b/apps/api/spec/requests/api/v1/profile_favorites_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/profile/favorites", type: :request do
+  let(:user)       { create(:user) }
+  let(:headers)    { auth_headers_for(user) }
+  let(:restaurant) { create(:restaurant, :published, name: "Ninis Taqueria") }
+  let(:taco)       { create(:item, :published, restaurant: restaurant, name: "Carne Asada Taco") }
+
+  it "401s anonymously" do
+    get "/api/v1/profile/favorites"
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns the caller's favorited restaurants and dishes with context" do
+    create(:favorite_restaurant, user: user, restaurant: restaurant)
+    create(:favorite_item, user: user, item: taco)
+
+    get "/api/v1/profile/favorites", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+    expect(body["restaurants"]).to contain_exactly(
+      hash_including("slug" => restaurant.slug, "name" => "Ninis Taqueria", "status" => "published")
+    )
+    expect(body["items"].first).to include("name" => "Carne Asada Taco", "status" => "published")
+    expect(body["items"].first["restaurant"]).to include("slug" => restaurant.slug)
+  end
+
+  it "scopes to the current user (no leak across users)" do
+    create(:favorite_restaurant, user: create(:user), restaurant: restaurant)
+    create(:favorite_item, user: user, item: taco)
+
+    get "/api/v1/profile/favorites", headers: headers
+    body = response.parsed_body
+    expect(body["restaurants"]).to be_empty
+    expect(body["items"].length).to eq(1)
+  end
+
+  it "still lists a favorite whose item was later removed, exposing the status" do
+    create(:favorite_item, user: user, item: taco)
+    taco.update!(status: "removed")
+
+    get "/api/v1/profile/favorites", headers: headers
+    expect(response.parsed_body["items"].first["status"]).to eq("removed")
+  end
+end

--- a/apps/api/spec/requests/api/v1/restaurants/item_show_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants/item_show_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+# GET /api/v1/restaurants/:restaurant_id/items/:id — single dish. Public
+# (optional auth). Covers the `favorited` flag that seeds the detail
+# page's save button.
+RSpec.describe "GET /api/v1/restaurants/:restaurant_id/items/:id", type: :request do
+  let(:restaurant) { create(:restaurant, :published) }
+  let!(:taco)      { create(:item, :published, restaurant: restaurant, name: "Carne Asada Taco") }
+
+  def show_path = "/api/v1/restaurants/#{restaurant.id}/items/#{taco.id}"
+
+  it "returns the dish with favorited=false anonymously" do
+    get show_path
+    expect(response).to have_http_status(:ok)
+    body = response.parsed_body
+    expect(body).to include("id" => taco.id, "name" => "Carne Asada Taco", "favorited" => false)
+  end
+
+  it "reports favorited=true for a user who saved the dish" do
+    user = create(:user)
+    create(:favorite_item, user: user, item: taco)
+
+    get show_path, headers: auth_headers_for(user)
+    expect(response.parsed_body["favorited"]).to be(true)
+  end
+end

--- a/apps/api/spec/requests/api/v1/restaurants_spec.rb
+++ b/apps/api/spec/requests/api/v1/restaurants_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe "GET /api/v1/restaurants/:id", type: :request do
     )
   end
 
+  it "reports favorited=false anonymously and true for a user who saved it" do
+    get "/api/v1/restaurants/#{restaurant.id}"
+    expect(response.parsed_body["favorited"]).to be(false)
+
+    user = create(:user)
+    create(:favorite_restaurant, user: user, restaurant: restaurant)
+    get "/api/v1/restaurants/#{restaurant.id}", headers: auth_headers_for(user)
+    expect(response.parsed_body["favorited"]).to be(true)
+  end
+
   it "404s on a non-existent id" do
     get "/api/v1/restaurants/00000000-0000-0000-0000-000000000000"
     expect(response).to have_http_status(:not_found)

--- a/apps/web/src/app/api/items/[id]/favorite/route.ts
+++ b/apps/web/src/app/api/items/[id]/favorite/route.ts
@@ -1,0 +1,16 @@
+/**
+ * Proxy POST/DELETE /api/items/:id/favorite to Rails with the
+ * bw_session cookie's JWT. Save/unsave a dish for the current user.
+ */
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../../lib/api-proxy';
+
+export async function POST(_request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  return proxyAuthed(`/api/v1/items/${encodeURIComponent(id)}/favorite`, { method: 'POST' });
+}
+
+export async function DELETE(_request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  return proxyAuthed(`/api/v1/items/${encodeURIComponent(id)}/favorite`, { method: 'DELETE' });
+}

--- a/apps/web/src/app/api/profile/favorites/route.ts
+++ b/apps/web/src/app/api/profile/favorites/route.ts
@@ -1,0 +1,11 @@
+/**
+ * Proxy GET /api/profile/favorites to Rails with the bw_session
+ * cookie's JWT. Backs the account page's Favorites section (the
+ * caller's saved restaurants + dishes). `no-store` — a stale list
+ * would show something the user just unsaved.
+ */
+import { proxyAuthed } from '../../../../lib/api-proxy';
+
+export async function GET() {
+  return proxyAuthed('/api/v1/profile/favorites', { cache: 'no-store' });
+}

--- a/apps/web/src/app/api/restaurants/[slug]/favorite/route.ts
+++ b/apps/web/src/app/api/restaurants/[slug]/favorite/route.ts
@@ -1,0 +1,19 @@
+/**
+ * Proxy POST/DELETE /api/restaurants/:slug/favorite to Rails with the
+ * bw_session cookie's JWT. Save/unsave a restaurant for the current
+ * user. The API accepts the slug or UUID interchangeably.
+ */
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../../lib/api-proxy';
+
+export async function POST(_request: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  const { slug } = await context.params;
+  return proxyAuthed(`/api/v1/restaurants/${encodeURIComponent(slug)}/favorite`, { method: 'POST' });
+}
+
+export async function DELETE(_request: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  const { slug } = await context.params;
+  return proxyAuthed(`/api/v1/restaurants/${encodeURIComponent(slug)}/favorite`, {
+    method: 'DELETE',
+  });
+}

--- a/apps/web/src/app/profile/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/profile/settings/__tests__/page.test.tsx
@@ -177,13 +177,20 @@ describe('ProfileSettingsPage — favorites', () => {
           id: 'i1',
           name: 'Carne Asada Taco',
           status: 'published',
-          restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+          restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis', status: 'published' },
         },
         {
           id: 'i2',
           name: 'Gone Dish',
           status: 'removed',
-          restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+          restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis', status: 'published' },
+        },
+        {
+          // Published dish, but its restaurant is closed → still must not link.
+          id: 'i3',
+          name: 'Orphan Dish',
+          status: 'published',
+          restaurant: { id: 'r2', slug: 'closed-spot', name: 'Closed Spot', status: 'closed' },
         },
       ],
     });
@@ -198,7 +205,11 @@ describe('ProfileSettingsPage — favorites', () => {
     // A removed dish is shown but not linked.
     const gone = screen.getByTestId('favorite-dish-i2');
     expect(gone.querySelector('a')).toBeNull();
-    expect(gone).toHaveTextContent(/no longer on the menu/i);
+    expect(gone).toHaveTextContent(/no longer available/i);
+
+    // A published dish at an unpublished restaurant must not link either.
+    const orphan = screen.getByTestId('favorite-dish-i3');
+    expect(orphan.querySelector('a')).toBeNull();
   });
 });
 

--- a/apps/web/src/app/profile/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/profile/settings/__tests__/page.test.tsx
@@ -24,6 +24,7 @@ vi.mock('next/navigation', () => ({
 const mockFetchProfile = vi.fn();
 const mockUpdateProfile = vi.fn();
 const mockFetchMyReviews = vi.fn();
+const mockFetchMyFavorites = vi.fn();
 vi.mock('../../../../lib/profile', () => {
   // Defined inside the hoisted factory — a top-level class can't be
   // referenced here (only `mock`-prefixed vars are hoist-exempt).
@@ -32,6 +33,7 @@ vi.mock('../../../../lib/profile', () => {
     fetchProfile: (...a: unknown[]) => mockFetchProfile(...a),
     updateProfile: (...a: unknown[]) => mockUpdateProfile(...a),
     fetchMyReviews: (...a: unknown[]) => mockFetchMyReviews(...a),
+    fetchMyFavorites: (...a: unknown[]) => mockFetchMyFavorites(...a),
     NotSignedInError,
   };
 });
@@ -79,6 +81,7 @@ beforeEach(() => {
   ]);
   mockSearchIngredients.mockReset().mockResolvedValue([]);
   mockFetchMyReviews.mockReset().mockResolvedValue({ reviews: [], total: 0 });
+  mockFetchMyFavorites.mockReset().mockResolvedValue({ restaurants: [], items: [] });
 });
 
 afterEach(() => localStorage.clear());
@@ -157,6 +160,45 @@ describe('ProfileSettingsPage — dietary preferences', () => {
     await waitFor(() =>
       expect(mockReplace).toHaveBeenCalledWith('/login?next=%2Fprofile%2Fsettings'),
     );
+  });
+});
+
+describe('ProfileSettingsPage — favorites', () => {
+  it('shows an empty state when nothing is saved', async () => {
+    render(<ProfileSettingsPage />);
+    expect(await screen.findByTestId('favorites-empty')).toBeInTheDocument();
+  });
+
+  it('lists saved restaurants and dishes, linking published ones', async () => {
+    mockFetchMyFavorites.mockResolvedValue({
+      restaurants: [{ id: 'r1', slug: 'ninis', name: 'Ninis', status: 'published' }],
+      items: [
+        {
+          id: 'i1',
+          name: 'Carne Asada Taco',
+          status: 'published',
+          restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+        },
+        {
+          id: 'i2',
+          name: 'Gone Dish',
+          status: 'removed',
+          restaurant: { id: 'r1', slug: 'ninis', name: 'Ninis' },
+        },
+      ],
+    });
+    render(<ProfileSettingsPage />);
+
+    const rest = await screen.findByTestId('favorite-restaurant-r1');
+    expect(rest.querySelector('a')).toHaveAttribute('href', '/restaurants/ninis');
+
+    const dish = screen.getByTestId('favorite-dish-i1');
+    expect(dish.querySelector('a')).toHaveAttribute('href', '/restaurants/ninis/items/i1');
+
+    // A removed dish is shown but not linked.
+    const gone = screen.getByTestId('favorite-dish-i2');
+    expect(gone.querySelector('a')).toBeNull();
+    expect(gone).toHaveTextContent(/no longer on the menu/i);
   });
 });
 

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -577,23 +577,28 @@ function FavoritesSection() {
             <div data-testid="favorite-dishes">
               <h3 className="text-bw-base font-semibold text-zinc-800">Dishes</h3>
               <ul className="mt-bw-2 space-y-bw-2">
-                {items.map((d) => (
-                  <li key={d.id} data-testid={`favorite-dish-${d.id}`}>
-                    {d.status === 'published' ? (
-                      <a
-                        href={`/restaurants/${encodeURIComponent(d.restaurant.slug)}/items/${encodeURIComponent(d.id)}`}
-                        className="text-bw-base font-semibold text-zinc-900 hover:text-bite"
-                      >
-                        {d.name}
-                      </a>
-                    ) : (
-                      <span className="text-bw-base font-semibold text-zinc-500">
-                        {d.name} <span className="text-bw-xs">(no longer on the menu)</span>
-                      </span>
-                    )}
-                    <span className="text-bw-sm text-zinc-500"> · {d.restaurant.name}</span>
-                  </li>
-                ))}
+                {items.map((d) => {
+                  // Safe to link only when the dish AND its restaurant are
+                  // published — the dish page 404s otherwise.
+                  const linkable = d.status === 'published' && d.restaurant.status === 'published';
+                  return (
+                    <li key={d.id} data-testid={`favorite-dish-${d.id}`}>
+                      {linkable ? (
+                        <a
+                          href={`/restaurants/${encodeURIComponent(d.restaurant.slug)}/items/${encodeURIComponent(d.id)}`}
+                          className="text-bw-base font-semibold text-zinc-900 hover:text-bite"
+                        >
+                          {d.name}
+                        </a>
+                      ) : (
+                        <span className="text-bw-base font-semibold text-zinc-500">
+                          {d.name} <span className="text-bw-xs">(no longer available)</span>
+                        </span>
+                      )}
+                      <span className="text-bw-sm text-zinc-500"> · {d.restaurant.name}</span>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           )}

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -8,10 +8,13 @@ import {
   fetchProfile,
   updateProfile,
   fetchMyReviews,
+  fetchMyFavorites,
   NotSignedInError,
   type ProfilePatch,
   type ProfilePayload,
   type MyReview,
+  type FavoriteRestaurant,
+  type FavoriteDish,
 } from '../../../lib/profile';
 import {
   fetchDietaryProfiles,
@@ -36,6 +39,7 @@ export default function ProfileSettingsPage() {
     <main className="mx-auto max-w-2xl px-bw-6 pt-bw-12 pb-bw-16">
       <h1 className="text-bw-2xl font-bold text-zinc-900">Account</h1>
       <PreferencesSection />
+      <FavoritesSection />
       <MyReviewsSection />
       <AnalyticsSection />
     </main>
@@ -501,6 +505,101 @@ function TasteRow({
         <span className="text-bw-sm text-zinc-400">none</span>
       )}
     </div>
+  );
+}
+
+// ─── Favorites ────────────────────────────────────────────────────
+
+function FavoritesSection() {
+  const router = useRouter();
+  const [restaurants, setRestaurants] = useState<FavoriteRestaurant[] | null>(null);
+  const [items, setItems] = useState<FavoriteDish[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchMyFavorites()
+      .then((f) => {
+        setRestaurants(f.restaurants);
+        setItems(f.items);
+      })
+      .catch((e) => {
+        if (e instanceof NotSignedInError) {
+          router.replace(`/login?next=${encodeURIComponent('/profile/settings')}`);
+          return;
+        }
+        setError((e as Error).message);
+      });
+  }, [router]);
+
+  const empty = restaurants !== null && restaurants.length === 0 && items.length === 0;
+
+  return (
+    <section className="mt-bw-8 border-t border-zinc-100 pt-bw-8" data-testid="favorites">
+      <h2 className="text-bw-lg font-bold text-zinc-900">Favorites</h2>
+      {error ? (
+        <p className="mt-bw-3 rounded-bw-md bg-bite-light px-bw-3 py-bw-2 text-bw-sm text-bite-dark">
+          Could not load your favorites — {error}
+        </p>
+      ) : restaurants === null ? (
+        <p className="mt-bw-3 text-bw-sm text-zinc-500" data-testid="favorites-loading">
+          Loading your favorites…
+        </p>
+      ) : empty ? (
+        <p className="mt-bw-3 text-bw-sm text-zinc-400" data-testid="favorites-empty">
+          You haven’t saved any restaurants or dishes yet.
+        </p>
+      ) : (
+        <div className="mt-bw-4 space-y-bw-6">
+          {restaurants.length > 0 && (
+            <div data-testid="favorite-restaurants">
+              <h3 className="text-bw-base font-semibold text-zinc-800">Restaurants</h3>
+              <ul className="mt-bw-2 space-y-bw-2">
+                {restaurants.map((r) => (
+                  <li key={r.id} data-testid={`favorite-restaurant-${r.id}`}>
+                    {r.status === 'published' ? (
+                      <a
+                        href={`/restaurants/${encodeURIComponent(r.slug)}`}
+                        className="text-bw-base font-semibold text-zinc-900 hover:text-bite"
+                      >
+                        {r.name}
+                      </a>
+                    ) : (
+                      <span className="text-bw-base font-semibold text-zinc-500">
+                        {r.name} <span className="text-bw-xs">(unavailable)</span>
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {items.length > 0 && (
+            <div data-testid="favorite-dishes">
+              <h3 className="text-bw-base font-semibold text-zinc-800">Dishes</h3>
+              <ul className="mt-bw-2 space-y-bw-2">
+                {items.map((d) => (
+                  <li key={d.id} data-testid={`favorite-dish-${d.id}`}>
+                    {d.status === 'published' ? (
+                      <a
+                        href={`/restaurants/${encodeURIComponent(d.restaurant.slug)}/items/${encodeURIComponent(d.id)}`}
+                        className="text-bw-base font-semibold text-zinc-900 hover:text-bite"
+                      >
+                        {d.name}
+                      </a>
+                    ) : (
+                      <span className="text-bw-base font-semibold text-zinc-500">
+                        {d.name} <span className="text-bw-xs">(no longer on the menu)</span>
+                      </span>
+                    )}
+                    <span className="text-bw-sm text-zinc-500"> · {d.restaurant.name}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -16,11 +16,13 @@ import {
   clearNeverHide,
   fetchRestaurantItems,
   setNeverHide,
+  setRestaurantFavorite,
   type FilterSummary,
   type Restaurant,
   type RestaurantItem,
   type RestaurantItemsResponse,
 } from '../../../lib/restaurants';
+import FavoriteButton from './_FavoriteButton';
 import { ItemRow } from './ItemRow';
 import { TopPicksRow } from './TopPicksRow';
 import { useTracker } from '../../_PostHogProvider';
@@ -42,12 +44,15 @@ export function RestaurantClient({
   restaurant,
   initialItems,
   profileToken = null,
+  signedIn = false,
 }: {
   slug: string;
   restaurant: Restaurant;
   initialItems: RestaurantItemsResponse;
   /** Phase 3.9 — passed from SSR when the URL had ?p=<token>. */
   profileToken?: string | null;
+  /** Gates the save button — the favorite endpoint is authed. */
+  signedIn?: boolean;
 }) {
   const tracker = useTracker();
   const [filter, setFilter] = useState<FilterSummary>(initialItems.filter);
@@ -164,6 +169,17 @@ export function RestaurantClient({
         {restaurant.city.name}, {restaurant.city.region}
       </p>
       <h1 className="mt-bw-2 text-bw-3xl font-bold">{restaurant.name}</h1>
+      {signedIn && (
+        <div className="mt-bw-3">
+          <FavoriteButton
+            initialFavorited={restaurant.favorited ?? false}
+            onToggle={(next) => setRestaurantFavorite(slug, next)}
+            savedLabel="Saved"
+            unsavedLabel="Save restaurant"
+            testId="favorite-restaurant"
+          />
+        </div>
+      )}
       <p className="mt-bw-2 text-bw-base text-zinc-700">
         Showing <span className="font-bold">{totalVisible}</span> item
         {totalVisible === 1 ? '' : 's'} that match your filter

--- a/apps/web/src/app/restaurants/[slug]/_FavoriteButton.tsx
+++ b/apps/web/src/app/restaurants/[slug]/_FavoriteButton.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Save/unsave toggle shared by the restaurant and dish detail pages.
+ * Optimistic: flips immediately, reverts on error. The caller supplies
+ * `onToggle` (the lib fn bound to the right id) and the initial state
+ * (SSR-seeded from the `favorited` flag on the show payload). Render it
+ * only for signed-in users — the endpoint is authed.
+ */
+export default function FavoriteButton({
+  initialFavorited,
+  onToggle,
+  savedLabel,
+  unsavedLabel,
+  testId,
+}: {
+  initialFavorited: boolean;
+  onToggle: (next: boolean) => Promise<{ favorited: boolean }>;
+  savedLabel: string;
+  unsavedLabel: string;
+  testId?: string;
+}) {
+  const [favorited, setFavorited] = useState(initialFavorited);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = async () => {
+    const next = !favorited;
+    setBusy(true);
+    setError(null);
+    setFavorited(next); // optimistic
+    try {
+      const res = await onToggle(next);
+      setFavorited(res.favorited);
+    } catch (e) {
+      setFavorited(!next); // revert
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <span className="inline-flex flex-col items-start gap-bw-1">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={busy}
+        aria-pressed={favorited}
+        data-testid={testId}
+        className={[
+          'rounded-bw-pill border px-bw-4 py-bw-2 text-bw-sm font-semibold transition disabled:opacity-50',
+          favorited
+            ? 'border-bite bg-bite-light text-bite-dark'
+            : 'border-zinc-300 bg-white text-zinc-700 hover:border-zinc-400',
+        ].join(' ')}
+      >
+        {favorited ? `♥ ${savedLabel}` : `♡ ${unsavedLabel}`}
+      </button>
+      {error && <span className="text-bw-xs text-bite-dark">Could not save — try again.</span>}
+    </span>
+  );
+}

--- a/apps/web/src/app/restaurants/[slug]/__tests__/FavoriteButton.test.tsx
+++ b/apps/web/src/app/restaurants/[slug]/__tests__/FavoriteButton.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import FavoriteButton from '../_FavoriteButton';
+
+describe('FavoriteButton', () => {
+  const labels = { savedLabel: 'Saved', unsavedLabel: 'Save' };
+
+  it('renders the unsaved state and toggles to saved on click', async () => {
+    const onToggle = vi.fn().mockResolvedValue({ favorited: true });
+    render(<FavoriteButton initialFavorited={false} onToggle={onToggle} {...labels} testId="fav" />);
+
+    const btn = screen.getByTestId('fav');
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+    expect(btn).toHaveTextContent('Save');
+
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalledWith(true);
+    await waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'true'));
+    expect(btn).toHaveTextContent('Saved');
+  });
+
+  it('reverts the optimistic flip when the toggle fails', async () => {
+    const onToggle = vi.fn().mockRejectedValue(new Error('boom'));
+    render(<FavoriteButton initialFavorited={false} onToggle={onToggle} {...labels} testId="fav" />);
+
+    const btn = screen.getByTestId('fav');
+    fireEvent.click(btn);
+    // Optimistically pressed, then reverts to false after the rejection.
+    await waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'false'));
+    expect(screen.getByText(/could not save/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
@@ -6,8 +6,10 @@ import {
   type Restaurant,
   type RestaurantItem,
 } from '../../../../../lib/restaurants';
+import { setItemFavorite } from '../../../../../lib/restaurants';
 import { fetchReviewsServer, type ReviewsResponse } from '../../../../../lib/reviews';
-import { getServerUserId } from '../../../../../lib/server-auth';
+import { getServerJwt, getServerUserId } from '../../../../../lib/server-auth';
+import FavoriteButton from '../../_FavoriteButton';
 import { ReviewsClient } from './ReviewsClient';
 import { SuggestFixClient } from './SuggestFixClient';
 
@@ -29,9 +31,12 @@ export default async function ItemDetailPage({
 }) {
   const { slug, id } = await params;
 
+  // The JWT lets fetchItem populate `favorited` for the save button;
+  // anonymous callers still render (favorited defaults false, button hidden).
+  const jwt = await getServerJwt();
   const [restaurant, item, initialReviews, currentUserId] = await Promise.all([
     fetchRestaurant(slug).catch(() => null),
-    fetchItem(slug, id).catch(() => null),
+    fetchItem(slug, id, { jwt: jwt ?? undefined }).catch(() => null),
     fetchReviewsServer(id).catch(() => null),
     getServerUserId(),
   ]);
@@ -69,6 +74,18 @@ function Page({
       <h1 className="mt-bw-2 text-bw-3xl font-bold">{item.name}</h1>
       {item.description && (
         <p className="mt-bw-2 text-bw-base text-zinc-700">{item.description}</p>
+      )}
+
+      {currentUserId && (
+        <div className="mt-bw-4">
+          <FavoriteButton
+            initialFavorited={item.favorited ?? false}
+            onToggle={(next) => setItemFavorite(item.id, next)}
+            savedLabel="Saved"
+            unsavedLabel="Save this dish"
+            testId="favorite-dish"
+          />
+        </div>
       )}
 
       <ReviewsClient

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
@@ -3,10 +3,10 @@ import Link from 'next/link';
 import {
   fetchItem,
   fetchRestaurant,
+  setItemFavorite,
   type Restaurant,
   type RestaurantItem,
 } from '../../../../../lib/restaurants';
-import { setItemFavorite } from '../../../../../lib/restaurants';
 import { fetchReviewsServer, type ReviewsResponse } from '../../../../../lib/reviews';
 import { getServerJwt, getServerUserId } from '../../../../../lib/server-auth';
 import FavoriteButton from '../../_FavoriteButton';

--- a/apps/web/src/app/restaurants/[slug]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation';
 import { fetchRestaurant, fetchRestaurantItems } from '../../../lib/restaurants';
+import { getServerJwt } from '../../../lib/server-auth';
 import { RestaurantClient } from './RestaurantClient';
 
 /**
@@ -31,8 +32,11 @@ export default async function RestaurantPage({
   const { slug } = await params;
   const { p: profileToken } = await searchParams;
 
+  // The JWT lets fetchRestaurant populate `favorited` for the save button;
+  // its presence also gates the button (the endpoint is authed).
+  const jwt = await getServerJwt();
   const [restaurant, initialItems] = await Promise.all([
-    fetchRestaurant(slug).catch(() => null),
+    fetchRestaurant(slug, { jwt: jwt ?? undefined }).catch(() => null),
     fetchRestaurantItems(slug, { profileToken }).catch(() => null),
   ]);
 
@@ -44,6 +48,7 @@ export default async function RestaurantPage({
       restaurant={restaurant}
       initialItems={initialItems}
       profileToken={profileToken ?? null}
+      signedIn={Boolean(jwt)}
     />
   );
 }

--- a/apps/web/src/lib/__tests__/restaurants.test.ts
+++ b/apps/web/src/lib/__tests__/restaurants.test.ts
@@ -4,7 +4,9 @@ import {
   fetchRestaurant,
   fetchRestaurantItems,
   fetchRestaurants,
+  setItemFavorite,
   setNeverHide,
+  setRestaurantFavorite,
   type Restaurant,
   type RestaurantItemsResponse,
   type RestaurantSummary,
@@ -150,6 +152,32 @@ describe('setNeverHide / clearNeverHide (Phase 4.2)', () => {
   it('throws on non-2xx', async () => {
     const fetchImpl = fakeFetch(401, { error: 'unauth' });
     await expect(setNeverHide('item-1', { fetchImpl })).rejects.toThrow(/401/);
+  });
+});
+
+describe('setItemFavorite / setRestaurantFavorite', () => {
+  it('POSTs to favorite a dish and DELETEs to unfavorite', async () => {
+    const post = fakeFetch(200, { item_id: 'item-1', favorited: true });
+    expect((await setItemFavorite('item-1', true, { fetchImpl: post })).favorited).toBe(true);
+    expect(String(post.mock.calls[0]![0])).toBe('/api/items/item-1/favorite');
+    expect((post.mock.calls[0]![1] as RequestInit).method).toBe('POST');
+
+    const del = fakeFetch(200, { item_id: 'item-1', favorited: false });
+    expect((await setItemFavorite('item-1', false, { fetchImpl: del })).favorited).toBe(false);
+    expect((del.mock.calls[0]![1] as RequestInit).method).toBe('DELETE');
+  });
+
+  it('favorites a restaurant by slug', async () => {
+    const fetchImpl = fakeFetch(200, { restaurant_id: 'r1', favorited: true });
+    const result = await setRestaurantFavorite('ninis', true, { fetchImpl });
+    expect(result.favorited).toBe(true);
+    expect(String(fetchImpl.mock.calls[0]![0])).toBe('/api/restaurants/ninis/favorite');
+    expect((fetchImpl.mock.calls[0]![1] as RequestInit).method).toBe('POST');
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchImpl = fakeFetch(401, { error: 'unauth' });
+    await expect(setItemFavorite('item-1', true, { fetchImpl })).rejects.toThrow(/401/);
   });
 });
 

--- a/apps/web/src/lib/profile.ts
+++ b/apps/web/src/lib/profile.ts
@@ -131,7 +131,10 @@ export interface FavoriteDish {
   id: string;
   name: string;
   status: string;
-  restaurant: { id: string; slug: string; name: string };
+  // `restaurant.status` matters too: a dish stays 'published' when its
+  // restaurant is later closed, but the dish page resolves through the
+  // restaurant, so the link is only safe when both are published.
+  restaurant: { id: string; slug: string; name: string; status: string };
 }
 
 export interface MyFavoritesResponse {

--- a/apps/web/src/lib/profile.ts
+++ b/apps/web/src/lib/profile.ts
@@ -117,3 +117,35 @@ export async function fetchMyReviews(
   });
   return readJsonOrThrow<MyReviewsResponse>(res, 'fetchMyReviews');
 }
+
+// ─── Favorites (account page) ─────────────────────────────────────
+
+export interface FavoriteRestaurant {
+  id: string;
+  slug: string;
+  name: string;
+  status: string;
+}
+
+export interface FavoriteDish {
+  id: string;
+  name: string;
+  status: string;
+  restaurant: { id: string; slug: string; name: string };
+}
+
+export interface MyFavoritesResponse {
+  restaurants: FavoriteRestaurant[];
+  items: FavoriteDish[];
+}
+
+export async function fetchMyFavorites(
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<MyFavoritesResponse> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl('/api/profile/favorites', {
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+  return readJsonOrThrow<MyFavoritesResponse>(res, 'fetchMyFavorites');
+}

--- a/apps/web/src/lib/restaurants.ts
+++ b/apps/web/src/lib/restaurants.ts
@@ -43,6 +43,8 @@ export interface Restaurant {
   claimed_at: string | null;
   claimed_by_user_id: string | null;
   city: RestaurantCity;
+  /** Set by GET show when the caller is authed; false anonymously. */
+  favorited?: boolean;
 }
 
 /** The lighter shape `GET /api/v1/restaurants` returns for browse/discovery. */
@@ -86,6 +88,8 @@ export interface RestaurantItem extends FilterableItem {
   taste_score?: number | null;
   /** Which liked tags/ingredients matched — the "because you like…" line. */
   taste_reasons?: TasteReason[];
+  /** Set by GET show when the caller is authed; false anonymously. */
+  favorited?: boolean;
 }
 
 export interface FilterSummary {
@@ -104,6 +108,8 @@ export interface RestaurantItemsResponse {
 
 export interface FetchOptions {
   fetchImpl?: typeof fetch;
+  /** Bearer token — pass on the server so `favorited` reflects the caller. */
+  jwt?: string;
 }
 
 export interface FetchItemsOptions extends FetchOptions {
@@ -118,7 +124,10 @@ export async function fetchRestaurant(
   slugOrId: string,
   opts: FetchOptions = {},
 ): Promise<Restaurant> {
+  const headers: Record<string, string> = {};
+  if (opts.jwt) headers.Authorization = `Bearer ${opts.jwt}`;
   return api<Restaurant>(`/restaurants/${encodeURIComponent(slugOrId)}`, {
+    headers,
     fetchImpl: opts.fetchImpl,
   });
 }
@@ -147,9 +156,11 @@ export async function fetchItem(
   itemId: string,
   opts: FetchOptions = {},
 ): Promise<RestaurantItem> {
+  const headers: Record<string, string> = {};
+  if (opts.jwt) headers.Authorization = `Bearer ${opts.jwt}`;
   return api<RestaurantItem>(
     `/restaurants/${encodeURIComponent(restaurantSlugOrId)}/items/${encodeURIComponent(itemId)}`,
-    { fetchImpl: opts.fetchImpl },
+    { headers, fetchImpl: opts.fetchImpl },
   );
 }
 
@@ -196,4 +207,37 @@ export async function clearNeverHide(
   });
   if (!res.ok) throw new Error(`clearNeverHide failed: ${res.status}`);
   return (await res.json()) as { item_id: string; overridden_by_user: boolean };
+}
+
+/**
+ * Save/unsave a dish via the Next proxy at /api/items/:id/favorite.
+ * `favorite` is true to save, false to unsave; returns the new state.
+ */
+export async function setItemFavorite(
+  itemId: string,
+  favorite: boolean,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<{ item_id: string; favorited: boolean }> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`/api/items/${encodeURIComponent(itemId)}/favorite`, {
+    method: favorite ? 'POST' : 'DELETE',
+    credentials: 'same-origin',
+  });
+  if (!res.ok) throw new Error(`setItemFavorite failed: ${res.status}`);
+  return (await res.json()) as { item_id: string; favorited: boolean };
+}
+
+/** Save/unsave a restaurant via /api/restaurants/:slug/favorite. */
+export async function setRestaurantFavorite(
+  slug: string,
+  favorite: boolean,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<{ restaurant_id: string; favorited: boolean }> {
+  const { fetchImpl = fetch } = opts;
+  const res = await fetchImpl(`/api/restaurants/${encodeURIComponent(slug)}/favorite`, {
+    method: favorite ? 'POST' : 'DELETE',
+    credentials: 'same-origin',
+  });
+  if (!res.ok) throw new Error(`setRestaurantFavorite failed: ${res.status}`);
+  return (await res.json()) as { restaurant_id: string; favorited: boolean };
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,23 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-21 — Account page PR-3: favorites (restaurants + dishes). Branch `feat/account-favorites`.
+
+- Final item of the account-page arc. Users can now save **restaurants and dishes**
+  and see them on `/profile/settings`. Two join tables `favorite_restaurants` /
+  `favorite_items` (migrations 20260721130000/130001), mirroring `user_item_overrides`
+  (presence-of-row = favorited, real FKs, unique (user, target) index).
+- API: toggle endpoints `POST/DELETE /api/v1/restaurants/:id/favorite` +
+  `/items/:id/favorite` (idempotent, mirror ItemOverridesController); list endpoint
+  `GET /api/v1/profile/favorites` (restaurants + items with status). `favorited` flag
+  added to `restaurants#show` + `items#show` (authed → seeds the detail-page button).
+  Model + request specs; brakeman clean.
+- Web: `FavoriteButton` island (optimistic, reverts on error) on the restaurant +
+  dish detail pages (SSR-seeded via a JWT-authed fetch, gated on signed-in); account
+  page "Favorites" section; proxies + `setItemFavorite`/`setRestaurantFavorite` +
+  `fetchMyFavorites`. Hand-written web types (no rswag), matching the history/reviews
+  siblings. Web vitest 234 (+7); typecheck/lint green. Account-page arc complete.
+
 2026-07-21 — Account page PR-2: "My reviews" list. Branch `feat/account-my-reviews`.
 
 - Adds a **My reviews** section to `/profile/settings`: the caller's own reviews,


### PR DESCRIPTION
## Summary

- Final item of the account-page arc: users can **save restaurants and dishes** and see them on `/profile/settings`.
- Two join tables (`favorite_restaurants` / `favorite_items`) mirroring `user_item_overrides`; idempotent toggle endpoints + a `GET /api/v1/profile/favorites` list; a `favorited` flag on `restaurants#show` / `items#show` seeds the detail-page buttons.
- Web: a shared optimistic `FavoriteButton` on the restaurant + dish detail pages (SSR-seeded, gated on signed-in) and a "Favorites" section on the account page.

Closes the 3-PR account-page arc (preferences → my reviews → favorites).
