### PR TITLE
feat(web): render restaurant menu as photo grid with placeholders

### DIFF
--- a/apps/web/src/app/restaurants/[slug]/ItemRow.tsx
+++ b/apps/web/src/app/restaurants/[slug]/ItemRow.tsx
@@ -5,7 +5,7 @@ import type { RestaurantItem } from '../../../lib/restaurants';
 import { HiddenReasonChip } from './RestaurantClient';
 
 /**
- * Phase 4.11.4 / post-5 — single menu-item row, extracted from
+ * Phase 4.11.4 / post-5 — single menu-item card, extracted from
  * RestaurantClient so render tests can target it directly.
  *
  * The original Phase 4.11.4 PR (#169) deferred a render snapshot
@@ -13,8 +13,9 @@ import { HiddenReasonChip } from './RestaurantClient';
  * yet. PR #189 wired `@testing-library/react` + jsdom; this PR
  * extracts ItemRow + ships the deferred snapshot.
  *
- * Behavior is byte-identical to the previous in-file version of
- * ItemRow — no logic changes, just a file boundary.
+ * Now renders as a card (photo on top, content below) so the menu
+ * lays out as a grid. Items with no `photo_url` get a deterministic
+ * monogram placeholder so the grid never has empty photo slots.
  */
 export interface ItemRowProps {
   item: RestaurantItem;
@@ -23,6 +24,58 @@ export interface ItemRowProps {
   overridden: boolean;
   onToggleOverride: (itemId: string) => void;
   onSetPersistentOverride: (itemId: string, next: boolean) => void;
+}
+
+/**
+ * Deterministic hue (0–359) from a stable string (the item id), so a
+ * given dish always gets the same placeholder tint and the grid reads
+ * as varied rather than a wall of identical gray boxes.
+ */
+function placeholderHue(seed: string): number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) % 360;
+  }
+  return hash;
+}
+
+/**
+ * The dish photo, or a monogram placeholder when the item has none.
+ * Real photos keep the `item-photo-<id>` testid + `<img>` contract
+ * from Phase 4.11.4; the placeholder uses a distinct testid so the
+ * "no <img> when photo_url is null" contract still holds.
+ */
+function ItemPhoto({ item }: { item: RestaurantItem }): ReactElement {
+  if (item.photo_url) {
+    // Cropped dish photo from the source menu page. Plain <img> (not
+    // next/image) since the URL is a Rails signed blob URL whose host
+    // varies per env; loader config would have to learn each one.
+    return (
+      <img
+        src={item.photo_url}
+        alt={item.name}
+        loading="lazy"
+        data-testid={`item-photo-${item.id}`}
+        className="h-40 w-full object-cover"
+      />
+    );
+  }
+
+  const hue = placeholderHue(item.id);
+  const initial = (item.name.trim()[0] ?? '·').toUpperCase();
+  return (
+    <div
+      role="img"
+      aria-label={`${item.name} — no photo yet`}
+      data-testid={`item-photo-placeholder-${item.id}`}
+      className="flex h-40 w-full select-none items-center justify-center"
+      style={{ backgroundColor: `hsl(${hue} 40% 90%)` }}
+    >
+      <span className="text-bw-4xl font-bold" style={{ color: `hsl(${hue} 32% 45%)` }}>
+        {initial}
+      </span>
+    </div>
+  );
 }
 
 export function ItemRow({
@@ -42,79 +95,70 @@ export function ItemRow({
   return (
     <li
       data-testid={`item-${item.id}`}
-      className={['py-bw-3', hidden ? 'opacity-60' : ''].join(' ')}
+      className={[
+        'flex flex-col overflow-hidden rounded-bw-lg border border-zinc-200 bg-white',
+        hidden ? 'opacity-60' : '',
+      ].join(' ')}
     >
-      {item.photo_url && (
-        // Phase 4.11.4 — cropped dish photo from the source menu page.
-        // Plain <img> (not next/image) since the URL is a Rails signed
-        // blob URL whose host varies per env; loader config would have
-        // to learn each one. Lazy-load + fixed max-height avoid CLS.
-        <img
-          src={item.photo_url}
-          alt={item.name}
-          loading="lazy"
-          data-testid={`item-photo-${item.id}`}
-          className="mb-bw-2 h-48 w-full rounded-bw-md object-cover"
-        />
-      )}
-      <p className={['font-semibold', hidden ? 'text-hide' : 'text-zinc-900'].join(' ')}>
-        {item.name}
-      </p>
-      {item.description && (
-        <p className="mt-1 text-bw-sm text-zinc-500">{item.description}</p>
-      )}
-      <a
-        href={`/restaurants/${encodeURIComponent(restaurantSlug)}/items/${encodeURIComponent(item.id)}`}
-        data-testid={`open-item-${item.id}`}
-        className="mt-1 inline-block text-bw-xs font-semibold text-bite hover:text-bite-dark"
-      >
-        {reviewsCount === 0
-          ? 'Be the first to review'
-          : `${reviewsCount} review${reviewsCount === 1 ? '' : 's'} →`}
-      </a>
+      <ItemPhoto item={item} />
+      <div className="flex flex-1 flex-col p-bw-3">
+        <p className={['font-semibold', hidden ? 'text-hide' : 'text-zinc-900'].join(' ')}>
+          {item.name}
+        </p>
+        {item.description && <p className="mt-1 text-bw-sm text-zinc-500">{item.description}</p>}
+        <a
+          href={`/restaurants/${encodeURIComponent(restaurantSlug)}/items/${encodeURIComponent(item.id)}`}
+          data-testid={`open-item-${item.id}`}
+          className="mt-1 inline-block text-bw-xs font-semibold text-bite hover:text-bite-dark"
+        >
+          {reviewsCount === 0
+            ? 'Be the first to review'
+            : `${reviewsCount} review${reviewsCount === 1 ? '' : 's'} →`}
+        </a>
 
-      {showChips && item.reasons.length > 0 && (
-        <div className="mt-bw-2 flex flex-wrap gap-bw-1">
-          {item.reasons.map((r, idx) => (
-            <HiddenReasonChip key={idx} reason={r} />
-          ))}
-        </div>
-      )}
+        {showChips && item.reasons.length > 0 && (
+          <div className="mt-bw-2 flex flex-wrap gap-bw-1">
+            {item.reasons.map((r, idx) => (
+              <HiddenReasonChip key={idx} reason={r} />
+            ))}
+          </div>
+        )}
 
-      {item.reasons.length > 0 && (
-        <div className="mt-bw-2 flex flex-wrap gap-bw-3 text-bw-sm font-semibold">
-          {persistent ? (
-            <button
-              type="button"
-              onClick={() => onSetPersistentOverride(item.id, false)}
-              data-testid={`undo-never-hide-${item.id}`}
-              className="text-bite hover:text-bite-dark"
-            >
-              Always shown — undo
-            </button>
-          ) : (
-            <>
+        {item.reasons.length > 0 && (
+          <div className="mt-bw-2 flex flex-wrap gap-bw-3 text-bw-sm font-semibold">
+            {persistent ? (
               <button
                 type="button"
-                onClick={() => onToggleOverride(item.id)}
+                onClick={() => onSetPersistentOverride(item.id, false)}
+                data-testid={`undo-never-hide-${item.id}`}
                 className="text-bite hover:text-bite-dark"
               >
-                {overridden ? 'Hide again' : 'Show anyway'}
+                Always shown — undo
               </button>
-              {overridden && (
+            ) : (
+              <>
                 <button
                   type="button"
-                  onClick={() => onSetPersistentOverride(item.id, true)}
-                  data-testid={`set-never-hide-${item.id}`}
-                  className="text-zinc-600 hover:text-zinc-800"
+                  onClick={() => onToggleOverride(item.id)}
+                  className="text-bite hover:text-bite-dark"
                 >
-                  Never hide this dish
+                  {overridden ? 'Hide again' : 'Show anyway'}
                 </button>
-              )}
-            </>
-          )}
-        </div>
-      )}
+                {overridden && (
+                  <button
+                    type="button"
+                    onClick={() => onSetPersistentOverride(item.id, true)}
+                    data-testid={`set-never-hide-${item.id}`}
+                    className="text-zinc-600 hover:text-zinc-800"
+                  >
+                    Never hide this dish
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
     </li>
   );
 }

--- a/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
+++ b/apps/web/src/app/restaurants/[slug]/RestaurantClient.tsx
@@ -250,9 +250,9 @@ export function AllergenNotice() {
       data-testid="allergen-notice"
       className="mt-bw-4 rounded-bw-md border border-warn/40 bg-warn/10 p-bw-3 text-bw-sm text-zinc-800"
     >
-      <strong>A filter, not a guarantee.</strong> BiteWorthy reads menus with AI and your
-      dietary filter — but recipes change and a result can still miss an allergen. Always
-      confirm with the restaurant before ordering for a serious allergy.
+      <strong>A filter, not a guarantee.</strong> BiteWorthy reads menus with AI and your dietary
+      filter — but recipes change and a result can still miss an allergen. Always confirm with the
+      restaurant before ordering for a serious allergy.
     </div>
   );
 }
@@ -262,8 +262,8 @@ function FilterBadge({ filter }: { filter: FilterSummary }) {
     filter.source === 'preset'
       ? `Preset · ${filter.preset_slug ?? 'unknown'}`
       : filter.source === 'user_profile'
-      ? 'Your saved profile'
-      : 'No filter';
+        ? 'Your saved profile'
+        : 'No filter';
   return (
     <span
       data-testid="filter-badge"
@@ -330,7 +330,7 @@ function SectionBlock({
   return (
     <section className="mt-bw-6">
       <h2 className="text-bw-lg font-bold">{section.name}</h2>
-      <ul className="mt-bw-2 divide-y divide-zinc-100">
+      <ul className="mt-bw-2 grid grid-cols-1 gap-bw-4 sm:grid-cols-2 lg:grid-cols-3">
         {section.visible.map((item) => (
           <ItemRow
             key={item.id}
@@ -342,7 +342,7 @@ function SectionBlock({
           />
         ))}
         {section.visible.length === 0 && section.hidden.length > 0 && (
-          <li className="py-bw-2 text-bw-sm text-zinc-500">
+          <li className="col-span-full py-bw-2 text-bw-sm text-zinc-500">
             Every item in this section is hidden by your filter.
           </li>
         )}
@@ -363,7 +363,7 @@ function SectionBlock({
       {hiddenOpen && (
         <ul
           id={`hidden-${section.id ?? 'none'}`}
-          className="mt-bw-2 divide-y divide-zinc-100"
+          className="mt-bw-2 grid grid-cols-1 gap-bw-4 sm:grid-cols-2 lg:grid-cols-3"
         >
           {section.hidden.map((item) => (
             <ItemRow
@@ -430,7 +430,8 @@ function ClaimSection({ slug, restaurant }: { slug: string; restaurant: Restaura
   if (done) {
     return (
       <p className="mt-bw-3 text-bw-sm text-zinc-700" data-testid="claim-sent">
-        Verification email sent to <strong>{done.email}</strong>. Click the link to confirm your claim.
+        Verification email sent to <strong>{done.email}</strong>. Click the link to confirm your
+        claim.
         {!done.auto && (
           <span className="ml-1 text-bw-xs text-zinc-500">
             (Domain didn&rsquo;t match this restaurant&rsquo;s website — admin review may follow.)
@@ -480,10 +481,15 @@ function ClaimSection({ slug, restaurant }: { slug: string; restaurant: Restaura
   };
 
   return (
-    <form onSubmit={submit} className="mt-bw-3 rounded-bw-md border border-zinc-200 p-bw-3" data-testid="claim-form">
+    <form
+      onSubmit={submit}
+      className="mt-bw-3 rounded-bw-md border border-zinc-200 p-bw-3"
+      data-testid="claim-form"
+    >
       <p className="text-bw-sm font-semibold text-zinc-700">Claim this restaurant</p>
       <p className="mt-1 text-bw-xs text-zinc-500">
-        Use an email at the restaurant&rsquo;s own domain — we&rsquo;ll send a one-time verification link.
+        Use an email at the restaurant&rsquo;s own domain — we&rsquo;ll send a one-time verification
+        link.
       </p>
       <input
         type="email"

--- a/apps/web/src/app/restaurants/[slug]/__tests__/ItemRow.test.tsx
+++ b/apps/web/src/app/restaurants/[slug]/__tests__/ItemRow.test.tsx
@@ -63,6 +63,28 @@ describe('ItemRow — photo_url contract (Phase 4.11.4)', () => {
   });
 });
 
+describe('ItemRow — placeholder photo', () => {
+  // Every card fills its photo slot: a real photo when we have one,
+  // otherwise a monogram placeholder so the grid never shows empty
+  // gaps. The two are mutually exclusive.
+  it('renders a monogram placeholder when photo_url is null', () => {
+    renderRow({ photo_url: null });
+    const placeholder = screen.getByTestId('item-photo-placeholder-item-1');
+    expect(placeholder).toBeInTheDocument();
+    // Monogram is the dish name's first letter, uppercased.
+    expect(placeholder).toHaveTextContent('P');
+    // Labelled for assistive tech, since it stands in for the photo.
+    expect(placeholder).toHaveAttribute('role', 'img');
+    expect(placeholder).toHaveAttribute('aria-label', expect.stringContaining('Pad Thai'));
+  });
+
+  it('renders the real photo and no placeholder when photo_url is set', () => {
+    renderRow({ photo_url: 'https://example.test/dish.jpg' });
+    expect(screen.getByTestId('item-photo-item-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('item-photo-placeholder-item-1')).not.toBeInTheDocument();
+  });
+});
+
 describe('ItemRow — name + description + open link', () => {
   it('renders the item name + description', () => {
     renderRow({});
@@ -78,17 +100,12 @@ describe('ItemRow — name + description + open link', () => {
   it('encodes the slug + id in the open-item link', () => {
     renderRow({});
     const link = screen.getByTestId('open-item-item-1');
-    expect(link).toHaveAttribute(
-      'href',
-      '/restaurants/cream-bean-berry/items/item-1',
-    );
+    expect(link).toHaveAttribute('href', '/restaurants/cream-bean-berry/items/item-1');
   });
 
   it('shows "Be the first to review" when reviews_count is 0 / undefined', () => {
     renderRow({});
-    expect(screen.getByTestId('open-item-item-1')).toHaveTextContent(
-      'Be the first to review',
-    );
+    expect(screen.getByTestId('open-item-item-1')).toHaveTextContent('Be the first to review');
   });
 
   it('pluralizes the reviews badge correctly', () => {

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,21 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-29 — Restaurant menu renders as a photo grid with placeholders. Branch `claude/placeholder-photos-restaurant-grid-rh7ich`.
+
+- The restaurant page (`apps/web/.../restaurants/[slug]`) listed items as a flat
+  vertical list; only items with a cropped `photo_url` showed an image, leaving
+  photo-less items visually bare. Reworked `ItemRow` into a card (photo on top,
+  content below) and switched `SectionBlock`'s visible + hidden lists to a
+  responsive grid (`grid-cols-1 sm:2 lg:3`).
+- Items with no `photo_url` now get a deterministic monogram placeholder
+  (first letter over an id-seeded HSL tint, `role="img"` + aria-label) so the
+  grid never has empty photo slots. Real-photo `<img>` contract from Phase
+  4.11.4 is unchanged; placeholder uses a distinct testid so the existing
+  "no `<img>` when photo_url is null" test still holds.
+- Purely presentational — no API/serializer changes. Added placeholder render
+  tests; web typecheck + lint clean, 34/34 restaurant tests pass.
+
 2026-07-28 — Web scan menu accepts multiple photos/uploads. Branch `claude/scan-menu-multiple-photos-qnjml8`.
 
 - The web `/ingest` "drop a PDF / photo" section was single-file only, while the


### PR DESCRIPTION
## Why

The restaurant menu page listed items as a flat vertical list with inconsistent visual presentation: only items with a cropped `photo_url` showed an image, leaving photo-less items visually bare and breaking the grid layout. This change reworks the menu into a responsive card grid where every item has a photo slot, improving visual consistency and scannability.

## What

- **Refactored `ItemRow` into a card layout**: photo on top (fixed height), content below. Changed from a list item with optional image to a flex column with consistent structure.
- **Added monogram placeholder photos**: Items without `photo_url` now render a deterministic placeholder (first letter of the dish name over an id-seeded HSL tint, `role="img"` + aria-label). The placeholder uses a distinct testid (`item-photo-placeholder-<id>`) so the existing "no `<img>` when photo_url is null" contract still holds.
- **Switched menu lists to responsive grid**: `SectionBlock` now renders visible and hidden item lists as `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` instead of `divide-y` vertical lists. Empty-state message spans full width with `col-span-full`.
- **Added `placeholderHue()` helper**: Stable hash function that derives a consistent hue (0–359) from the item id, so a given dish always gets the same tint and the grid reads as visually varied.
- **Extracted `ItemPhoto` component**: Encapsulates the photo/placeholder logic with clear testid contracts.
- **No API/serializer changes**: Purely presentational. Existing `photo_url` field is unchanged.

## Test plan

- [x] CI green (typecheck + lint clean)
- [x] Added placeholder render tests: monogram displays correctly, aria-label present, real photo and placeholder are mutually exclusive
- [x] Existing 34 restaurant tests pass (photo contract, name/description, open link, reviews badge, filter chips, override buttons all unchanged)
- [x] Grid layout verified in browser at mobile/tablet/desktop breakpoints

## Notes

The placeholder hue derivation uses a simple modular hash (not cryptographic) to keep the function lightweight and deterministic. The monogram uses the first character of `item.name.trim()` with a fallback to `·` if the name is empty, ensuring every card has visible content.

https://claude.ai/code/session_016ytrkoMohxP7kSUwKv4PAe