### PR TITLE
feat(api): match staged ingestion items against existing restaurant items

### DIFF
--- a/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
+++ b/apps/api/app/controllers/api/v1/ingestion_items_controller.rb
@@ -18,6 +18,7 @@ module Api
       def index
         run = authorized_run
         items = run.ingestion_items.order(:position, :created_at)
+                   .includes(matched_item: %i[item_variants ingredients tags])
         render json: { items: items.map { |it| serialize_item(it) } }
       end
 
@@ -75,6 +76,7 @@ module Api
         run.maybe_publish!
 
         items = run.ingestion_items.order(:position, :created_at)
+                   .includes(matched_item: %i[item_variants ingredients tags])
         render json: { items: items.map { |it| serialize_item(it) } }
       end
 
@@ -140,7 +142,32 @@ module Api
           prices_payload:         item.prices_payload,
           addons_payload:         item.addons_payload,
           unresolved_ingredients: item.unresolved_ingredients,
-          unresolved_tags:        item.unresolved_tags
+          unresolved_tags:        item.unresolved_tags,
+          match:                  serialize_match(item)
+        }
+      end
+
+      # Re-scan dedup — the existing Item this staged row matched, with a
+      # serialize-time diff (never stored: gap-fill keeps appending to the
+      # payloads after :staged, so a stored diff would lie). nil for
+      # unmatched rows, i.e. plain "new item" cards.
+      def serialize_match(item)
+        target = item.matched_item
+        return nil if target.nil?
+
+        diff = Ingestion::ItemUpdateDiff.call(item, target)
+        {
+          item_id: target.id,
+          score:   item.match_score,
+          existing: {
+            name:        target.name,
+            description: target.description,
+            prices: target.item_variants.sort_by(&:position).map do |v|
+              { size: v.size, price_cents: v.price_cents }
+            end
+          },
+          diff:       diff.except(:no_changes),
+          no_changes: diff[:no_changes]
         }
       end
     end

--- a/apps/api/app/jobs/resolve_items_job.rb
+++ b/apps/api/app/jobs/resolve_items_job.rb
@@ -28,9 +28,13 @@ class ResolveItemsJob < ApplicationJob
 
     results = Ingestion::DeterministicResolver.call(items)
     gaps = results.any?(&:gap?)
+    # Re-scan dedup: link staged items to the restaurant's existing Items
+    # before the batch promote below, so items accepted while the run was
+    # still :resolving promote as updates instead of duplicates.
+    matches = Ingestion::ExistingItemMatcher.call(run: run, items: items)
 
     run.transaction do
-      write_payloads!(run, results)
+      write_payloads!(run, items, results, matches)
       promote_accepted_items!(run)
       run.transition_to!(:staged)
       # Written both ways so a re-run (Avo re-extract) can't inherit a
@@ -48,17 +52,28 @@ class ResolveItemsJob < ApplicationJob
   # conflicts on the PK (the ids were just read from the DB), so this is
   # a pure bulk UPDATE; bypassing validations/callbacks is safe —
   # IngestionItem has none that touch these columns.
-  def write_payloads!(run, results)
+  def write_payloads!(run, items, results, matches)
+    by_id = items.index_by(&:id)
     # ingestion_run_id rides along because Postgres checks NOT NULL on
     # the insert tuple before ON CONFLICT resolves; updated_at is
     # stamped by upsert_all itself (record_timestamps).
     rows = results.map do |r|
+      staged = by_id.fetch(r.item_id)
+      match  = matches[r.item_id]
+      # Already-promoted items keep their linkage; everyone else takes
+      # this pass's match — nil clears anything stale from a prior cycle
+      # (Avo re-extract re-runs resolve on the same rows).
+      promoted = staged.item_id.present?
       { id: r.item_id,
         ingestion_run_id: run.id,
         ingredients_payload: r.ingredients,
-        tags_payload: r.tags }
+        tags_payload: r.tags,
+        matched_item_id: promoted ? staged.matched_item_id : match&.dig(:item_id),
+        match_score:     promoted ? staged.match_score     : match&.dig(:score) }
     end
-    IngestionItem.upsert_all(rows, update_only: %i[ingredients_payload tags_payload])
+    IngestionItem.upsert_all(
+      rows, update_only: %i[ingredients_payload tags_payload matched_item_id match_score]
+    )
   end
 
   # Items accepted while the run was still :resolving were recorded but

--- a/apps/api/app/models/ingestion_item.rb
+++ b/apps/api/app/models/ingestion_item.rb
@@ -3,6 +3,10 @@ class IngestionItem < ApplicationRecord
 
   belongs_to :ingestion_run
   belongs_to :item, optional: true
+  # Re-scan dedup: the existing Item this staged row was matched against
+  # (Ingestion::ExistingItemMatcher). Distinct from :item, which is the
+  # promotion result.
+  belongs_to :matched_item, class_name: "Item", optional: true
 
   validates :decision, inclusion: { in: DECISIONS }
 

--- a/apps/api/app/services/ingestion/existing_item_matcher.rb
+++ b/apps/api/app/services/ingestion/existing_item_matcher.rb
@@ -1,0 +1,142 @@
+module Ingestion
+  # Matches staged IngestionItems against the restaurant's existing Items
+  # so a re-scan stages updates instead of duplicating the menu.
+  # Deterministic, no LLM: normalized-token equality first, then a pg_trgm
+  # similarity band guarded by a token-subset veto. Greedy one-to-one —
+  # each existing Item is claimed by at most one staged item per pass.
+  #
+  # Returns { ingestion_item_id => { item_id:, score: } }.
+  #
+  # Calibration (similarity() on lowercased names, probed 2026-07-30):
+  #
+  #   same dish:      carne asada taco | carne asada tacos    0.842  (exact after singularize)
+  #                   mac & cheese     | mac and cheese       0.733  (exact after stopword strip)
+  #                   margherita pizza | margarita pizza      0.650  <- must clear the threshold
+  #   different dish: chicken burrito  | chicken burrito bowl 0.800  <- subset veto
+  #                   caesar salad     | side caesar salad    0.765  <- subset veto
+  #                   cheeseburger     | bacon cheeseburger   0.684  <- subset veto
+  #                   chicken quesadilla | cheese quesadilla  0.542  <- must stay below
+  #
+  # No raw-similarity threshold separates the containment pairs (0.684+)
+  # from real plural/spelling variants — hence the veto: a name whose
+  # token set strictly contains the other's is a different dish ("Chicken
+  # Burrito Bowl" is not an update to "Chicken Burrito"). That leaves the
+  # 0.542–0.650 gap, split at SIMILARITY_THRESHOLD = 0.60. A false merge
+  # silently corrupts a live menu item while a missed match is just a
+  # duplicate card a human can reject — when in doubt, don't match.
+  class ExistingItemMatcher
+    SIMILARITY_THRESHOLD = 0.60
+    STOPWORDS = %w[and with w the of].freeze
+
+    def self.call(run:, items:)
+      new(run: run, items: items).call
+    end
+
+    def initialize(run:, items:)
+      @run = run
+      @items = items
+    end
+
+    def call
+      return {} if run.restaurant_id.blank?
+
+      staged = items.select { |i| i.item_id.nil? && i.name.present? }
+      return {} if staged.empty?
+
+      candidates = eligible_candidates
+      return {} if candidates.empty?
+
+      exact = exact_pairs(staged, candidates)
+      matched_staged_ids = exact.map { |p| p[:staged].id }.to_set
+      fuzzy = fuzzy_pairs(staged.reject { |i| matched_staged_ids.include?(i.id) }, candidates)
+
+      assign(exact + fuzzy)
+    end
+
+    private
+
+    attr_reader :run, :items
+
+    # Existing menu minus removed items and minus Items this run already
+    # promoted (their staged rows are done; a second staged copy of the
+    # same dish must not "update" what this run just created).
+    def eligible_candidates
+      linked = run.ingestion_items.where.not(item_id: nil).pluck(:item_id)
+      scope = run.restaurant.items.where.not(status: "removed")
+      scope = scope.where.not(id: linked) if linked.any?
+      scope.select(:id, :name).to_a
+    end
+
+    def exact_pairs(staged, candidates)
+      by_key = candidates.group_by { |c| token_key(c.name) }
+      staged.flat_map do |ingestion_item|
+        (by_key[token_key(ingestion_item.name)] || []).map do |candidate|
+          { staged: ingestion_item, item_id: candidate.id, score: 1.0 }
+        end
+      end
+    end
+
+    # pg_trgm already ignores case and punctuation, so similarity runs on
+    # the raw names; the veto runs on normalized token sets.
+    def fuzzy_pairs(staged, candidates)
+      candidate_ids = candidates.map(&:id)
+      tokens_by_id = candidates.to_h { |c| [c.id, tokens(c.name).to_set] }
+
+      staged.flat_map do |ingestion_item|
+        staged_tokens = tokens(ingestion_item.name).to_set
+        scored_candidates(candidate_ids, ingestion_item.name).filter_map do |row|
+          candidate_tokens = tokens_by_id.fetch(row.id)
+          next if subset?(staged_tokens, candidate_tokens)
+
+          { staged: ingestion_item, item_id: row.id, score: row.match_score.to_f }
+        end
+      end
+    end
+
+    def scored_candidates(candidate_ids, name)
+      Item.where(id: candidate_ids)
+          .where("similarity(items.name, ?) >= ?", name, SIMILARITY_THRESHOLD)
+          .select(
+            "items.id",
+            Arel.sql(ActiveRecord::Base.sanitize_sql_array(
+                       ["similarity(items.name, ?) AS match_score", name]
+                     ))
+          )
+    end
+
+    def subset?(a, b)
+      return false if a == b
+
+      a.subset?(b) || b.subset?(a)
+    end
+
+    # Best score wins; ties break on staged position then candidate id so
+    # re-runs assign identically.
+    def assign(pairs)
+      claimed_staged = Set.new
+      claimed_items = Set.new
+      matches = {}
+
+      sorted = pairs.sort_by { |p| [-p[:score], p[:staged].position || 0, p[:item_id]] }
+      sorted.each do |pair|
+        staged_id = pair[:staged].id
+        next if claimed_staged.include?(staged_id) || claimed_items.include?(pair[:item_id])
+
+        claimed_staged << staged_id
+        claimed_items << pair[:item_id]
+        matches[staged_id] = { item_id: pair[:item_id], score: pair[:score] }
+      end
+
+      matches
+    end
+
+    def tokens(name)
+      name.to_s.downcase.gsub(/[^a-z0-9\s]/, " ").split
+          .map(&:singularize) - STOPWORDS
+    end
+
+    def token_key(name)
+      tokens(name).sort.join(" ")
+    end
+  end
+end

--- a/apps/api/app/services/ingestion/existing_item_matcher.rb
+++ b/apps/api/app/services/ingestion/existing_item_matcher.rb
@@ -130,8 +130,10 @@ module Ingestion
       matches
     end
 
+    # Transliterate first so "Jalapeño" and "Jalapeno" tokenize
+    # identically instead of the ñ shattering into a stray token.
     def tokens(name)
-      name.to_s.downcase.gsub(/[^a-z0-9\s]/, " ").split
+      I18n.transliterate(name.to_s).downcase.gsub(/[^a-z0-9\s]/, " ").split
           .map(&:singularize) - STOPWORDS
     end
 

--- a/apps/api/app/services/ingestion/item_update_diff.rb
+++ b/apps/api/app/services/ingestion/item_update_diff.rb
@@ -1,0 +1,68 @@
+module Ingestion
+  # Pure diff between a staged IngestionItem's payloads and the live Item
+  # its matcher link points at. Computed at serialize time, never stored:
+  # gap-fill appends ingredient rows after the run is already :staged, so
+  # a stored diff would go stale the moment enrichment lands.
+  #
+  # Absence of evidence is never a change: a blank scanned description or
+  # an empty scanned price set yields nil for that field rather than
+  # proposing a blank-out/delete.
+  class ItemUpdateDiff
+    def self.call(ingestion_item, item)
+      description = description_change(ingestion_item, item)
+      prices = prices_change(ingestion_item, item)
+      added_ingredients = added_slugs(ingestion_item.ingredients_payload, item.ingredients)
+      added_tags = added_slugs(ingestion_item.tags_payload, item.tags)
+
+      {
+        description: description,
+        prices: prices,
+        added_ingredients: added_ingredients,
+        added_tags: added_tags,
+        no_changes: description.nil? && prices.nil? &&
+          added_ingredients.empty? && added_tags.empty?
+      }
+    end
+
+    # Canonical price shape for comparison and display: priceless rows
+    # dropped (a bare size is noise), stable sort so payload order vs
+    # variant position order can't fake a change.
+    def self.normalize_prices(rows)
+      Array(rows).filter_map do |row|
+        row = row.with_indifferent_access if row.respond_to?(:with_indifferent_access)
+        cents = row[:price_cents]
+        next if cents.blank?
+
+        { size: row[:size].presence, price_cents: cents.to_i }
+      end.sort_by { |r| [r[:price_cents], r[:size].to_s] }
+    end
+
+    def self.description_change(ingestion_item, item)
+      scanned = ingestion_item.description.to_s.strip
+      return nil if scanned.blank?
+      return nil if scanned == item.description.to_s.strip
+
+      { from: item.description, to: ingestion_item.description }
+    end
+    private_class_method :description_change
+
+    def self.prices_change(ingestion_item, item)
+      to = normalize_prices(ingestion_item.prices_payload)
+      return nil if to.empty?
+
+      from = normalize_prices(
+        item.item_variants.map { |v| { size: v.size, price_cents: v.price_cents } }
+      )
+      return nil if from == to
+
+      { from: from, to: to }
+    end
+    private_class_method :prices_change
+
+    def self.added_slugs(payload, existing_records)
+      existing = existing_records.map(&:slug)
+      Array(payload).filter_map { |row| row["slug"] || row[:slug] }.uniq - existing
+    end
+    private_class_method :added_slugs
+  end
+end

--- a/apps/api/db/migrate/20260730120000_add_rescan_matching_to_ingestion_items.rb
+++ b/apps/api/db/migrate/20260730120000_add_rescan_matching_to_ingestion_items.rb
@@ -1,0 +1,13 @@
+class AddRescanMatchingToIngestionItems < ActiveRecord::Migration[8.1]
+  # Re-scan dedup: ResolveItemsJob matches staged items against the
+  # restaurant's existing Items (Ingestion::ExistingItemMatcher) and links
+  # the candidate here. nullify-on-delete is the fallback semantics — if
+  # the matched Item disappears before the human accepts, the link
+  # self-clears and accept falls back to creating a fresh Item.
+  def change
+    add_column :ingestion_items, :matched_item_id, :uuid
+    add_column :ingestion_items, :match_score, :float
+    add_index  :ingestion_items, :matched_item_id
+    add_foreign_key :ingestion_items, :items, column: :matched_item_id, on_delete: :nullify
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -156,6 +156,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_130000) do
     t.uuid "ingestion_run_id", null: false
     t.jsonb "ingredients_payload", default: []
     t.uuid "item_id"
+    t.float "match_score"
+    t.uuid "matched_item_id"
     t.string "name"
     t.integer "position"
     t.jsonb "prices_payload", default: []
@@ -167,6 +169,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_130000) do
     t.index ["ingestion_run_id", "decision"], name: "index_ingestion_items_on_ingestion_run_id_and_decision"
     t.index ["ingestion_run_id"], name: "index_ingestion_items_on_ingestion_run_id"
     t.index ["item_id"], name: "index_ingestion_items_on_item_id"
+    t.index ["matched_item_id"], name: "index_ingestion_items_on_matched_item_id"
   end
 
   create_table "ingestion_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -602,6 +605,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_130000) do
   add_foreign_key "hours", "restaurants"
   add_foreign_key "ingestion_items", "ingestion_runs"
   add_foreign_key "ingestion_items", "items"
+  add_foreign_key "ingestion_items", "items", column: "matched_item_id", on_delete: :nullify
   add_foreign_key "ingestion_runs", "restaurants"
   add_foreign_key "ingestion_runs", "users"
   add_foreign_key "item_ingredients", "ingredients"

--- a/apps/api/spec/jobs/gap_fill_resolve_job_spec.rb
+++ b/apps/api/spec/jobs/gap_fill_resolve_job_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe GapFillResolveJob, type: :job do
       expect(Rails.logger).to have_received(:warn).with(/not-a-real-slug/)
     end
 
+    it "leaves the re-scan match columns alone (its upsert must not clobber the matcher)" do
+      target = create(:item, restaurant: restaurant, name: "Caesar Salad")
+      gap_item.update!(matched_item_id: target.id, match_score: 1.0)
+
+      described_class.perform_now(run.id)
+
+      gap_item.reload
+      expect(gap_item.matched_item_id).to eq(target.id)
+      expect(gap_item.match_score).to eq(1.0)
+    end
+
     it "re-derives allergen tags in code from the AI ingredients and appends AI cuisine" do
       create(:tag, slug: "contains-peanut", family: "allergen", path: "allergen.contains_peanut")
       described_class.perform_now(run.id)

--- a/apps/api/spec/jobs/resolve_items_job_spec.rb
+++ b/apps/api/spec/jobs/resolve_items_job_spec.rb
@@ -98,6 +98,47 @@ RSpec.describe ResolveItemsJob, type: :job do
     end
   end
 
+  # Re-scan dedup — the resolve pass links staged items to the
+  # restaurant's existing Items so the verify UI can stage updates
+  # instead of duplicates (and PR3's apply path can merge on accept).
+  describe "existing-item matching" do
+    let!(:existing) { create(:item, restaurant: restaurant, name: "Taco", status: "published") }
+
+    it "writes matched_item_id + match_score alongside the payloads" do
+      row = make_item(run, position: 0, name: "Tacos", description: "steak")
+
+      described_class.perform_now(run.id)
+
+      row.reload
+      expect(row.matched_item_id).to eq(existing.id)
+      expect(row.match_score).to eq(1.0)
+    end
+
+    it "clears a stale match from a previous cycle when the item no longer matches" do
+      row = make_item(run, position: 0, name: "Limeade", description: "lime")
+      row.update!(matched_item_id: existing.id, match_score: 1.0)
+
+      described_class.perform_now(run.id)
+
+      expect(row.reload.matched_item_id).to be_nil
+      expect(row.match_score).to be_nil
+    end
+
+    it "matches pre-accepted items before the batch promote sees them" do
+      row = make_item(run, position: 0, name: "Tacos", description: "steak",
+                           decision: "accepted")
+
+      described_class.perform_now(run.id)
+
+      row.reload
+      expect(row.matched_item_id).to eq(existing.id)
+      # PR boundary: promote! doesn't branch on the match yet, so the
+      # accept still creates a fresh Item — behavior ships dark here.
+      expect(row.item_id).to be_present
+      expect(row.item_id).not_to eq(existing.id)
+    end
+  end
+
   it "fails the run when there are no items" do
     described_class.perform_now(run.id)
     expect(run.reload.status).to eq("failed")

--- a/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
+++ b/apps/api/spec/requests/api/v1/ingestion_items_api_spec.rb
@@ -312,6 +312,60 @@ RSpec.describe "Ingestion items API (PATCH/INDEX)", type: :request do
     end
   end
 
+  # Re-scan dedup PR boundary: the match + diff serialize so clients can
+  # render update cards, but accept still CREATES — the apply-on-accept
+  # path ships separately. These examples prove the feature is dark.
+  describe "re-scan matching (serialization only)" do
+    let!(:existing_item) do
+      create(:item, restaurant: restaurant, name: "Carne Asada Taco",
+                    description: "The original.", status: "published", confidence: "confirmed")
+    end
+
+    before do
+      ItemVariant.create!(item: existing_item, size: nil, price_cents: 400, position: 0)
+      item.update!(matched_item_id: existing_item.id, match_score: 1.0)
+    end
+
+    it "serializes the match block with a serialize-time diff on index" do
+      get "/api/v1/ingestion_runs/#{run.id}/items", headers: auth_for(admin)
+
+      match = response.parsed_body["items"].first["match"]
+      expect(match["item_id"]).to eq(existing_item.id)
+      expect(match["score"]).to eq(1.0)
+      expect(match["existing"]).to eq(
+        "name" => "Carne Asada Taco", "description" => "The original.",
+        "prices" => [{ "size" => nil, "price_cents" => 400 }]
+      )
+      expect(match["diff"]["description"]).to eq(
+        "from" => "The original.", "to" => item.description
+      )
+      expect(match["diff"]["prices"]).to eq(
+        "from" => [{ "size" => nil, "price_cents" => 400 }],
+        "to"   => [{ "size" => nil, "price_cents" => 450 }]
+      )
+      expect(match["diff"]["added_ingredients"]).to eq(["meat-beef"])
+      expect(match["no_changes"]).to be false
+    end
+
+    it "serializes match: null for unmatched rows" do
+      unmatched = create(:ingestion_item, ingestion_run: run, name: "Pad Thai", position: 9)
+
+      get "/api/v1/ingestion_runs/#{run.id}/items", headers: auth_for(admin)
+
+      row = response.parsed_body["items"].find { |i| i["id"] == unmatched.id }
+      expect(row["match"]).to be_nil
+    end
+
+    it "accepting a matched item still creates a new Item (apply ships in the next PR)" do
+      expect {
+        patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",
+              params: { decision: "accepted" }.to_json, headers: auth_for(admin)
+      }.to change(Item, :count).by(1)
+
+      expect(response.parsed_body["item_id"]).not_to eq(existing_item.id)
+    end
+  end
+
   describe "undo (PATCH decision: pending)" do
     it "reverts an accepted+promoted item to pending and removes its live Item + joins" do
       patch "/api/v1/ingestion_runs/#{run.id}/items/#{item.id}",

--- a/apps/api/spec/services/ingestion/existing_item_matcher_spec.rb
+++ b/apps/api/spec/services/ingestion/existing_item_matcher_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe Ingestion::ExistingItemMatcher do
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:run)        { create(:ingestion_run, restaurant: restaurant, status: "resolving") }
+
+  def staged(name, position: 0, **attrs)
+    create(:ingestion_item, ingestion_run: run, name: name, position: position, **attrs)
+  end
+
+  def existing(name, status: "published", target: restaurant)
+    create(:item, restaurant: target, name: name, status: status)
+  end
+
+  def matches
+    described_class.call(run: run, items: run.ingestion_items.order(:position, :created_at).to_a)
+  end
+
+  describe "exact normalized matching" do
+    it "matches a plural variant of an existing item at score 1.0" do
+      target = existing("Carne Asada Taco")
+      row    = staged("Carne Asada Tacos")
+
+      expect(matches[row.id]).to eq(item_id: target.id, score: 1.0)
+    end
+
+    it "matches through punctuation and stopwords ('Mac & Cheese' = 'Mac and Cheese')" do
+      target = existing("Mac and Cheese")
+      row    = staged("Mac & Cheese")
+
+      expect(matches[row.id]).to eq(item_id: target.id, score: 1.0)
+    end
+
+    it "matches regardless of token order ('Taco Carne Asada')" do
+      target = existing("Carne Asada Taco")
+      row    = staged("Taco Carne Asada")
+
+      expect(matches[row.id]).to eq(item_id: target.id, score: 1.0)
+    end
+  end
+
+  describe "similarity band with token-subset veto" do
+    it "matches a spelling variant above the threshold" do
+      target = existing("Margherita Pizza")
+      row    = staged("Margarita Pizza")
+
+      match = matches[row.id]
+      expect(match[:item_id]).to eq(target.id)
+      expect(match[:score]).to be_between(described_class::SIMILARITY_THRESHOLD, 1.0)
+    end
+
+    it "refuses a containment pair even though its similarity clears the threshold" do
+      existing("Chicken Burrito Bowl")
+      row = staged("Chicken Burrito")
+
+      expect(matches[row.id]).to be_nil
+    end
+
+    it "refuses the reverse containment (staged name contains the existing one)" do
+      existing("Cheeseburger")
+      row = staged("Bacon Cheeseburger")
+
+      expect(matches[row.id]).to be_nil
+    end
+
+    it "refuses different dishes below the threshold" do
+      existing("Chicken Quesadilla")
+      row = staged("Cheese Quesadilla")
+
+      expect(matches[row.id]).to be_nil
+    end
+
+    # Pins the pg_trgm behavior the threshold + veto were calibrated
+    # against. If Postgres' similarity() ever shifts these orderings the
+    # constants must be re-derived, not patched around.
+    it "calibration: the veto covers exactly the pairs no threshold can separate" do
+      sim = lambda do |a, b|
+        ActiveRecord::Base.connection.select_value(
+          ActiveRecord::Base.sanitize_sql_array(["SELECT similarity(?, ?)", a, b])
+        ).to_f
+      end
+
+      threshold = described_class::SIMILARITY_THRESHOLD
+      # Different dishes that SCORE ABOVE the threshold — only the subset
+      # veto keeps them apart.
+      expect(sim.call("chicken burrito", "chicken burrito bowl")).to be > threshold
+      expect(sim.call("caesar salad", "side caesar salad")).to be > threshold
+      # Same dish (spelling variant) that must clear the threshold.
+      expect(sim.call("margherita pizza", "margarita pizza")).to be >= threshold
+      # Different dishes that must stay below it.
+      expect(sim.call("chicken quesadilla", "cheese quesadilla")).to be < threshold
+      expect(sim.call("veggie burrito", "chicken burrito")).to be < threshold
+    end
+  end
+
+  describe "candidate scope" do
+    it "never matches another restaurant's items" do
+      other = create(:restaurant, :published)
+      existing("Carne Asada Taco", target: other)
+      row = staged("Carne Asada Taco")
+
+      expect(matches[row.id]).to be_nil
+    end
+
+    it "skips removed items" do
+      existing("Carne Asada Taco", status: "removed")
+      row = staged("Carne Asada Taco")
+
+      expect(matches[row.id]).to be_nil
+    end
+
+    it "skips Items this run already promoted" do
+      target = existing("Carne Asada Taco")
+      staged("Carne Asada Taco", position: 0, item_id: target.id, decision: "accepted")
+      second = staged("Carne Asada Taco", position: 1)
+
+      expect(matches[second.id]).to be_nil
+    end
+
+    it "ignores staged rows that are already promoted" do
+      target = existing("Pad Thai")
+      row = staged("Pad Thai", item: create(:item, restaurant: restaurant, name: "Pad Thai"))
+
+      expect(matches).not_to have_key(row.id)
+      expect(target).to be_present
+    end
+
+    it "returns {} when the run has no restaurant" do
+      orphan = create(:ingestion_run, restaurant: nil)
+      create(:ingestion_item, ingestion_run: orphan, name: "Pad Thai")
+
+      result = described_class.call(run: orphan, items: orphan.ingestion_items.to_a)
+      expect(result).to eq({})
+    end
+  end
+
+  describe "greedy one-to-one assignment" do
+    it "lets only one of two identical staged rows claim the existing item (lowest position wins)" do
+      target = existing("Carne Asada Taco")
+      first  = staged("Carne Asada Taco", position: 0)
+      second = staged("Carne Asada Taco", position: 1)
+
+      result = matches
+      expect(result[first.id]).to  eq(item_id: target.id, score: 1.0)
+      expect(result[second.id]).to be_nil
+    end
+
+    it "prefers the exact match when an exact and a fuzzy staged row compete" do
+      target = existing("Margherita Pizza")
+      exact  = staged("Margherita Pizza", position: 1)
+      fuzzy  = staged("Margarita Pizza",  position: 0)
+
+      result = matches
+      expect(result[exact.id]).to eq(item_id: target.id, score: 1.0)
+      expect(result[fuzzy.id]).to be_nil
+    end
+  end
+end

--- a/apps/api/spec/services/ingestion/existing_item_matcher_spec.rb
+++ b/apps/api/spec/services/ingestion/existing_item_matcher_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe Ingestion::ExistingItemMatcher do
 
       expect(matches[row.id]).to eq(item_id: target.id, score: 1.0)
     end
+
+    it "matches across diacritics ('Jalapeño Poppers' = 'Jalapeno Poppers')" do
+      target = existing("Jalapeno Poppers")
+      row    = staged("Jalapeño Poppers")
+
+      expect(matches[row.id]).to eq(item_id: target.id, score: 1.0)
+    end
   end
 
   describe "similarity band with token-subset veto" do

--- a/apps/api/spec/services/ingestion/item_update_diff_spec.rb
+++ b/apps/api/spec/services/ingestion/item_update_diff_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe Ingestion::ItemUpdateDiff do
+  let(:restaurant) { create(:restaurant, :published) }
+  let(:run)        { create(:ingestion_run, restaurant: restaurant) }
+  let(:item) do
+    create(:item, restaurant: restaurant, name: "Carne Asada Taco",
+                  description: "Grilled steak, cilantro, onion.")
+  end
+
+  let!(:beef)  { create(:ingredient, slug: "meat-beef") }
+  let!(:onion) { create(:ingredient, slug: "vegetable-onion") }
+
+  def staged(attrs = {})
+    create(:ingestion_item, {
+      ingestion_run: run,
+      name: "Carne Asada Taco",
+      description: item.description,
+      ingredients_payload: [],
+      tags_payload: [],
+      prices_payload: []
+    }.merge(attrs))
+  end
+
+  describe "description" do
+    it "reports a change as from/to" do
+      diff = described_class.call(staged(description: "Now with lime."), item)
+
+      expect(diff[:description]).to eq(from: item.description, to: "Now with lime.")
+      expect(diff[:no_changes]).to be false
+    end
+
+    it "never proposes blanking a description (absence of evidence)" do
+      diff = described_class.call(staged(description: nil), item)
+      expect(diff[:description]).to be_nil
+    end
+
+    it "ignores whitespace-only differences" do
+      diff = described_class.call(staged(description: "  #{item.description}  "), item)
+      expect(diff[:description]).to be_nil
+    end
+  end
+
+  describe "prices" do
+    before { ItemVariant.create!(item: item, size: "small", price_cents: 450, position: 0) }
+
+    it "reports a changed price set as normalized from/to" do
+      diff = described_class.call(
+        staged(prices_payload: [{ "size" => "small", "price_cents" => 550 }]), item
+      )
+
+      expect(diff[:prices]).to eq(
+        from: [{ size: "small", price_cents: 450 }],
+        to:   [{ size: "small", price_cents: 550 }]
+      )
+    end
+
+    it "never proposes deleting variants when the scan carries no prices" do
+      diff = described_class.call(staged(prices_payload: []), item)
+      expect(diff[:prices]).to be_nil
+    end
+
+    it "treats the same price set in a different order as unchanged" do
+      ItemVariant.create!(item: item, size: "large", price_cents: 750, position: 1)
+
+      diff = described_class.call(
+        staged(prices_payload: [
+                 { "size" => "large", "price_cents" => 750 },
+                 { "size" => "small", "price_cents" => 450 }
+               ]), item
+      )
+      expect(diff[:prices]).to be_nil
+    end
+
+    it "drops priceless rows before comparing" do
+      diff = described_class.call(
+        staged(prices_payload: [
+                 { "size" => "market", "price_cents" => nil },
+                 { "size" => "small", "price_cents" => 450 }
+               ]), item
+      )
+      expect(diff[:prices]).to be_nil
+    end
+  end
+
+  describe "added ingredients and tags" do
+    before { ItemIngredient.create!(item: item, ingredient: beef, confidence: "confirmed", source: "human") }
+
+    it "lists payload slugs the item doesn't have yet" do
+      diff = described_class.call(
+        staged(ingredients_payload: [
+                 { "slug" => "meat-beef", "confidence" => 0.97 },
+                 { "slug" => "vegetable-onion", "confidence" => 0.93 }
+               ]), item
+      )
+
+      expect(diff[:added_ingredients]).to eq(["vegetable-onion"])
+    end
+
+    it "reports tags the same way" do
+      tag = create(:tag, slug: "grilled")
+      ItemTag.create!(item: item, tag: tag, confidence: "confirmed", source: "human")
+
+      diff = described_class.call(
+        staged(tags_payload: [
+                 { "slug" => "grilled", "confidence" => 0.9 },
+                 { "slug" => "spicy", "confidence" => 0.8 }
+               ]), item
+      )
+
+      expect(diff[:added_tags]).to eq(["spicy"])
+    end
+  end
+
+  it "flags no_changes when nothing differs" do
+    diff = described_class.call(staged, item)
+
+    expect(diff).to eq(
+      description: nil, prices: nil,
+      added_ingredients: [], added_tags: [],
+      no_changes: true
+    )
+  end
+end

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -73,6 +73,17 @@ the taxonomy already in Postgres:
   hit = confidence 1.0, alias hit = 0.95, `source: "match"`. The
   description is the ingredient authority; dish-name leftovers only
   count when the name is all the evidence there is.
+- **Existing-item match** (`Ingestion::ExistingItemMatcher`): staged
+  items are linked (`matched_item_id` + `match_score`) to the
+  restaurant's existing Items so a re-scan stages updates instead of
+  duplicates. Deterministic and greedy one-to-one: normalized-token
+  equality (lowercase, punctuation stripped, singularized, stopwords
+  dropped) wins at 1.0; otherwise pg_trgm `similarity() >= 0.60` with a
+  token-subset veto — "Chicken Burrito" never matches "Chicken Burrito
+  Bowl" no matter how similar, because a name whose token set strictly
+  contains the other's is a different dish. Calibration data lives with
+  the constant. A false merge corrupts a live item; a missed match is
+  just a duplicate card a human can reject.
 - **Tag derivation** (`Ingestion::TagDeriver`): one strategy per tag
   family. `allergen` derives from the resolved ingredients' ltree
   ancestry (`dairy.* → contains-dairy`, plus cross-root exceptions like
@@ -118,9 +129,11 @@ tags_payload: [
 ```
 
 (`source: "derived"` marks a tag derived from a deterministic
-ingredient's ancestry.) Re-ingestion dedup (trgm name-match against
-existing items) remains a **known gap** — re-scanning a restaurant
-still duplicates its menu.
+ingredient's ancestry.) Matched items serialize a `match` block
+(existing item + a serialize-time diff: description, prices, added
+ingredients/tags) for the verify UI. **Known gap**: accepting a
+matched item still creates a duplicate — the apply-update-on-accept
+path is the next PR in the re-scan arc.
 
 ### 4. Verify
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,8 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-30 — Re-scan matching ships dark: ResolveItemsJob now links staged items to the restaurant's existing Items (`Ingestion::ExistingItemMatcher` — normalized-token exact, else trgm ≥ 0.60 + token-subset veto; greedy 1:1) and the verify API serializes a `match` block with a serialize-time diff (`Ingestion::ItemUpdateDiff`). Accept still creates (dark) — apply-on-accept is the next PR. Threshold calibrated against live pg_trgm probes: raw similarity cannot separate "Chicken Burrito|Chicken Burrito Bowl" (0.800) from plurals (0.842), hence the subset veto instead of the originally-planned 0.70 raw threshold. Branch `feature/ingestion-rescan-matching`.
+
 2026-07-29 — Add-on guard: "Add X for $3" upsell lines no longer stage as dishes. Branch `feature/ingestion-addon-guard`.
 
 - Extraction prompt + schema now classify add-on lines and nest them under the


### PR DESCRIPTION
## Summary

- Re-scanning a restaurant duplicates its whole menu (documented known gap). This PR ships the matching half of the fix, dark: ResolveItemsJob links staged items to existing Items and the verify API serializes a match block + diff; accept behavior is unchanged.
- Matching is deterministic (no LLM): normalized-token equality, else pg_trgm similarity >= 0.60 with a token-subset veto — live probes showed no raw threshold separates "Chicken Burrito Bowl" (0.800, different dish) from plurals (0.842, same dish). Calibration is pinned in a spec against real similarity() output.
- Apply-on-accept + the undo branch that makes it safe land together in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsQM2hexYk2HRR5kqoXNJn
