### PR TITLE
chore(api): add .env.test to keep RAILS_ENV=test off production

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -3,6 +3,13 @@
 # Copy to .env (which is gitignored) and fill in real values for any
 # variables you need locally. The Rails app boots without these — only
 # the live OAuth handshake or JWT signing actually requires them.
+#
+# NOTE: if your .env sets a production DATABASE_URL (e.g. the Neon URL),
+# the checked-in .env.test pins RAILS_ENV=test to a LOCAL database so
+# rspec/db:* never touch production. dotenv loads .env.test before .env
+# and doesn't overwrite, so .env.test wins for the test env; CI is
+# unaffected (it sets DATABASE_URL in the job env). Override locally with
+# .env.test.local if your Postgres differs.
 
 # --- JWT signing -------------------------------------------------------------
 # 64+ random chars. Falls back to Rails.application.secret_key_base

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -1,0 +1,12 @@
+# Local test database — keeps `RAILS_ENV=test` off production.
+#
+# dotenv-rails loads `.env.test` BEFORE `.env` for the test environment and
+# never overwrites an already-set key, so this DATABASE_URL wins over the
+# (production Neon) DATABASE_URL in `.env`. Without it, `RAILS_ENV=test`
+# rails tasks — rspec, db:create/db:migrate/db:drop — connect to production.
+#
+# CI is unaffected: ci-api.yml sets DATABASE_URL in the job env, which takes
+# precedence over every dotenv file. If your local Postgres uses a different
+# user/port, override with `.env.test.local` (gitignored) rather than editing
+# this shared file.
+DATABASE_URL=postgresql://postgres@localhost:5432/biteworthy_test


### PR DESCRIPTION
## Summary

- The local `.env` holds a production (Neon) `DATABASE_URL`, and dotenv applies it to every environment — so `RAILS_ENV=test` tasks (rspec, `db:*`) connect to **production**. A stray `db:drop`/`db:reset` there would target prod.
- `.env.test` pins the test env to a local DB. dotenv loads `.env.test` before `.env` and never overwrites, so it wins for test; **CI is unaffected** (it sets `DATABASE_URL` in the job env, which beats every dotenv file).
- Verified: `RAILS_ENV=test` now resolves to `biteworthy_test`, and the suite runs green with no manual override.
