### PR TITLE
feat(web): render re-scan update cards in the verify list

### DIFF
--- a/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/_VerifyItemRow.tsx
@@ -49,6 +49,11 @@ export function VerifyItemRow({
   // Nullish fallback: web (Vercel) and API (Kamal) deploy independently, so a
   // fresh client may briefly see responses without the field.
   const addons = item.addons_payload ?? [];
+  const match = item.match ?? null;
+  const diff = match && !match.no_changes ? match.diff : null;
+
+  const fmtPrices = (rows: Array<{ size: string | null; price_cents: number }>) =>
+    rows.map((r) => `${r.size ? `${r.size} ` : ''}$${(r.price_cents / 100).toFixed(2)}`).join(' · ');
 
   return (
     <li className="rounded-xl border border-zinc-200 p-4" data-testid={`verify-item-${item.id}`}>
@@ -60,7 +65,46 @@ export function VerifyItemRow({
               <span className="ml-2 font-normal text-zinc-500">${(price / 100).toFixed(2)}</span>
             )}
           </p>
+          {match && (
+            <span
+              data-testid="match-badge"
+              className="mt-1 inline-block rounded-full bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-800"
+            >
+              {match.no_changes
+                ? 'Already on the menu — no changes'
+                : `Updates “${match.existing.name}”`}
+            </span>
+          )}
           {item.description && <p className="mt-1 text-sm text-zinc-600">{item.description}</p>}
+
+          {diff && (
+            <div className="mt-2 space-y-1 text-xs" data-testid="match-diff">
+              {diff.description && (
+                <p className="text-zinc-500">
+                  <span className="line-through">{diff.description.from ?? '(none)'}</span>{' '}
+                  <span className="text-zinc-700">→ {diff.description.to}</span>
+                </p>
+              )}
+              {diff.prices && (
+                <p className="text-zinc-500">
+                  <span className="line-through">{fmtPrices(diff.prices.from) || '(no price)'}</span>{' '}
+                  <span className="text-zinc-700">→ {fmtPrices(diff.prices.to)}</span>
+                </p>
+              )}
+              {(diff.added_ingredients.length > 0 || diff.added_tags.length > 0) && (
+                <p className="flex flex-wrap gap-1">
+                  {[...diff.added_ingredients, ...diff.added_tags].map((slug) => (
+                    <span
+                      key={slug}
+                      className="rounded-full bg-green-50 px-2 py-0.5 text-green-800"
+                    >
+                      + {slug}
+                    </span>
+                  ))}
+                </p>
+              )}
+            </div>
+          )}
 
           {addons.length > 0 && (
             <ul className="mt-2 space-y-0.5" data-testid="item-addons">
@@ -141,7 +185,7 @@ export function VerifyItemRow({
                 onClick={() => void decide('accepted')}
                 className="rounded bg-green-600 px-3 py-1 text-sm font-semibold text-white disabled:opacity-50"
               >
-                Accept
+                {diff ? 'Accept update' : 'Accept'}
               </button>
               <button
                 type="button"

--- a/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
+++ b/apps/web/src/app/ingest/verify/[runId]/__tests__/VerifyItemRow.test.tsx
@@ -138,6 +138,71 @@ describe('VerifyItemRow', () => {
     });
   });
 
+  describe('re-scan update cards', () => {
+    const match: ingestion.IngestionItemMatch = {
+      item_id: 'existing-1',
+      score: 1.0,
+      existing: {
+        name: 'Pad Thai',
+        description: 'Old description.',
+        prices: [{ size: null, price_cents: 1250 }],
+      },
+      diff: {
+        description: { from: 'Old description.', to: 'Rice noodles, peanut, lime.' },
+        prices: {
+          from: [{ size: null, price_cents: 1250 }],
+          to: [{ size: null, price_cents: 1450 }],
+        },
+        added_ingredients: ['fruit-lime'],
+        added_tags: [],
+      },
+      no_changes: false,
+    };
+
+    it('renders the update badge, diff, and "Accept update" for a matched item', () => {
+      render(
+        <VerifyItemRow runId="run-1" item={{ ...item, match }} enriched onDecided={vi.fn()} />,
+      );
+
+      expect(screen.getByTestId('match-badge')).toHaveTextContent('Updates “Pad Thai”');
+      const diffBlock = screen.getByTestId('match-diff');
+      expect(diffBlock).toHaveTextContent('Old description.');
+      expect(diffBlock).toHaveTextContent('→ Rice noodles, peanut, lime.');
+      expect(diffBlock).toHaveTextContent('$12.50');
+      expect(diffBlock).toHaveTextContent('→ $14.50');
+      expect(diffBlock).toHaveTextContent('+ fruit-lime');
+      expect(screen.getByRole('button', { name: 'Accept update' })).toBeInTheDocument();
+    });
+
+    it('renders a no-changes badge without a diff block', () => {
+      const unchanged = {
+        ...match,
+        diff: { description: null, prices: null, added_ingredients: [], added_tags: [] },
+        no_changes: true,
+      };
+      render(
+        <VerifyItemRow
+          runId="run-1"
+          item={{ ...item, match: unchanged }}
+          enriched
+          onDecided={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('match-badge')).toHaveTextContent('Already on the menu');
+      expect(screen.queryByTestId('match-diff')).toBeNull();
+      expect(screen.getByRole('button', { name: 'Accept' })).toBeInTheDocument();
+    });
+
+    it('renders a plain create card when the field is absent (old API)', () => {
+      render(<VerifyItemRow runId="run-1" item={item} enriched onDecided={vi.fn()} />);
+
+      expect(screen.queryByTestId('match-badge')).toBeNull();
+      expect(screen.queryByTestId('match-diff')).toBeNull();
+      expect(screen.getByRole('button', { name: 'Accept' })).toBeInTheDocument();
+    });
+  });
+
   it('renders the friendly error when the decision fails', async () => {
     decideMock.mockImplementation(() =>
       Promise.reject(new ingestion.IngestionRequestError(503, { error: 'cost_ceiling_reached' })),

--- a/apps/web/src/lib/ingestion.ts
+++ b/apps/web/src/lib/ingestion.ts
@@ -127,6 +127,34 @@ export async function createRestaurant(opts: {
   return { kind: 'created', restaurant: (await res.json()) as CreatedRestaurant };
 }
 
+/** A price row as the API serializes it (existing item or diff sides). */
+export interface MatchPriceRow {
+  size: string | null;
+  price_cents: number;
+}
+
+/**
+ * Re-scan dedup: the existing Item this staged row was matched against,
+ * plus a server-computed diff. Accepting a matched row APPLIES the diff
+ * to the existing Item instead of creating a duplicate.
+ */
+export interface IngestionItemMatch {
+  item_id: string;
+  score: number | null;
+  existing: {
+    name: string;
+    description: string | null;
+    prices: MatchPriceRow[];
+  };
+  diff: {
+    description: { from: string | null; to: string | null } | null;
+    prices: { from: MatchPriceRow[]; to: MatchPriceRow[] } | null;
+    added_ingredients: string[];
+    added_tags: string[];
+  };
+  no_changes: boolean;
+}
+
 export interface IngestionItemPayload {
   id: string;
   ingestion_run_id: string;
@@ -149,6 +177,12 @@ export interface IngestionItemPayload {
   addons_payload?: Array<{ name: string; price_cents: number | null; source: 'extract' | 'guard' }>;
   unresolved_ingredients: string[];
   unresolved_tags: string[];
+  /**
+   * Present when this staged row matched an existing Item (re-scan).
+   * Optional for the same independent-deploy reason as addons_payload —
+   * always fall back to null.
+   */
+  match?: IngestionItemMatch | null;
 }
 
 async function getJson<T>(path: string, fetchImpl: typeof fetch): Promise<T> {

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,8 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-30 — Web verify renders re-scan update cards: amber "Updates ‹name›" badge, strikethrough→new diff for description/prices, green `+slug` chips for added ingredients/tags, "Accept update" button label, "Already on the menu" for no-change matches. Absent `match` field falls back to today's create card (deploy-skew guard). Branch `feature/web-rescan-update-cards`.
+
 2026-07-30 — `promote!` now materializes `prices_payload` as `ItemVariant` rows (size + price_cents, payload order; priceless rows skipped). Previously extracted prices were silently dropped at accept. Branch `fix/promote-prices-item-variants`. First PR of the re-scan dedup + diff/merge arc (matching + apply-update PRs follow).
 
 2026-07-29 — Add-on guard: "Add X for $3" upsell lines no longer stage as dishes. Branch `feature/ingestion-addon-guard`.


### PR DESCRIPTION
## Summary

- Web verify now renders the API's re-scan match block: "Updates ‹name›" badge, description/price diff, +slug chips for new ingredients/tags, and an "Accept update" button; no-change matches read "Already on the menu".
- The match field is optional with a null fallback so an older API renders exactly today's create card (independent deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsQM2hexYk2HRR5kqoXNJn
