### PR TITLE
fix(api): materialize prices_payload as ItemVariants on promote

### DIFF
--- a/apps/api/app/models/ingestion_item.rb
+++ b/apps/api/app/models/ingestion_item.rb
@@ -87,6 +87,17 @@ class IngestionItem < ApplicationRecord
         )
       end
 
+      # A size with no price is noise, not a variant — skip it.
+      Array(prices_payload).each_with_index do |row, index|
+        price_cents = row["price_cents"] || row[:price_cents]
+        next if price_cents.blank?
+
+        ItemVariant.create!(
+          item: created, size: row["size"] || row[:size],
+          price_cents: price_cents, position: index
+        )
+      end
+
       attach_dish_photo!(created)
 
       update!(item: created, decision: "accepted", decided_at: Time.current)

--- a/apps/api/spec/models/ingestion_item_spec.rb
+++ b/apps/api/spec/models/ingestion_item_spec.rb
@@ -109,6 +109,51 @@ RSpec.describe IngestionItem, type: :model do
       end
     end
 
+    # Extraction captures per-size prices into prices_payload; promote!
+    # must land them as ItemVariant rows or the data is silently dropped
+    # at the exact moment a human confirmed it.
+    describe "prices_payload" do
+      it "creates an ItemVariant per priced row, preserving payload order" do
+        item.update!(prices_payload: [
+          { "size" => "small", "price_cents" => 450 },
+          { "size" => "large", "price_cents" => 750 }
+        ])
+
+        promoted = item.promote!
+
+        expect(promoted.item_variants.order(:position).pluck(:size, :price_cents, :position))
+          .to eq([["small", 450, 0], ["large", 750, 1]])
+      end
+
+      it "skips rows without a price — a bare size is noise, not a variant" do
+        item.update!(prices_payload: [
+          { "size" => "market", "price_cents" => nil },
+          { "size" => nil, "price_cents" => 1200 }
+        ])
+
+        promoted = item.promote!
+
+        expect(promoted.item_variants.pluck(:size, :price_cents)).to eq([[nil, 1200]])
+      end
+
+      it "creates no variants when prices_payload is empty" do
+        item.update!(prices_payload: [])
+
+        promoted = item.promote!
+        expect(promoted.item_variants).to be_empty
+      end
+
+      it "does not duplicate variants on idempotent re-promote" do
+        item.update!(prices_payload: [{ "size" => nil, "price_cents" => 450 }])
+
+        first  = item.promote!
+        second = item.promote!
+
+        expect(second).to eq(first)
+        expect(first.item_variants.count).to eq(1)
+      end
+    end
+
     # Phase 4.11.3 — when Anthropic vision marked a per-dish photo on
     # the source page (image_bbox jsonb populated by 4.11.2), promote!
     # crops it out and attaches it to the new Item. Must be best-effort

--- a/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
@@ -123,6 +123,21 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
         expect(promoted.tags).to        contain_exactly(taco_tag)
       end
 
+      it "materializes prices_payload as ItemVariants on the promoted Item" do
+        item.update!(prices_payload: [
+          { "size" => "small", "price_cents" => 450 },
+          { "size" => "large", "price_cents" => 750 }
+        ])
+
+        patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+              params: { decision: "accepted" }.to_json,
+              headers: auth_for(admin)
+
+        promoted = Item.find(response.parsed_body["item_id"])
+        expect(promoted.item_variants.order(:position).pluck(:size, :price_cents))
+          .to eq([["small", 450], ["large", 750]])
+      end
+
       it "applies edit overrides BEFORE promoting (so the live Item has the human's tweaks)" do
         patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
               params: {
@@ -330,6 +345,9 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
       expect(body["item_id"]).to be_nil
       expect(Item.exists?(promoted_id)).to be false
       expect(ItemIngredient.where(item_id: promoted_id)).to be_empty
+      # Variants ride the Item's dependent: :destroy — undo must not strand
+      # price rows pointing at a dead Item.
+      expect(ItemVariant.where(item_id: promoted_id)).to be_empty
     end
   end
 end

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -129,7 +129,9 @@ Contributor opens a swipe UI:
 - ✅ Accept → `IngestionItem.decision = 'accepted'`, promote to a real
   `Item` with `confidence = 'confirmed'`. Each `addons_payload` row
   becomes an `ItemModifier` (`kind: "addition"`, name + price) on the
-  new Item.
+  new Item; each priced `prices_payload` row becomes an `ItemVariant`
+  (size + price_cents, payload order) — rows without a price are
+  skipped.
 - ✏️ Edit → tweak ingredients / tags → `decision = 'edited'`, then
   promote.
 - ❌ Reject → `decision = 'rejected'`, stays in the run for audit.

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,8 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-30 — `promote!` now materializes `prices_payload` as `ItemVariant` rows (size + price_cents, payload order; priceless rows skipped). Previously extracted prices were silently dropped at accept. Branch `fix/promote-prices-item-variants`. First PR of the re-scan dedup + diff/merge arc (matching + apply-update PRs follow).
+
 2026-07-29 — Add-on guard: "Add X for $3" upsell lines no longer stage as dishes. Branch `feature/ingestion-addon-guard`.
 
 - Extraction prompt + schema now classify add-on lines and nest them under the


### PR DESCRIPTION
## Summary

- promote! silently dropped extracted prices: prices_payload never became ItemVariant rows, so confirmed menus published with no price data.
- Each priced payload row now materializes as an ItemVariant (size + price_cents, payload order); priceless rows are skipped. Undo already cleans them up via the Item's dependent: :destroy.
- First PR of the re-scan dedup + diff/merge arc — the upcoming update-diff needs live variants to diff against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsQM2hexYk2HRR5kqoXNJn
