### PR TITLE
feat(api): nest menu add-on lines as addons during ingestion

### DIFF
--- a/apps/api/app/avo/resources/ingestion_item.rb
+++ b/apps/api/app/avo/resources/ingestion_item.rb
@@ -26,6 +26,7 @@ class Avo::Resources::IngestionItem < Avo::BaseResource
       field :ingredients_payload, as: :code, language: "json", name: "Ingredients (slug + confidence)"
       field :tags_payload,        as: :code, language: "json", name: "Tags (slug + confidence)"
       field :prices_payload,      as: :code, language: "json", name: "Prices (size + cents)"
+      field :addons_payload,      as: :code, language: "json", name: "Add-ons (name + cents)"
     end
 
     panel "Couldn't match" do

--- a/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
@@ -118,6 +118,7 @@ module Api
           :name, :description,
           ingredients_payload:    [:slug, :confidence, :source],
           tags_payload:           [:slug, :confidence, :source],
+          addons_payload:         [:name, :price_cents, :source],
           unresolved_ingredients: [],
           unresolved_tags:        []
         )
@@ -137,6 +138,7 @@ module Api
           ingredients_payload:    item.ingredients_payload,
           tags_payload:           item.tags_payload,
           prices_payload:         item.prices_payload,
+          addons_payload:         item.addons_payload,
           unresolved_ingredients: item.unresolved_ingredients,
           unresolved_tags:        item.unresolved_tags
         }

--- a/apps/api/app/jobs/extract_menu_job.rb
+++ b/apps/api/app/jobs/extract_menu_job.rb
@@ -63,16 +63,29 @@ class ExtractMenuJob < ApplicationJob
   # position so the resolve stages can write their indexed results back onto
   # the right row. ingredients_payload / tags_payload stay empty ([] default)
   # until enrichment fills them.
+  #
+  # Add-on guard: the extraction prompt nests add-on/upsell lines under
+  # their parent dish (`addons`), but the model sometimes still emits an
+  # "Add X" line as a top-level item. Those fold into the PREVIOUS item's
+  # addons_payload here (source: "guard") instead of materializing — an
+  # upsell line must never publish as a dish. First-in-section has no
+  # parent to attach to, so it materializes normally.
   def materialize_items!(run)
     position = 0
     Array(run.staging["sections"]).each do |section|
-      section_name = section["name"]
+      previous = nil
       Array(section["items"]).each do |item|
-        run.ingestion_items.create!(
+        if previous && addon_line?(item["name"])
+          previous.update!(addons_payload: previous.addons_payload + [guard_addon_row(item)])
+          next
+        end
+
+        previous = run.ingestion_items.create!(
           name:           item["name"],
           description:    item["description"],
-          section_name:   section_name,
+          section_name:   section["name"],
           prices_payload: Array(item["prices"]),
+          addons_payload: addon_rows(item["addons"]),
           image_bbox:     item["image_bbox"],
           position:       position,
           decision:       "pending"
@@ -80,5 +93,24 @@ class ExtractMenuJob < ApplicationJob
         position += 1
       end
     end
+  end
+
+  # Deliberately narrow — "Add chicken", "Chips & salsa +". Not "extra"
+  # (collides with dish names like "Extra Crispy Wings").
+  def addon_line?(name)
+    stripped = name.to_s.strip
+    stripped.match?(/\Aadd\s/i) || stripped.end_with?("+")
+  end
+
+  def addon_rows(addons)
+    Array(addons).map do |addon|
+      { "name" => addon["name"], "price_cents" => addon["price_cents"], "source" => "extract" }
+    end
+  end
+
+  def guard_addon_row(item)
+    name = item["name"].to_s.strip.sub(/\Aadd\s+/i, "").sub(/\s*\+\z/, "").strip
+    first_price = Array(item["prices"]).first || {}
+    { "name" => name, "price_cents" => first_price["price_cents"], "source" => "guard" }
   end
 end

--- a/apps/api/app/jobs/extract_menu_job.rb
+++ b/apps/api/app/jobs/extract_menu_job.rb
@@ -95,11 +95,14 @@ class ExtractMenuJob < ApplicationJob
     end
   end
 
-  # Deliberately narrow — "Add chicken", "Chips & salsa +". Not "extra"
-  # (collides with dish names like "Extra Crispy Wings").
+  # Deliberately narrow — a false fold silently drops a dish with no
+  # recovery path in verify, so only the unambiguous "Add …" prefix
+  # triggers. Not "extra" (collides with "Extra Crispy Wings") and not
+  # a trailing "+" (menus use it as a footnote/spice marker); those rely
+  # on the prompt's LLM classification, and a miss just stages a card a
+  # human can reject.
   def addon_line?(name)
-    stripped = name.to_s.strip
-    stripped.match?(/\Aadd\s/i) || stripped.end_with?("+")
+    name.to_s.strip.match?(/\Aadd\s/i)
   end
 
   def addon_rows(addons)

--- a/apps/api/app/models/ingestion_item.rb
+++ b/apps/api/app/models/ingestion_item.rb
@@ -77,6 +77,16 @@ class IngestionItem < ApplicationRecord
         )
       end
 
+      Array(addons_payload).each do |row|
+        addon_name = row["name"] || row[:name]
+        next if addon_name.blank?
+
+        ItemModifier.create!(
+          item: created, name: addon_name, kind: "addition",
+          price_cents: row["price_cents"] || row[:price_cents]
+        )
+      end
+
       attach_dish_photo!(created)
 
       update!(item: created, decision: "accepted", decided_at: Time.current)

--- a/apps/api/app/services/ingestion/extract_menu_prompt.rb
+++ b/apps/api/app/services/ingestion/extract_menu_prompt.rb
@@ -31,6 +31,12 @@ module Ingestion
                     "price_cents": <integer cents, or null if absent>
                   }
                 ],
+                "addons": [
+                  {
+                    "name": "<the thing being added>",
+                    "price_cents": <integer cents, or null if absent>
+                  }
+                ],
                 "image_bbox": { "x": 0.0, "y": 0.0, "w": 0.0, "h": 0.0 }
               }
             ]
@@ -46,6 +52,20 @@ module Ingestion
         emit one element per price in the `prices` array.
       * `price_cents` is in CENTS. "$4.50" becomes 450.
       * Output JSON only — no markdown fences, no commentary.
+
+      Add-ons / upsells:
+      * A line offering to ADD something to a dish for extra money —
+        "Add chicken $3", "+ guajillo salsa 4.00", "add avocado +$2" —
+        is NOT a menu item. Emit it in the `addons` array of the item
+        it modifies (the dish it is printed under or beside).
+      * An addon's `name` is the thing being added, stripped of the
+        "Add"/"+"/price scaffolding: "Add guajillo-tomatillo salsa +
+        $4.00" becomes { "name": "guajillo-tomatillo salsa",
+        "price_cents": 400 }.
+      * A standalone dish that happens to be a side or extra ("Side of
+        Guacamole" in a Sides section) is still a normal item — only
+        lines that modify another dish become addons.
+      * If an item has no add-on lines, OMIT the `addons` field.
 
       Per-dish photos:
       * Many menus include a small photo of an individual dish next to

--- a/apps/api/app/services/ingestion/menu_extraction_schema.rb
+++ b/apps/api/app/services/ingestion/menu_extraction_schema.rb
@@ -54,6 +54,21 @@ module Ingestion
                       }
                     }
                   },
+                  # Add-on / upsell lines ("Add chicken $3") nested under
+                  # the dish they modify instead of surfacing as items.
+                  # Optional — items without add-ons omit the field.
+                  addons: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      required: ["name"],
+                      additionalProperties: false,
+                      properties: {
+                        name:        { type: "string", minLength: 1 },
+                        price_cents: { type: %w[integer null], minimum: 0 }
+                      }
+                    }
+                  },
                   # Phase 4.11.2 — optional per-dish bounding box for the
                   # cropper (Phase 4.11.1 + 4.11.3). Coordinates are
                   # fractions of the source page so resolution-independent:

--- a/apps/api/db/migrate/20260729130000_add_addons_payload_to_ingestion_items.rb
+++ b/apps/api/db/migrate/20260729130000_add_addons_payload_to_ingestion_items.rb
@@ -1,0 +1,10 @@
+class AddAddonsPayloadToIngestionItems < ActiveRecord::Migration[8.1]
+  # Add-on/upsell lines ("Add guajillo-tomatillo salsa + $4.00") nested under
+  # their parent dish at extraction. Rows: { name, price_cents, source }
+  # where source is "extract" (LLM classified it) or "guard" (deterministic
+  # materialization backstop folded a stray top-level "Add X" item).
+  # Promoted to ItemModifier (kind: "addition") when the parent is accepted.
+  def change
+    add_column :ingestion_items, :addons_payload, :jsonb, default: [], null: false
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_29_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -147,6 +147,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_120000) do
   end
 
   create_table "ingestion_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "addons_payload", default: [], null: false
     t.datetime "created_at", null: false
     t.datetime "decided_at"
     t.string "decision", default: "pending", null: false

--- a/apps/api/spec/cassettes/extract_menu_job/simply_tasty_thai_appetizers.yml
+++ b/apps/api/spec/cassettes/extract_menu_job/simply_tasty_thai_appetizers.yml
@@ -15,13 +15,24 @@ http_interactions:
         \"\u003cthe printed description, or null if absent\u003e\",\n          \"prices\":
         [\n            {\n              \"size\": \"\u003csize label, or null when
         there is only one price\u003e\",\n              \"price_cents\": \u003cinteger
-        cents, or null if absent\u003e\n            }\n          ],\n          \"image_bbox\":
+        cents, or null if absent\u003e\n            }\n          ],\n          \"addons\":
+        [\n            {\n              \"name\": \"\u003cthe thing being added\u003e\",\n              \"price_cents\":
+        \u003cinteger cents, or null if absent\u003e\n            }\n          ],\n          \"image_bbox\":
         { \"x\": 0.0, \"y\": 0.0, \"w\": 0.0, \"h\": 0.0 }\n        }\n      ]\n    }\n  ]\n}\n\nRules:\n*
         Do NOT invent items. If you can''t read it, omit it.\n* Preserve item names
         verbatim — including spelling, capitalization,\n  diacritics. Don''t translate.\n*
         If a single item has multiple prices (small / large / etc.),\n  emit one element
         per price in the `prices` array.\n* `price_cents` is in CENTS. \"$4.50\" becomes
-        450.\n* Output JSON only — no markdown fences, no commentary.\n\nPer-dish
+        450.\n* Output JSON only — no markdown fences, no commentary.\n\nAdd-ons /
+        upsells:\n* A line offering to ADD something to a dish for extra money —\n  \"Add
+        chicken $3\", \"+ guajillo salsa 4.00\", \"add avocado +$2\" —\n  is NOT a
+        menu item. Emit it in the `addons` array of the item\n  it modifies (the dish
+        it is printed under or beside).\n* An addon''s `name` is the thing being added,
+        stripped of the\n  \"Add\"/\"+\"/price scaffolding: \"Add guajillo-tomatillo
+        salsa +\n  $4.00\" becomes { \"name\": \"guajillo-tomatillo salsa\",\n  \"price_cents\":
+        400 }.\n* A standalone dish that happens to be a side or extra (\"Side of\n  Guacamole\"
+        in a Sides section) is still a normal item — only\n  lines that modify another
+        dish become addons.\n* If an item has no add-on lines, OMIT the `addons` field.\n\nPer-dish
         photos:\n* Many menus include a small photo of an individual dish next to\n  its
         name + description. When you see one, return its bounding\n  box as `image_bbox:
         { \"x\": \u003cleft\u003e, \"y\": \u003ctop\u003e, \"w\": \u003cwidth\u003e,\n  \"h\":
@@ -40,7 +51,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v2.14.1
+      - Faraday v2.14.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -51,7 +62,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2026 00:13:23 GMT
+      - Thu, 30 Jul 2026 03:44:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -59,75 +70,100 @@ http_interactions:
       Connection:
       - keep-alive
       Anthropic-Ratelimit-Input-Tokens-Limit:
-      - '800000'
+      - '10000000'
       Anthropic-Ratelimit-Input-Tokens-Remaining:
-      - '799000'
+      - '9999000'
       Anthropic-Ratelimit-Input-Tokens-Reset:
-      - '2026-05-01T00:13:13Z'
+      - '2026-07-30T03:43:46Z'
       Anthropic-Ratelimit-Output-Tokens-Limit:
-      - '160000'
+      - '2000000'
       Anthropic-Ratelimit-Output-Tokens-Remaining:
-      - '159000'
+      - '2000000'
       Anthropic-Ratelimit-Output-Tokens-Reset:
-      - '2026-05-01T00:13:23Z'
+      - '2026-07-30T03:44:02Z'
       Anthropic-Ratelimit-Requests-Limit:
-      - '2000'
+      - '10000'
       Anthropic-Ratelimit-Requests-Remaining:
-      - '1999'
+      - '9999'
       Anthropic-Ratelimit-Requests-Reset:
-      - '2026-05-01T00:13:12Z'
+      - '2026-07-30T03:43:45Z'
       Anthropic-Ratelimit-Tokens-Limit:
-      - '960000'
+      - '12000000'
       Anthropic-Ratelimit-Tokens-Remaining:
-      - '958000'
+      - '11999000'
       Anthropic-Ratelimit-Tokens-Reset:
-      - '2026-05-01T00:13:13Z'
+      - '2026-07-30T03:43:46Z'
       Request-Id:
-      - req_011Caat8Q95BgZSkP5udWgkt
+      - req_011CdXYz5bKY7cKwdeYyf8FH
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Anthropic-Organization-Id:
       - 1ddf08a4-ce21-4dfb-bbf0-fd52d76d3811
+      Traceresponse:
+      - 00-49b3e0343e11078bf857d541cca23c0d-7730646cfea71fd2-01
       Server:
       - cloudflare
-      X-Envoy-Upstream-Service-Time:
-      - '11543'
       Vary:
       - Accept-Encoding
-      Set-Cookie:
-      - _cfuvid=AkCpGK3hD9Q1vsfST0yOSKgz49GgZmgiUafVKG5GZHw-1777594391.674771-1.0.1.1-9saPfXFHTfutDSIIBqycRREfjgcpO9Gz8pEBAoH9Jqs;
-        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
       X-Robots-Tag:
       - none
-      Cf-Cache-Status:
-      - DYNAMIC
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Cf-Cache-Status:
+      - DYNAMIC
       Cf-Ray:
-      - 9f4a9433fac25660-ATL
+      - a2315c61aa5a4cb3-SLC
     body:
       encoding: ASCII-8BIT
-      string: '{"model":"claude-sonnet-4-6","id":"msg_01CRYFBkqc32UaNkk25PG9gn","type":"message","role":"assistant","content":[{"type":"text","text":"{\"sections\":[{\"name\":\"APPETIZERS\",\"items\":[{\"name\":\"SPRING
-        ROLLS\",\"description\":\"Crispy fried mini pork and vegetable roll. Vegetarian
-        spring rolls are available.\",\"prices\":[{\"size\":null,\"price_cents\":699}],\"image_bbox\":{\"x\":0.57,\"y\":0.11,\"w\":0.38,\"h\":0.16}},{\"name\":\"LUMPIA\",\"description\":\"Crispy
-        fried mini chicken and vegetable roll.\",\"prices\":[{\"size\":null,\"price_cents\":699}]},{\"name\":\"FORGET
-        ME NOT\",\"description\":\"Spring rolls in a cucumber salad, topped with plum
-        sauce, peanuts, and green onions.\",\"prices\":[{\"size\":null,\"price_cents\":799}],\"image_bbox\":{\"x\":0.57,\"y\":0.27,\"w\":0.38,\"h\":0.16}},{\"name\":\"FRESH
-        ROLL\",\"description\":\"Shrimp, lettuce, carrots, red cabbage, and plum sauce
-        wrapped in rice paper, served with peanut sauce.\",\"prices\":[{\"size\":\"Vegetarian\",\"price_cents\":699},{\"size\":\"Shrimp\",\"price_cents\":799}]},{\"name\":\"FRIED
-        TOFU\",\"description\":\"Crispy tofu served on top of cucumber salad and plum
-        sauce.\",\"prices\":[{\"size\":null,\"price_cents\":699}]},{\"name\":\"GOLDEN
-        MONEY BAGS\",\"description\":\"Marinated pork with Thai herbs. Served with
-        Thai chilli sauce.\",\"prices\":[{\"size\":null,\"price_cents\":699}],\"image_bbox\":{\"x\":0.03,\"y\":0.6,\"w\":0.3,\"h\":0.18}},{\"name\":\"CHICKEN
-        SATAY\",\"description\":\"Marinated and grilled in curry spices. Served with
-        peanut sauce.\",\"prices\":[{\"size\":null,\"price_cents\":799}],\"image_bbox\":{\"x\":0.03,\"y\":0.78,\"w\":0.3,\"h\":0.18}},{\"name\":\"CRAB
-        RANGOON\",\"description\":\"Crispy wontons with cream cheese and a curry seasoned
-        mix of real and imitation crab.\",\"prices\":[{\"size\":null,\"price_cents\":699}],\"image_bbox\":{\"x\":0.03,\"y\":0.96,\"w\":0.3,\"h\":0.18}},{\"name\":\"GYOZA\",\"description\":\"(Steamed
-        or fried) Pork pot-stickers served with vinegar soy sauce.\",\"prices\":[{\"size\":null,\"price_cents\":699}]},{\"name\":\"FRIED
-        CALAMARI\",\"description\":null,\"prices\":[{\"size\":null,\"price_cents\":799}]},{\"name\":\"THAI
-        MINI CURRY PUFF\",\"description\":\"Homemade mini pastry filled with minced
-        curry-chicken and potatoes. Served with plum sauce.\",\"prices\":[{\"size\":null,\"price_cents\":699}]},{\"name\":\"CRISPY
-        OCEAN\",\"description\":\"Jumbo seafood and vegetable tempura with shrimp,
-        mussels, squid, crab and scallops. Served with Sriracha plum sauce.\",\"prices\":[{\"size\":null,\"price_cents\":1999}]}]}]}"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":2079,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":774,"service_tier":"standard","inference_geo":"global"}}'
-  recorded_at: Fri, 01 May 2026 00:13:23 GMT
+      string: '{"model":"claude-sonnet-4-6","id":"msg_011CdXYz6sDXxY7o7g7CzLbu","type":"message","role":"assistant","content":[{"type":"text","text":"```json\n{\n  \"sections\":
+        [\n    {\n      \"name\": \"APPETIZERS\",\n      \"items\": [\n        {\n          \"name\":
+        \"SPRING ROLLS\",\n          \"description\": \"Crispy fried mini pork and
+        vegetable roll. Vegetarian spring rolls are available.\",\n          \"prices\":
+        [\n            {\n              \"size\": null,\n              \"price_cents\":
+        699\n            }\n          ],\n          \"image_bbox\": { \"x\": 0.57,
+        \"y\": 0.1, \"w\": 0.4, \"h\": 0.15 }\n        },\n        {\n          \"name\":
+        \"LUMPIA\",\n          \"description\": \"Crispy fried mini chicken and vegetable
+        roll.\",\n          \"prices\": [\n            {\n              \"size\":
+        null,\n              \"price_cents\": 699\n            }\n          ]\n        },\n        {\n          \"name\":
+        \"FORGET ME NOT\",\n          \"description\": \"Spring rolls in a cucumber
+        salad, topped with plum sauce, peanuts, and green onions.\",\n          \"prices\":
+        [\n            {\n              \"size\": null,\n              \"price_cents\":
+        799\n            }\n          ],\n          \"image_bbox\": { \"x\": 0.57,
+        \"y\": 0.26, \"w\": 0.4, \"h\": 0.15 }\n        },\n        {\n          \"name\":
+        \"FRESH ROLL\",\n          \"description\": \"Shrimp, lettuce, carrots, red
+        cabbage, and plum sauce wrapped in rice paper, served with peanut sauce.\",\n          \"prices\":
+        [\n            {\n              \"size\": \"Vegetarian\",\n              \"price_cents\":
+        699\n            },\n            {\n              \"size\": \"Shrimp\",\n              \"price_cents\":
+        799\n            }\n          ]\n        },\n        {\n          \"name\":
+        \"FRIED TOFU\",\n          \"description\": \"Crispy tofu served on top of
+        cucumber salad and plum sauce.\",\n          \"prices\": [\n            {\n              \"size\":
+        null,\n              \"price_cents\": 699\n            }\n          ]\n        },\n        {\n          \"name\":
+        \"GOLDEN MONEY BAGS\",\n          \"description\": \"Marinated pork with Thai
+        herbs. Served with Thai chilli sauce.\",\n          \"prices\": [\n            {\n              \"size\":
+        null,\n              \"price_cents\": 699\n            }\n          ],\n          \"image_bbox\":
+        { \"x\": 0.02, \"y\": 0.6, \"w\": 0.35, \"h\": 0.18 }\n        },\n        {\n          \"name\":
+        \"CHICKEN SATAY\",\n          \"description\": \"Marinated and grilled in
+        curry spices. Served with peanut sauce.\",\n          \"prices\": [\n            {\n              \"size\":
+        null,\n              \"price_cents\": 799\n            }\n          ],\n          \"image_bbox\":
+        { \"x\": 0.02, \"y\": 0.74, \"w\": 0.35, \"h\": 0.18 }\n        },\n        {\n          \"name\":
+        \"CRAB RANGOON\",\n          \"description\": \"Crispy wontons with cream
+        cheese and a curry seasoned mix of real and imitation crab.\",\n          \"prices\":
+        [\n            {\n              \"size\": null,\n              \"price_cents\":
+        699\n            }\n          ],\n          \"image_bbox\": { \"x\": 0.02,
+        \"y\": 0.88, \"w\": 0.35, \"h\": 0.18 }\n        },\n        {\n          \"name\":
+        \"GYOZA\",\n          \"description\": \"(Steamed or fried) Pork pot-stickers
+        served with vinegar soy sauce.\",\n          \"prices\": [\n            {\n              \"size\":
+        null,\n              \"price_cents\": 699\n            }\n          ]\n        },\n        {\n          \"name\":
+        \"FRIED CALAMARI\",\n          \"description\": null,\n          \"prices\":
+        [\n            {\n              \"size\": null,\n              \"price_cents\":
+        799\n            }\n          ]\n        },\n        {\n          \"name\":
+        \"THAI MINI CURRY PUFF\",\n          \"description\": \"Homemade mini pastry
+        filled with minced curry-chicken and potatoes. Served with plum sauce.\",\n          \"prices\":
+        [\n            {\n              \"size\": null,\n              \"price_cents\":
+        699\n            }\n          ]\n        },\n        {\n          \"name\":
+        \"CRISPY OCEAN\",\n          \"description\": \"Jumbo seafood and vegetable
+        tempura with shrimp, mussels, squid, crab and scallops. Served with Sriracha
+        plum sauce.\",\n          \"prices\": [\n            {\n              \"size\":
+        null,\n              \"price_cents\": 1999\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}\n```"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":2358,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1192,"service_tier":"standard","inference_geo":"global"}}'
+  recorded_at: Thu, 30 Jul 2026 03:44:02 GMT
 recorded_with: VCR 6.4.0

--- a/apps/api/spec/jobs/extract_menu_job_spec.rb
+++ b/apps/api/spec/jobs/extract_menu_job_spec.rb
@@ -116,6 +116,99 @@ RSpec.describe ExtractMenuJob, type: :job do
     end
   end
 
+  # Add-on guard — upsell lines ("Add X for $3") must never materialize as
+  # dishes. The prompt nests them under their parent (`addons`); the
+  # deterministic backstop here catches the ones the model still emits as
+  # top-level items.
+  describe "add-on handling" do
+    def perform_with(extraction)
+      attach_fake_input!
+      allow_any_instance_of(AnthropicClient)
+        .to receive(:messages_create).and_return(extraction)
+      described_class.perform_now(run.id)
+    end
+
+    it "copies nested addons onto the parent's addons_payload with extract provenance" do
+      perform_with(
+        "sections" => [
+          { "name" => "Starters", "items" => [
+            { "name" => "Fire-Roasted Guacamole",
+              "prices" => [{ "size" => nil, "price_cents" => 1700 }],
+              "addons" => [{ "name" => "guajillo-tomatillo salsa", "price_cents" => 400 }] }
+          ] }
+        ]
+      )
+
+      item = run.ingestion_items.sole
+      expect(item.addons_payload).to eq(
+        [{ "name" => "guajillo-tomatillo salsa", "price_cents" => 400, "source" => "extract" }]
+      )
+    end
+
+    it "folds a stray top-level 'Add X' item into the previous item instead of materializing it" do
+      perform_with(
+        "sections" => [
+          { "name" => "Starters", "items" => [
+            { "name" => "Fire-Roasted Guacamole",
+              "prices" => [{ "size" => nil, "price_cents" => 1700 }] },
+            { "name" => "Add guajillo-tomatillo salsa",
+              "prices" => [{ "size" => nil, "price_cents" => 400 }] },
+            { "name" => "Roasted Brussels Sprouts",
+              "prices" => [{ "size" => nil, "price_cents" => 1700 }] }
+          ] }
+        ]
+      )
+
+      expect(run.ingestion_items.pluck(:name))
+        .to contain_exactly("Fire-Roasted Guacamole", "Roasted Brussels Sprouts")
+      expect(run.ingestion_items.find_by(name: "Fire-Roasted Guacamole").addons_payload).to eq(
+        [{ "name" => "guajillo-tomatillo salsa", "price_cents" => 400, "source" => "guard" }]
+      )
+      # Positions stay contiguous — only real dishes count.
+      expect(run.ingestion_items.order(:position).pluck(:position)).to eq([0, 1])
+    end
+
+    it "folds a trailing-plus name and strips the scaffolding" do
+      perform_with(
+        "sections" => [
+          { "name" => "Starters", "items" => [
+            { "name" => "Guacamole", "prices" => [{ "size" => nil, "price_cents" => 1700 }] },
+            { "name" => "chips & salsa +", "prices" => [{ "size" => nil, "price_cents" => 300 }] }
+          ] }
+        ]
+      )
+
+      expect(run.ingestion_items.sole.addons_payload).to eq(
+        [{ "name" => "chips & salsa", "price_cents" => 300, "source" => "guard" }]
+      )
+    end
+
+    it "materializes an addon-looking line normally when the section has no previous item" do
+      perform_with(
+        "sections" => [
+          { "name" => "Extras", "items" => [
+            { "name" => "Add chicken", "prices" => [{ "size" => nil, "price_cents" => 300 }] }
+          ] }
+        ]
+      )
+
+      expect(run.ingestion_items.sole.name).to eq("Add chicken")
+    end
+
+    it "does not fold ordinary dishes whose names merely start with common words" do
+      perform_with(
+        "sections" => [
+          { "name" => "Mains", "items" => [
+            { "name" => "Burger", "prices" => [{ "size" => nil, "price_cents" => 1200 }] },
+            { "name" => "Addictive Wings", "prices" => [{ "size" => nil, "price_cents" => 1400 }] }
+          ] }
+        ]
+      )
+
+      expect(run.ingestion_items.pluck(:name)).to contain_exactly("Burger", "Addictive Wings")
+    end
+  end
+
   describe "no inputs attached" do
     it "fails the run with the no_inputs_attached message" do
       # No attach_fake_input! call — this test is the one that exercises

--- a/apps/api/spec/jobs/extract_menu_job_spec.rb
+++ b/apps/api/spec/jobs/extract_menu_job_spec.rb
@@ -168,12 +168,12 @@ RSpec.describe ExtractMenuJob, type: :job do
       expect(run.ingestion_items.order(:position).pluck(:position)).to eq([0, 1])
     end
 
-    it "folds a trailing-plus name and strips the scaffolding" do
+    it "strips the Add/plus scaffolding from a folded name" do
       perform_with(
         "sections" => [
           { "name" => "Starters", "items" => [
             { "name" => "Guacamole", "prices" => [{ "size" => nil, "price_cents" => 1700 }] },
-            { "name" => "chips & salsa +", "prices" => [{ "size" => nil, "price_cents" => 300 }] }
+            { "name" => "Add chips & salsa +", "prices" => [{ "size" => nil, "price_cents" => 300 }] }
           ] }
         ]
       )
@@ -181,6 +181,19 @@ RSpec.describe ExtractMenuJob, type: :job do
       expect(run.ingestion_items.sole.addons_payload).to eq(
         [{ "name" => "chips & salsa", "price_cents" => 300, "source" => "guard" }]
       )
+    end
+
+    it "does not fold a trailing-plus name without the Add prefix (footnote/spice markers)" do
+      perform_with(
+        "sections" => [
+          { "name" => "Noodles", "items" => [
+            { "name" => "Pad Thai", "prices" => [{ "size" => nil, "price_cents" => 1400 }] },
+            { "name" => "Pad See Ew +", "prices" => [{ "size" => nil, "price_cents" => 1400 }] }
+          ] }
+        ]
+      )
+
+      expect(run.ingestion_items.pluck(:name)).to contain_exactly("Pad Thai", "Pad See Ew +")
     end
 
     it "materializes an addon-looking line normally when the section has no previous item" do

--- a/apps/api/spec/models/ingestion_item_spec.rb
+++ b/apps/api/spec/models/ingestion_item_spec.rb
@@ -79,6 +79,36 @@ RSpec.describe IngestionItem, type: :model do
       expect { orphan_item.promote! }.to raise_error(/no restaurant/)
     end
 
+    # Add-on guard — upsell lines nested at extraction become ItemModifier
+    # rows on the live Item instead of publishing as their own dishes.
+    describe "addons_payload" do
+      it "creates an ItemModifier (kind: addition) per addon row" do
+        item.update!(addons_payload: [
+          { "name" => "guajillo-tomatillo salsa", "price_cents" => 400, "source" => "extract" },
+          { "name" => "chicken", "price_cents" => nil, "source" => "guard" }
+        ])
+
+        promoted = item.promote!
+
+        expect(promoted.item_modifiers.pluck(:name, :kind, :price_cents)).to contain_exactly(
+          ["guajillo-tomatillo salsa", "addition", 400],
+          ["chicken", "addition", nil]
+        )
+      end
+
+      it "creates no modifiers when addons_payload is empty" do
+        promoted = item.promote!
+        expect(promoted.item_modifiers).to be_empty
+      end
+
+      it "skips addon rows without a name" do
+        item.update!(addons_payload: [{ "price_cents" => 400, "source" => "extract" }])
+
+        promoted = item.promote!
+        expect(promoted.item_modifiers).to be_empty
+      end
+    end
+
     # Phase 4.11.3 — when Anthropic vision marked a per-dish photo on
     # the source page (image_bbox jsonb populated by 4.11.2), promote!
     # crops it out and attaches it to the new Item. Must be best-effort

--- a/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
@@ -166,6 +166,46 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
       end
     end
 
+    context "addons (add-on guard)" do
+      before do
+        item.update!(addons_payload: [
+          { "name" => "guajillo-tomatillo salsa", "price_cents" => 400, "source" => "extract" },
+          { "name" => "chips", "price_cents" => 300, "source" => "guard" }
+        ])
+      end
+
+      it "serializes addons_payload on index" do
+        get "/api/v1/ingestion_runs/#{run.id}/items", headers: auth_for(admin)
+
+        addons = response.parsed_body["items"].first["addons_payload"]
+        expect(addons.map { |a| a["name"] }).to eq(["guajillo-tomatillo salsa", "chips"])
+      end
+
+      it "promotes addons to ItemModifiers on accept" do
+        patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+              params: { decision: "accepted" }.to_json,
+              headers: auth_for(admin)
+
+        promoted = Item.find(response.parsed_body["item_id"])
+        expect(promoted.item_modifiers.pluck(:name, :kind, :price_cents)).to contain_exactly(
+          ["guajillo-tomatillo salsa", "addition", 400],
+          ["chips", "addition", 300]
+        )
+      end
+
+      it "lets an edit replace addons_payload before accept (drop a wrongly-folded addon)" do
+        patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+              params: {
+                decision:       "accepted",
+                addons_payload: [{ name: "guajillo-tomatillo salsa", price_cents: 400, source: "extract" }]
+              }.to_json,
+              headers: auth_for(admin)
+
+        promoted = Item.find(response.parsed_body["item_id"])
+        expect(promoted.item_modifiers.pluck(:name)).to eq(["guajillo-tomatillo salsa"])
+      end
+    end
+
     context "decision: edited (without accepting)" do
       it "saves the edited fields but does NOT materialize an Item" do
         expect {

--- a/apps/api/spec/services/ingestion/menu_extraction_schema_spec.rb
+++ b/apps/api/spec/services/ingestion/menu_extraction_schema_spec.rb
@@ -68,4 +68,37 @@ RSpec.describe Ingestion::MenuExtractionSchema do
     payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
     expect(validate(payload)).not_to be_empty
   end
+
+  # Add-on guard — upsell lines nest under their parent item instead of
+  # surfacing as items, so the schema has to accept the nested shape.
+  describe "addons" do
+    it "accepts an item with well-formed addons" do
+      item = base_item.merge(
+        "addons" => [
+          { "name" => "guajillo-tomatillo salsa", "price_cents" => 400 },
+          { "name" => "chicken", "price_cents" => nil }
+        ]
+      )
+      payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+      expect(validate(payload)).to be_empty
+    end
+
+    it "rejects an addon without a name" do
+      item = base_item.merge("addons" => [{ "price_cents" => 400 }])
+      payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+      expect(validate(payload)).not_to be_empty
+    end
+
+    it "rejects an addon with unknown properties (additionalProperties: false)" do
+      item = base_item.merge("addons" => [{ "name" => "salsa", "spicy" => true }])
+      payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+      expect(validate(payload)).not_to be_empty
+    end
+
+    it "rejects a negative addon price" do
+      item = base_item.merge("addons" => [{ "name" => "salsa", "price_cents" => -1 }])
+      payload = { "sections" => [{ "name" => "Appetizers", "items" => [item] }] }
+      expect(validate(payload)).not_to be_empty
+    end
+  end
 end

--- a/apps/mobile/__tests__/screens/verify.render.test.tsx
+++ b/apps/mobile/__tests__/screens/verify.render.test.tsx
@@ -59,6 +59,7 @@ const pendingItem = {
   decided_at: null,
   ingredients_payload: [{ slug: 'pork', confidence: 0.95 }],
   tags_payload: [],
+  addons_payload: [],
   unresolved_ingredients: [],
   unresolved_tags: [],
 };
@@ -110,6 +111,21 @@ describe('VerifyScreen (Phase 7.3)', () => {
 
     await waitFor(() => expect(screen.getByText('All done!')).toBeTruthy());
     expect(screen.getByLabelText('view-menu')).toBeTruthy();
+  });
+
+  it('renders add-on rows on the card when the dish has them', async () => {
+    mockGetRun.mockResolvedValue(run('staged'));
+    mockListItems.mockResolvedValue([
+      {
+        ...pendingItem,
+        addons_payload: [{ name: 'guajillo salsa', price_cents: 400, source: 'extract' }],
+      },
+    ]);
+    render(<VerifyScreen />);
+
+    await waitFor(() => expect(screen.getByText('Carnitas Taco')).toBeTruthy());
+    expect(screen.getByText('Add-ons')).toBeTruthy();
+    expect(screen.getByText('+ guajillo salsa $4.00')).toBeTruthy();
   });
 
   it('"nothing to verify" still offers the menu link', async () => {

--- a/apps/mobile/__tests__/screens/verify.render.test.tsx
+++ b/apps/mobile/__tests__/screens/verify.render.test.tsx
@@ -59,7 +59,8 @@ const pendingItem = {
   decided_at: null,
   ingredients_payload: [{ slug: 'pork', confidence: 0.95 }],
   tags_payload: [],
-  addons_payload: [],
+  // addons_payload deliberately absent — an older API doesn't send the field,
+  // and the card must render without it (deploy-skew guard).
   unresolved_ingredients: [],
   unresolved_tags: [],
 };

--- a/apps/mobile/app/ingest/verify.tsx
+++ b/apps/mobile/app/ingest/verify.tsx
@@ -261,6 +261,19 @@ export default function VerifyScreen() {
           <Text style={styles.muted}>Section: {current.section_name}</Text>
         ) : null}
 
+        {current.addons_payload.length > 0 && (
+          <>
+            <View style={styles.divider} />
+            <Text style={styles.label}>Add-ons</Text>
+            {current.addons_payload.map((addon, i) => (
+              <Text style={styles.row} key={`${addon.name}-${i}`}>
+                + {addon.name}
+                {addon.price_cents != null ? ` $${(addon.price_cents / 100).toFixed(2)}` : ''}
+              </Text>
+            ))}
+          </>
+        )}
+
         <View style={styles.divider} />
         <Text style={styles.label}>Ingredients</Text>
         {current.ingredients_payload.map((ing) => (

--- a/apps/mobile/app/ingest/verify.tsx
+++ b/apps/mobile/app/ingest/verify.tsx
@@ -261,11 +261,11 @@ export default function VerifyScreen() {
           <Text style={styles.muted}>Section: {current.section_name}</Text>
         ) : null}
 
-        {current.addons_payload.length > 0 && (
+        {(current.addons_payload ?? []).length > 0 && (
           <>
             <View style={styles.divider} />
             <Text style={styles.label}>Add-ons</Text>
-            {current.addons_payload.map((addon, i) => (
+            {(current.addons_payload ?? []).map((addon, i) => (
               <Text style={styles.row} key={`${addon.name}-${i}`}>
                 + {addon.name}
                 {addon.price_cents != null ? ` $${(addon.price_cents / 100).toFixed(2)}` : ''}

--- a/apps/mobile/lib/api/ingestion-runs.ts
+++ b/apps/mobile/lib/api/ingestion-runs.ts
@@ -66,8 +66,12 @@ export interface IngestionItemPayload {
   ingredients_payload: Array<{ slug: string; confidence: number }>;
   tags_payload: Array<{ slug: string; confidence: number }>;
   prices_payload: Array<{ size: string | null; price_cents: number | null }>;
-  /** Add-on/upsell lines nested under this dish; promoted to ItemModifiers on accept. */
-  addons_payload: Array<{ name: string; price_cents: number | null; source: 'extract' | 'guard' }>;
+  /**
+   * Add-on/upsell lines nested under this dish; promoted to ItemModifiers on
+   * accept. Optional: the app and API deploy independently, so an older API
+   * may not send the field — always fall back to [].
+   */
+  addons_payload?: Array<{ name: string; price_cents: number | null; source: 'extract' | 'guard' }>;
   unresolved_ingredients: string[];
   unresolved_tags: string[];
 }

--- a/apps/mobile/lib/api/ingestion-runs.ts
+++ b/apps/mobile/lib/api/ingestion-runs.ts
@@ -66,6 +66,8 @@ export interface IngestionItemPayload {
   ingredients_payload: Array<{ slug: string; confidence: number }>;
   tags_payload: Array<{ slug: string; confidence: number }>;
   prices_payload: Array<{ size: string | null; price_cents: number | null }>;
+  /** Add-on/upsell lines nested under this dish; promoted to ItemModifiers on accept. */
+  addons_payload: Array<{ name: string; price_cents: number | null; source: 'extract' | 'guard' }>;
   unresolved_ingredients: string[];
   unresolved_tags: string[];
 }

--- a/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
@@ -46,6 +46,9 @@ export function VerifyItemRow({
 
   const decided = item.decision === 'accepted' || item.decision === 'rejected';
   const price = item.prices_payload[0]?.price_cents;
+  // Nullish fallback: web (Vercel) and API (Kamal) deploy independently, so a
+  // fresh client may briefly see responses without the field.
+  const addons = item.addons_payload ?? [];
 
   return (
     <li className="rounded-xl border border-zinc-200 p-4" data-testid={`verify-item-${item.id}`}>
@@ -59,9 +62,9 @@ export function VerifyItemRow({
           </p>
           {item.description && <p className="mt-1 text-sm text-zinc-600">{item.description}</p>}
 
-          {item.addons_payload.length > 0 && (
+          {addons.length > 0 && (
             <ul className="mt-2 space-y-0.5" data-testid="item-addons">
-              {item.addons_payload.map((addon, i) => (
+              {addons.map((addon, i) => (
                 <li key={`${addon.name}-${i}`} className="text-sm text-zinc-500">
                   + {addon.name}
                   {addon.price_cents != null && (

--- a/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
@@ -59,6 +59,21 @@ export function VerifyItemRow({
           </p>
           {item.description && <p className="mt-1 text-sm text-zinc-600">{item.description}</p>}
 
+          {item.addons_payload.length > 0 && (
+            <ul className="mt-2 space-y-0.5" data-testid="item-addons">
+              {item.addons_payload.map((addon, i) => (
+                <li key={`${addon.name}-${i}`} className="text-sm text-zinc-500">
+                  + {addon.name}
+                  {addon.price_cents != null && (
+                    <span className="ml-1 text-zinc-400">
+                      ${(addon.price_cents / 100).toFixed(2)}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
           {enriched &&
             enriching &&
             item.ingredients_payload.length === 0 &&

--- a/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
@@ -24,6 +24,7 @@ const item: IngestionItemPayload = {
   ingredients_payload: [{ slug: 'nut-peanut', confidence: 0.97 }],
   tags_payload: [{ slug: 'cuisine-thai', confidence: 0.99 }],
   prices_payload: [{ size: null, price_cents: 1450 }],
+  addons_payload: [],
   unresolved_ingredients: [],
   unresolved_tags: [],
 };
@@ -40,6 +41,26 @@ describe('VerifyItemRow', () => {
     expect(screen.getByText('$14.50')).toBeInTheDocument();
     expect(screen.getByText('nut-peanut')).toBeInTheDocument();
     expect(screen.getByText('cuisine-thai')).toBeInTheDocument();
+  });
+
+  it('renders add-on sub-rows with prices, and none when the dish has no add-ons', () => {
+    const withAddons = {
+      ...item,
+      addons_payload: [
+        { name: 'guajillo-tomatillo salsa', price_cents: 400, source: 'extract' as const },
+        { name: 'extra peanuts', price_cents: null, source: 'guard' as const },
+      ],
+    };
+    const { rerender } = render(
+      <VerifyItemRow runId="run-1" item={withAddons} enriched onDecided={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId('item-addons')).toHaveTextContent('+ guajillo-tomatillo salsa');
+    expect(screen.getByTestId('item-addons')).toHaveTextContent('$4.00');
+    expect(screen.getByTestId('item-addons')).toHaveTextContent('+ extra peanuts');
+
+    rerender(<VerifyItemRow runId="run-1" item={item} enriched onDecided={vi.fn()} />);
+    expect(screen.queryByTestId('item-addons')).toBeNull();
   });
 
   it('shows an "AI is still checking" hint on a staged, empty-payload dish while gap-fill runs', () => {

--- a/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
@@ -24,7 +24,8 @@ const item: IngestionItemPayload = {
   ingredients_payload: [{ slug: 'nut-peanut', confidence: 0.97 }],
   tags_payload: [{ slug: 'cuisine-thai', confidence: 0.99 }],
   prices_payload: [{ size: null, price_cents: 1450 }],
-  addons_payload: [],
+  // addons_payload deliberately absent — an older API doesn't send the field,
+  // and the row must render without it (deploy-skew guard).
   unresolved_ingredients: [],
   unresolved_tags: [],
 };
@@ -43,7 +44,7 @@ describe('VerifyItemRow', () => {
     expect(screen.getByText('cuisine-thai')).toBeInTheDocument();
   });
 
-  it('renders add-on sub-rows with prices, and none when the dish has no add-ons', () => {
+  it('renders add-on sub-rows with prices, and none when the field is absent (old API)', () => {
     const withAddons = {
       ...item,
       addons_payload: [

--- a/apps/web/src/lib/__tests__/ingestion.test.ts
+++ b/apps/web/src/lib/__tests__/ingestion.test.ts
@@ -195,6 +195,7 @@ const sampleItem: IngestionItemPayload = {
   ingredients_payload: [{ slug: 'nut-peanut', confidence: 0.97 }],
   tags_payload: [{ slug: 'cuisine-thai', confidence: 0.99 }],
   prices_payload: [{ size: null, price_cents: 1450 }],
+  addons_payload: [],
   unresolved_ingredients: [],
   unresolved_tags: [],
 };

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -141,6 +141,8 @@ export interface IngestionItemPayload {
   ingredients_payload: Array<{ slug: string; confidence: number }>;
   tags_payload: Array<{ slug: string; confidence: number }>;
   prices_payload: Array<{ size: string | null; price_cents: number }>;
+  /** Add-on/upsell lines nested under this dish; promoted to ItemModifiers on accept. */
+  addons_payload: Array<{ name: string; price_cents: number | null; source: 'extract' | 'guard' }>;
   unresolved_ingredients: string[];
   unresolved_tags: string[];
 }

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -141,8 +141,12 @@ export interface IngestionItemPayload {
   ingredients_payload: Array<{ slug: string; confidence: number }>;
   tags_payload: Array<{ slug: string; confidence: number }>;
   prices_payload: Array<{ size: string | null; price_cents: number }>;
-  /** Add-on/upsell lines nested under this dish; promoted to ItemModifiers on accept. */
-  addons_payload: Array<{ name: string; price_cents: number | null; source: 'extract' | 'guard' }>;
+  /**
+   * Add-on/upsell lines nested under this dish; promoted to ItemModifiers on
+   * accept. Optional: web and API deploy independently, so an older API may
+   * not send the field — always fall back to [].
+   */
+  addons_payload?: Array<{ name: string; price_cents: number | null; source: 'extract' | 'guard' }>;
   unresolved_ingredients: string[];
   unresolved_tags: string[];
 }

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -55,10 +55,12 @@ Add-on/upsell lines ("Add guacamole $2") are classified by the model
 and nested under the dish they modify (`addons`, optional) — they must
 never surface as standalone items. A deterministic backstop at
 materialization catches stragglers: a top-level item whose name matches
-`/\Aadd\s/i` or ends with `+` folds into the previous item's
-`addons_payload` (`source: "guard"`; the model's own nesting lands as
-`source: "extract"`). First-in-section has no parent, so it stages as a
-normal item for the human to judge.
+`/\Aadd\s/i` folds into the previous item's `addons_payload`
+(`source: "guard"`; the model's own nesting lands as
+`source: "extract"`). The pattern is deliberately just the "Add …"
+prefix — a false fold silently drops a dish, so anything more ambiguous
+(trailing `+`, "extra") stays a card a human can reject.
+First-in-section has no parent, so it stages as a normal item.
 
 ### 2. Resolve (deterministic — no LLM)
 

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -42,13 +42,23 @@ Output (validated against a JSON Schema):
         {
           "name": "Carne Asada Taco",
           "description": "Grilled steak, cilantro, onion, lime.",
-          "prices": [{ "size": null, "price_cents": 450 }]
+          "prices": [{ "size": null, "price_cents": 450 }],
+          "addons": [{ "name": "guacamole", "price_cents": 200 }]
         }
       ]
     }
   ]
 }
 ```
+
+Add-on/upsell lines ("Add guacamole $2") are classified by the model
+and nested under the dish they modify (`addons`, optional) — they must
+never surface as standalone items. A deterministic backstop at
+materialization catches stragglers: a top-level item whose name matches
+`/\Aadd\s/i` or ends with `+` folds into the previous item's
+`addons_payload` (`source: "guard"`; the model's own nesting lands as
+`source: "extract"`). First-in-section has no parent, so it stages as a
+normal item for the human to judge.
 
 ### 2. Resolve (deterministic — no LLM)
 
@@ -115,7 +125,9 @@ still duplicates its menu.
 Contributor opens a swipe UI:
 
 - ✅ Accept → `IngestionItem.decision = 'accepted'`, promote to a real
-  `Item` with `confidence = 'confirmed'`.
+  `Item` with `confidence = 'confirmed'`. Each `addons_payload` row
+  becomes an `ItemModifier` (`kind: "addition"`, name + price) on the
+  new Item.
 - ✏️ Edit → tweak ingredients / tags → `decision = 'edited'`, then
   promote.
 - ❌ Reject → `decision = 'rejected'`, stays in the run for audit.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -34,6 +34,8 @@ The v2 data model lives in `apps/api/db/migrate/`. This is a 60-second tour.
   the join tables are the source of truth + audit log.
 - `item_variants` — sized pricing.
 - `item_modifiers` — choices/additions/sides collapsed into one table.
+  Ingestion writes these: a staged item's `addons_payload` promotes to
+  `kind: "addition"` rows on accept.
 
 Each join row carries `confidence` (`confirmed | suggested | inferred`)
 and `source` (`human | ai | owner`). This powers strict-mode honest
@@ -50,7 +52,8 @@ disclosure: *we know X, we suspect Y, we inferred Z*.
 - `ingestion_runs` — state machine: `queued → extracting → resolving →
   staged → published` (or `failed`). Tracks model used + cost.
 - `ingestion_items` — staged items waiting on contributor decisions
-  (`pending | accepted | rejected | edited`).
+  (`pending | accepted | rejected | edited`). `addons_payload` holds
+  nested add-on/upsell lines (`{name, price_cents, source}`).
 
 ## The filter query (Phase 3 punchline)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,12 +21,14 @@ the Phase 5 pause) are archived in
 
 - Extraction prompt + schema now classify add-on lines and nest them under the
   parent dish (`addons`); a deterministic materialization backstop folds stray
-  top-level `/\Aadd\s/i` (or trailing `+`) items into the previous item's new
+  top-level `/\Aadd\s/i` items into the previous item's new
   `ingestion_items.addons_payload` (`source: "guard"` vs `"extract"`). Accept
   promotes each row to an `ItemModifier` (`kind: "addition"`) — first writer the
   table has ever had. Verify UIs (web + mobile) render addon sub-rows. v1 is
-  name+price only — no ingredient/tag resolution on addons yet.
-- ⚠️ Prompt edit invalidated the ExtractMenuJob live cassette — re-record needed.
+  name+price only — no ingredient/tag resolution on addons yet; a folded line
+  keeps only its first price.
+- Live cassette re-recorded in this branch (prompt edit invalidates the request
+  match); clients guard `addons_payload` with `?? []` for API deploy skew.
 
 2026-07-29 — Deterministic-first resolve: the two LLM resolve calls are gone. Branch `feature/deterministic-resolve`.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,17 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-29 — Add-on guard: "Add X for $3" upsell lines no longer stage as dishes. Branch `feature/ingestion-addon-guard`.
+
+- Extraction prompt + schema now classify add-on lines and nest them under the
+  parent dish (`addons`); a deterministic materialization backstop folds stray
+  top-level `/\Aadd\s/i` (or trailing `+`) items into the previous item's new
+  `ingestion_items.addons_payload` (`source: "guard"` vs `"extract"`). Accept
+  promotes each row to an `ItemModifier` (`kind: "addition"`) — first writer the
+  table has ever had. Verify UIs (web + mobile) render addon sub-rows. v1 is
+  name+price only — no ingredient/tag resolution on addons yet.
+- ⚠️ Prompt edit invalidated the ExtractMenuJob live cassette — re-record needed.
+
 2026-07-29 — Deterministic-first resolve: the two LLM resolve calls are gone. Branch `feature/deterministic-resolve`.
 
 - Owner's call: resolve was slow + over-relied on LLMs — it was asking Haiku to do


### PR DESCRIPTION
## Summary

- Menu upsell lines ("Add guajillo-tomatillo salsa + $4.00") were extracted, staged, and published as standalone dishes; they now nest under the parent item as add-ons.
- The vision prompt classifies add-on lines into a new `addons` array; a narrow deterministic backstop at materialization folds stray top-level `Add X` / trailing-`+` items into the previous item's `addons_payload` (`source: "guard"` vs `"extract"`).
- Accept promotes each addon to an `ItemModifier` (`kind: "addition"`) — the table existed but had no writers. Web + mobile verify cards render the nested rows. v1 is name+price only (no ingredient/tag resolution on addons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsQM2hexYk2HRR5kqoXNJn
