### PR TITLE
feat(web): let the scan-menu page upload multiple photos/PDFs

### DIFF
--- a/apps/web/src/app/ingest/__tests__/page.camera.test.tsx
+++ b/apps/web/src/app/ingest/__tests__/page.camera.test.tsx
@@ -24,4 +24,44 @@ describe('IngestPage — camera capture', () => {
     fireEvent.change(screen.getByTestId('camera-input'), { target: { files: [photo] } });
     expect(screen.getByTestId('selected-file')).toHaveTextContent('menu.jpg');
   });
+
+  it('accepts multiple files at once via the picker', () => {
+    render(<IngestPage />);
+    // The file picker is multi-select so a whole menu can upload as one run.
+    expect(screen.getByTestId('file-input')).toHaveAttribute('multiple');
+
+    const page1 = new File(['a'], 'page-1.jpg', { type: 'image/jpeg' });
+    const page2 = new File(['b'], 'page-2.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [page1, page2] } });
+
+    const list = screen.getByTestId('selected-file');
+    expect(list).toHaveTextContent('page-1.jpg');
+    expect(list).toHaveTextContent('page-2.jpg');
+  });
+
+  it('accumulates repeated camera captures into the same run instead of replacing', () => {
+    render(<IngestPage />);
+    const shot1 = new File(['a'], 'shot-1.jpg', { type: 'image/jpeg' });
+    const shot2 = new File(['b'], 'shot-2.jpg', { type: 'image/jpeg' });
+
+    fireEvent.change(screen.getByTestId('camera-input'), { target: { files: [shot1] } });
+    fireEvent.change(screen.getByTestId('camera-input'), { target: { files: [shot2] } });
+
+    const list = screen.getByTestId('selected-file');
+    expect(list).toHaveTextContent('shot-1.jpg');
+    expect(list).toHaveTextContent('shot-2.jpg');
+  });
+
+  it('removes a single selected file without clearing the rest', () => {
+    render(<IngestPage />);
+    const page1 = new File(['a'], 'page-1.jpg', { type: 'image/jpeg' });
+    const page2 = new File(['b'], 'page-2.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByTestId('file-input'), { target: { files: [page1, page2] } });
+
+    fireEvent.click(screen.getByLabelText('Remove page-1.jpg'));
+
+    const list = screen.getByTestId('selected-file');
+    expect(list).not.toHaveTextContent('page-1.jpg');
+    expect(list).toHaveTextContent('page-2.jpg');
+  });
 });

--- a/apps/web/src/app/ingest/page.tsx
+++ b/apps/web/src/app/ingest/page.tsx
@@ -27,13 +27,23 @@ export default function IngestPage() {
   const [manualId, setManualId] = useState('');
   const [sourceUrl, setSourceUrl] = useState('');
   const [sourceText, setSourceText] = useState('');
-  const [file, setFile] = useState<File | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const restaurantId = restaurant?.id ?? manualId;
 
-  const onPickFile = (e: ChangeEvent<HTMLInputElement>) => setFile(e.target.files?.[0] ?? null);
+  // Both the camera and the file picker append to the same list, so a
+  // multi-page menu can mix rear-camera shots and picked PDFs/photos.
+  // Clearing the input's value lets the same file (or another camera
+  // shot) be picked again — React won't refire change on an unchanged value.
+  const onPickFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const picked = Array.from(e.target.files ?? []);
+    if (picked.length > 0) setFiles((prev) => [...prev, ...picked]);
+    e.target.value = '';
+  };
+
+  const removeFile = (index: number) => setFiles((prev) => prev.filter((_, i) => i !== index));
 
   const submit = async (mode: 'url' | 'file' | 'text') => {
     setError(null);
@@ -45,7 +55,7 @@ export default function IngestPage() {
       setError('Paste a URL.');
       return;
     }
-    if (mode === 'file' && !file) {
+    if (mode === 'file' && files.length === 0) {
       setError('Drop a file.');
       return;
     }
@@ -60,7 +70,7 @@ export default function IngestPage() {
         mode === 'url'
           ? await ingestFromUrl({ restaurantId, sourceUrl })
           : mode === 'file'
-            ? await ingestFromFile({ restaurantId, file: file! })
+            ? await ingestFromFile({ restaurantId, files })
             : await ingestFromText({ restaurantId, sourceText });
       router.push(`/ingest/verify/${run.id}` as Route);
     } catch (e) {
@@ -82,9 +92,8 @@ export default function IngestPage() {
         </p>
         <h1 className="mt-1 text-3xl font-bold">Add a restaurant’s menu</h1>
         <p className="mt-2 text-zinc-600">
-          Pick the restaurant (or create it if it’s new), then give us the menu — a
-          URL or a PDF. The AI extracts the items and you verify them before they go
-          live.
+          Pick the restaurant (or create it if it’s new), then give us the menu — a URL or a PDF.
+          The AI extracts the items and you verify them before they go live.
         </p>
       </header>
 
@@ -147,11 +156,16 @@ export default function IngestPage() {
       </section>
 
       <section className="space-y-3 rounded-xl border border-zinc-200 p-4">
-        <h2 className="text-lg font-semibold">Or drop a PDF / photo</h2>
+        <h2 className="text-lg font-semibold">Or drop PDFs / photos</h2>
+        <p className="text-sm text-zinc-600">
+          Add as many pages as the menu has — take several photos or pick multiple files. They’re
+          extracted together as one menu.
+        </p>
         <div className="flex flex-wrap items-center gap-3">
           {/* capture="environment" opens the phone's rear camera directly.
               Kept separate from the picker below because `capture` would
-              otherwise block PDF + existing-photo selection on mobile. */}
+              otherwise block PDF + existing-photo selection on mobile. Each
+              tap adds one more page to the list. */}
           <label className="inline-flex cursor-pointer items-center gap-2 rounded border border-orange-600 px-4 py-2 font-semibold text-orange-700 hover:bg-orange-50">
             📷 Take a photo
             <input
@@ -166,15 +180,28 @@ export default function IngestPage() {
           <input
             type="file"
             accept="application/pdf,image/*"
+            multiple
             onChange={onPickFile}
             className="block text-sm"
             data-testid="file-input"
           />
         </div>
-        {file && (
-          <p className="text-sm text-zinc-700" data-testid="selected-file">
-            Selected <span className="font-medium">{file.name}</span>
-          </p>
+        {files.length > 0 && (
+          <ul className="space-y-1 text-sm text-zinc-700" data-testid="selected-file">
+            {files.map((f, i) => (
+              <li key={`${f.name}-${i}`} className="flex items-center justify-between gap-3">
+                <span className="font-medium">{f.name}</span>
+                <button
+                  type="button"
+                  onClick={() => removeFile(i)}
+                  className="text-xs font-semibold text-zinc-500 underline hover:text-zinc-800"
+                  aria-label={`Remove ${f.name}`}
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
         )}
         <button
           type="button"
@@ -182,7 +209,11 @@ export default function IngestPage() {
           disabled={submitting}
           className="rounded bg-orange-600 px-4 py-2 font-semibold text-white disabled:opacity-50"
         >
-          {submitting ? 'Uploading…' : 'Upload file'}
+          {submitting
+            ? 'Uploading…'
+            : files.length > 1
+              ? `Upload ${files.length} files`
+              : 'Upload file'}
         </button>
       </section>
 

--- a/apps/web/src/lib/__tests__/ingestion.test.ts
+++ b/apps/web/src/lib/__tests__/ingestion.test.ts
@@ -23,12 +23,13 @@ const sampleRun: IngestionRunPayload = {
 };
 
 function fakeFetch(status: number, body: unknown) {
-  return vi.fn(async () =>
-    ({
-      ok: status >= 200 && status < 300,
-      status,
-      json: async () => body,
-    }) as unknown as Response,
+  return vi.fn(
+    async () =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+      }) as unknown as Response,
   );
 }
 
@@ -112,7 +113,7 @@ describe('ingestFromFile', () => {
 
     const result = await ingestFromFile({
       restaurantId: 'rest-1',
-      file,
+      files: [file],
       fetchImpl,
     });
 
@@ -125,24 +126,42 @@ describe('ingestFromFile', () => {
     // No Content-Type either — let fetch set the multipart boundary itself.
     expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
     expect(init.body).toBeInstanceOf(FormData);
+    const body = init.body as FormData;
+    expect(body.getAll('inputs[]')).toHaveLength(1);
+  });
+
+  it('appends every file under inputs[] so a multi-page menu uploads as one run', async () => {
+    const fetchImpl = fakeFetch(201, { ...sampleRun, input_kind: 'photo' });
+    const page1 = new File(['a'], 'page-1.jpg', { type: 'image/jpeg' });
+    const page2 = new File(['b'], 'page-2.jpg', { type: 'image/jpeg' });
+
+    await ingestFromFile({ restaurantId: 'rest-1', files: [page1, page2], fetchImpl });
+
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const body = init.body as FormData;
+    const inputs = body.getAll('inputs[]') as File[];
+    expect(inputs).toHaveLength(2);
+    expect(inputs.map((f) => f.name)).toEqual(['page-1.jpg', 'page-2.jpg']);
+    expect(body.get('restaurant_id')).toBe('rest-1');
   });
 
   it('returns a typed IngestionRequestError on non-JSON 5xx', async () => {
-    const fetchImpl = vi.fn(async () =>
-      ({
-        ok: false,
-        status: 500,
-        json: async () => {
-          throw new Error('not json');
-        },
-      }) as unknown as Response,
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 500,
+          json: async () => {
+            throw new Error('not json');
+          },
+        }) as unknown as Response,
     );
     const file = new File(['x'], 'x.pdf', { type: 'application/pdf' });
 
     await expect(
       ingestFromFile({
         restaurantId: 'rest-1',
-        file,
+        files: [file],
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
     ).rejects.toBeInstanceOf(IngestionRequestError);
@@ -181,7 +200,12 @@ const sampleItem: IngestionItemPayload = {
 
 describe('createRestaurant', () => {
   it('returns created on 201', async () => {
-    const fetchImpl = fakeFetch(201, { id: 'r-1', slug: 'marias', name: "Maria's", status: 'draft' });
+    const fetchImpl = fakeFetch(201, {
+      id: 'r-1',
+      slug: 'marias',
+      name: "Maria's",
+      status: 'draft',
+    });
 
     const result = await createRestaurant({ name: "Maria's", citySlug: 'durango', fetchImpl });
 
@@ -191,12 +215,21 @@ describe('createRestaurant', () => {
     });
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe('/api/restaurants');
-    expect(JSON.parse(init.body as string)).toMatchObject({ name: "Maria's", city_slug: 'durango' });
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      name: "Maria's",
+      city_slug: 'durango',
+    });
   });
 
   it('returns the candidate list on 409 instead of throwing', async () => {
     const candidates = [
-      { id: 'r-9', slug: 'marias', name: "Maria's Tacos", status: 'published', street: '742 Main Ave' },
+      {
+        id: 'r-9',
+        slug: 'marias',
+        name: "Maria's Tacos",
+        status: 'published',
+        street: '742 Main Ave',
+      },
     ];
     const fetchImpl = fakeFetch(409, { error: 'possible_duplicate', candidates });
 
@@ -274,7 +307,9 @@ describe('fetchRunItems / decideRunItem', () => {
 describe('friendlyIngestionError', () => {
   it('maps 429 quota errors with the limit', () => {
     const err = new IngestionRequestError(429, { error: 'quota_exceeded', limit: 5 } as never);
-    expect(friendlyIngestionError(err)).toBe('Daily scan limit reached (5/day) — try again tomorrow.');
+    expect(friendlyIngestionError(err)).toBe(
+      'Daily scan limit reached (5/day) — try again tomorrow.',
+    );
   });
 
   it('maps 503 ceiling errors', () => {

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -158,7 +158,10 @@ export async function fetchRun(
   runId: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<IngestionRunPayload> {
-  return getJson<IngestionRunPayload>(`/api/ingestion_runs/${encodeURIComponent(runId)}`, fetchImpl);
+  return getJson<IngestionRunPayload>(
+    `/api/ingestion_runs/${encodeURIComponent(runId)}`,
+    fetchImpl,
+  );
 }
 
 export async function fetchRunItems(
@@ -206,10 +209,10 @@ export async function acceptAllRunItems(
   runId: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<IngestionItemPayload[]> {
-  const res = await fetchImpl(
-    `/api/ingestion_runs/${encodeURIComponent(runId)}/items/accept_all`,
-    { method: 'POST', credentials: 'same-origin' },
-  );
+  const res = await fetchImpl(`/api/ingestion_runs/${encodeURIComponent(runId)}/items/accept_all`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  });
   if (!res.ok) {
     let parsed: IngestionApiError | null = null;
     try {
@@ -258,13 +261,17 @@ export async function ingestFromUrl(opts: {
 
 export async function ingestFromFile(opts: {
   restaurantId: string;
-  file: File;
+  files: File[];
   fetchImpl?: typeof fetch;
 }): Promise<IngestionRunPayload> {
-  const { restaurantId, file, fetchImpl = fetch } = opts;
+  const { restaurantId, files, fetchImpl = fetch } = opts;
   const form = new FormData();
   form.append('restaurant_id', restaurantId);
-  form.append('inputs[]', file, file.name);
+  // One run can carry several pages — each menu page/photo becomes an
+  // `inputs[]` entry (the Rails endpoint caps this at INGESTION_MAX_INPUT_FILES).
+  for (const file of files) {
+    form.append('inputs[]', file, file.name);
+  }
   return postIngestionRun(form, fetchImpl, true);
 }
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,22 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-28 — Web scan menu accepts multiple photos/uploads. Branch `claude/scan-menu-multiple-photos-qnjml8`.
+
+- The web `/ingest` "drop a PDF / photo" section was single-file only, while the
+  Rails endpoint (`inputs[]`, capped at `INGESTION_MAX_INPUT_FILES` = 10) and the
+  mobile multi-page capture already supported many. Closed the web gap so a whole
+  multi-page menu uploads as one run.
+- `apps/web/src/lib/ingestion.ts`: `ingestFromFile` now takes `files: File[]` and
+  appends each as `inputs[]` (was a single `file`).
+- `apps/web/src/app/ingest/page.tsx`: `file` state → `File[]`; file picker gets
+  `multiple`; both the camera and picker inputs accumulate (repeat captures + picks
+  add pages rather than replace), input value cleared so the same file can re-add;
+  removable per-file list; "Upload N files" button label.
+- No API/mobile change needed — API + mobile were already multi-input.
+- Tests: +1 lib test (multi-file → 2 `inputs[]`), +3 page tests (multiple picker
+  files, camera accumulation, single-file removal). Web vitest 238; typecheck/lint green.
+
 2026-07-21 — Account page PR-3: favorites (restaurants + dishes). Branch `feat/account-favorites`.
 
 - Final item of the account-page arc. Users can now save **restaurants and dishes**


### PR DESCRIPTION
The web /ingest "drop a PDF / photo" section only held a single file,
while the Rails endpoint already accepts up to INGESTION_MAX_INPUT_FILES
inputs[] and the mobile app already does multi-page capture. This closes
the web gap so a whole multi-page menu uploads as one run.

- ingestFromFile now takes files: File[] and appends each as inputs[].
- The file picker gains `multiple`; both the camera and picker inputs
  accumulate (repeated captures/picks add pages instead of replacing),
  with the input value cleared so the same file can be re-added. Selected
  files render as a removable list; the button reads "Upload N files".

No API or mobile change needed — both were already multi-input.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JHZnrAFAhp3buvhFt4hA8d