### PR TITLE
feat(api): admin auth foundation — require_admin! gate, /me, admin dashboard JSON, admin roster tasks

### DIFF
--- a/apps/api/app/controllers/api/v1/admin/base_controller.rb
+++ b/apps/api/app/controllers/api/v1/admin/base_controller.rb
@@ -2,11 +2,11 @@ module Api
   module V1
     module Admin
       # Parent for every /api/v1/admin/* controller. Authenticated
-      # non-admins get the same 404 an unknown path would return, so
-      # the namespace's existence is never advertised (matches the
-      # owner-or-404 precedent in IngestionRunsController#show).
-      # Unauthenticated callers still get Devise's 401 from the
-      # inherited authenticate_user!.
+      # non-admins get a 404 instead of a 403 — same shape as the
+      # owner-or-404 precedent in IngestionRunsController#show — so a
+      # response never confirms "admin-only thing here, you just can't
+      # have it". Unauthenticated callers still get Devise's 401 from
+      # the inherited authenticate_user!.
       class BaseController < Api::V1::BaseController
         before_action :require_admin!
 

--- a/apps/api/app/controllers/api/v1/admin/base_controller.rb
+++ b/apps/api/app/controllers/api/v1/admin/base_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    module Admin
+      # Parent for every /api/v1/admin/* controller. Authenticated
+      # non-admins get the same 404 an unknown path would return, so
+      # the namespace's existence is never advertised (matches the
+      # owner-or-404 precedent in IngestionRunsController#show).
+      # Unauthenticated callers still get Devise's 401 from the
+      # inherited authenticate_user!.
+      class BaseController < Api::V1::BaseController
+        before_action :require_admin!
+
+        private
+
+        def require_admin!
+          return if current_user&.is_admin?
+
+          render json: { error: "not_found" }, status: :not_found
+        end
+      end
+    end
+  end
+end

--- a/apps/api/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/apps/api/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -1,0 +1,54 @@
+module Api
+  module V1
+    module Admin
+      # GET /api/v1/admin/dashboard — JSON twin of the Phase 2.9 ERB
+      # dashboard (Ingestion::CostMetrics buckets + the community
+      # counters), plus queue counts the web admin renders as nav
+      # badges. The ERB version at /admin/dashboard is retired with
+      # Avo once the web admin has full parity.
+      class DashboardsController < BaseController
+        def show
+          render json: {
+            target_cents_per_item: Ingestion::CostMetrics::TARGET_CENTS_PER_ITEM,
+            periods: Ingestion::CostMetrics.by_period.transform_values(&:to_h),
+            community: community_counters,
+            queues: queue_counts
+          }
+        end
+
+        private
+
+        # Same UTC-day window the Phase 6.1 cost ceiling enforces, so
+        # "spend today" is exactly the number the 503 guard compares
+        # against. (Parens required: an endless range at end-of-line
+        # parses the NEXT line as its end.)
+        def community_counters
+          today_utc = (Time.current.utc.beginning_of_day..)
+
+          {
+            runs_today: IngestionRun.joins(:user)
+                                    .where(users: { is_admin: false })
+                                    .where(created_at: today_utc)
+                                    .count,
+            spend_today_cents: IngestionRun.where(created_at: today_utc).sum(:api_cost_cents),
+            ceiling_cents: Integer(ENV.fetch(
+              "INGESTION_DAILY_COST_CEILING_CENTS",
+              Api::V1::IngestionRunsController::DAILY_COST_CEILING_CENTS_DEFAULT
+            ))
+          }
+        end
+
+        # All four are cheap indexed counts (partial index on flagged
+        # reviews, status columns elsewhere).
+        def queue_counts
+          {
+            flagged_reviews: Review.awaiting_moderation.count,
+            pending_suggestions: Suggestion.where(status: "pending").count,
+            community_published_restaurants: Restaurant.community_published.count,
+            staged_runs: IngestionRun.where(status: "staged").count
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/app/controllers/api/v1/me_controller.rb
+++ b/apps/api/app/controllers/api/v1/me_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    # GET /api/v1/me — the caller's own identity payload.
+    #
+    # Exists so clients can re-read the user (notably `is_admin`, which
+    # gates the web /admin shell) without POST /api/v1/auth/refresh —
+    # refresh rotates the jti and would invalidate the user's other
+    # sessions if used as a read probe.
+    class MeController < BaseController
+      include AuthTokenResponse
+
+      def show
+        render json: { user: user_payload(current_user) }
+      end
+    end
+  end
+end

--- a/apps/api/app/controllers/concerns/auth_token_response.rb
+++ b/apps/api/app/controllers/concerns/auth_token_response.rb
@@ -16,7 +16,8 @@ module AuthTokenResponse
       id: user.id,
       email: user.email,
       handle: user.handle,
-      display_name: user.display_name
+      display_name: user.display_name,
+      is_admin: user.is_admin
     }
     payload[:provider] = user.provider if include_provider
     payload

--- a/apps/api/app/services/biteworthy/admin_roster.rb
+++ b/apps/api/app/services/biteworthy/admin_roster.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Manages the `users.is_admin` roster from a trusted context (rake /
+# console). Kept as a service so the admin:grant / admin:revoke /
+# admin:sync tasks stay thin and the logic is spec-testable — same
+# split as Biteworthy::EmailSmoke / ProductionSmoke.
+#
+# Deliberately does NOT create placeholder users for unknown emails:
+# User.from_omniauth looks up by (provider, uid), not email, so a
+# pre-created stub would collide with a later OAuth signup on the
+# users.email unique index. Unknown emails are reported and skipped;
+# re-run after the account signs up.
+module Biteworthy
+  class AdminRoster
+    def initialize(logger: $stdout)
+      @logger = logger
+    end
+
+    # Returns :granted, :already_admin, or :missing.
+    def grant(email)
+      with_user(email) do |user|
+        return :already_admin if user.is_admin?
+
+        user.update!(is_admin: true)
+        log "granted admin → #{user.email} (#{user.id})"
+        :granted
+      end
+    end
+
+    # Returns :revoked, :not_admin, or :missing.
+    def revoke(email)
+      with_user(email) do |user|
+        return :not_admin unless user.is_admin?
+
+        user.update!(is_admin: false)
+        log "revoked admin → #{user.email} (#{user.id})"
+        :revoked
+      end
+    end
+
+    # Grants every address in `emails` (typically ENV["ADMIN_EMAILS"],
+    # comma-separated). Idempotent; returns { email => result }.
+    def sync(emails)
+      emails.to_s.split(",").map(&:strip).reject(&:empty?).index_with do |email|
+        grant(email)
+      end
+    end
+
+    private
+
+    def with_user(email)
+      # Devise downcases emails on write; normalize before lookup.
+      user = User.find_by(email: email.to_s.strip.downcase)
+      unless user
+        log "no account for #{email} — run again after signup"
+        return :missing
+      end
+
+      yield user
+    end
+
+    def log(message)
+      @logger << "AdminRoster: #{message}\n"
+    end
+  end
+end

--- a/apps/api/app/services/biteworthy/admin_roster.rb
+++ b/apps/api/app/services/biteworthy/admin_roster.rb
@@ -19,7 +19,10 @@ module Biteworthy
     # Returns :granted, :already_admin, or :missing.
     def grant(email)
       with_user(email) do |user|
-        return :already_admin if user.is_admin?
+        if user.is_admin?
+          log "already admin — #{user.email}"
+          return :already_admin
+        end
 
         user.update!(is_admin: true)
         log "granted admin → #{user.email} (#{user.id})"
@@ -30,7 +33,10 @@ module Biteworthy
     # Returns :revoked, :not_admin, or :missing.
     def revoke(email)
       with_user(email) do |user|
-        return :not_admin unless user.is_admin?
+        unless user.is_admin?
+          log "not an admin — #{user.email}"
+          return :not_admin
+        end
 
         user.update!(is_admin: false)
         log "revoked admin → #{user.email} (#{user.id})"

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -118,6 +118,16 @@ Rails.application.routes.draw do
           collection { post :accept_all }
         end
       end
+      # The caller's own identity incl. `is_admin` — the web /admin
+      # guard's probe. Read-only on purpose: auth/refresh also returns
+      # the user payload but rotates the jti, killing other sessions.
+      get "/me", to: "me#show"
+      # Web-admin backoffice JSON namespace. Admin-only; non-admins get
+      # 404 (see Api::V1::Admin::BaseController). Replaces Avo + the
+      # ERB /admin/dashboard capability by capability.
+      namespace :admin do
+        get :dashboard, to: "dashboards#show"
+      end
     end
   end
 

--- a/apps/api/lib/tasks/admin.rake
+++ b/apps/api/lib/tasks/admin.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Admin-roster management. All three tasks are idempotent and safe to
+# re-run; unknown emails are reported and skipped (see
+# Biteworthy::AdminRoster for why they are never pre-created).
+#
+# Usage:
+#   bin/rails "admin:grant[skylar@example.com]"
+#   bin/rails "admin:revoke[skylar@example.com]"
+#   ADMIN_EMAILS=a@x.com,b@y.com bin/rails admin:sync
+namespace :admin do
+  desc "Grant is_admin to the user with the given email"
+  task :grant, [:email] => :environment do |_t, args|
+    abort("usage: admin:grant[email]") if args[:email].blank?
+    Biteworthy::AdminRoster.new.grant(args[:email])
+  end
+
+  desc "Revoke is_admin from the user with the given email"
+  task :revoke, [:email] => :environment do |_t, args|
+    abort("usage: admin:revoke[email]") if args[:email].blank?
+    Biteworthy::AdminRoster.new.revoke(args[:email])
+  end
+
+  desc "Grant is_admin to every email in ADMIN_EMAILS (comma-separated)"
+  task sync: :environment do
+    abort("ADMIN_EMAILS must be set") if ENV["ADMIN_EMAILS"].blank?
+    Biteworthy::AdminRoster.new.sync(ENV["ADMIN_EMAILS"])
+  end
+end

--- a/apps/api/lib/tasks/admin.rake
+++ b/apps/api/lib/tasks/admin.rake
@@ -21,7 +21,7 @@ namespace :admin do
     Biteworthy::AdminRoster.new.revoke(args[:email])
   end
 
-  desc "Grant is_admin to every email in ADMIN_EMAILS (comma-separated)"
+  desc "Grant is_admin to every email in ADMIN_EMAILS (comma-separated; never revokes)"
   task sync: :environment do
     abort("ADMIN_EMAILS must be set") if ENV["ADMIN_EMAILS"].blank?
     Biteworthy::AdminRoster.new.sync(ENV["ADMIN_EMAILS"])

--- a/apps/api/spec/factories/users.rb
+++ b/apps/api/spec/factories/users.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     # in Phase 4. No-op for now.
     trait :confirmed do
     end
+
+    trait :admin do
+      is_admin { true }
+    end
   end
 end

--- a/apps/api/spec/integration/api/v1/admin/dashboard_spec.rb
+++ b/apps/api/spec/integration/api/v1/admin/dashboard_spec.rb
@@ -1,0 +1,91 @@
+require "swagger_helper"
+
+RSpec.describe "admin/dashboard", type: :request do
+  path "/api/v1/admin/dashboard" do
+    get("Ops dashboard: ingestion cost metrics, community spend, queue counts") do
+      tags "Admin"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true,
+                description: "Bearer <jwt> for a user with is_admin"
+
+      response(200, "metrics buckets + community counters + queue counts") do
+        period_bucket = {
+          type: :object,
+          required: %w[label run_count item_count total_cost_cents
+                       cost_per_item_cents cache_hit_rate],
+          properties: {
+            label:               { type: :string },
+            run_count:           { type: :integer },
+            item_count:          { type: :integer },
+            total_cost_cents:    { type: :integer },
+            cost_per_item_cents: { type: :number },
+            avg_latency_ms:      { type: :integer, nullable: true },
+            p95_latency_ms:      { type: :integer, nullable: true },
+            cache_hit_rate:      { type: :number }
+          }
+        }
+
+        schema type: :object,
+               required: %w[target_cents_per_item periods community queues],
+               properties: {
+                 target_cents_per_item: { type: :number },
+                 periods: {
+                   type: :object,
+                   required: %w[today last_7_days last_30_days],
+                   properties: {
+                     today:        period_bucket,
+                     last_7_days:  period_bucket,
+                     last_30_days: period_bucket
+                   }
+                 },
+                 community: {
+                   type: :object,
+                   required: %w[runs_today spend_today_cents ceiling_cents],
+                   properties: {
+                     runs_today:        { type: :integer },
+                     spend_today_cents: { type: :integer },
+                     ceiling_cents:     { type: :integer }
+                   }
+                 },
+                 queues: {
+                   type: :object,
+                   required: %w[flagged_reviews pending_suggestions
+                                community_published_restaurants staged_runs],
+                   properties: {
+                     flagged_reviews:                 { type: :integer },
+                     pending_suggestions:             { type: :integer },
+                     community_published_restaurants: { type: :integer },
+                     staged_runs:                     { type: :integer }
+                   }
+                 }
+               }
+
+        let(:account) { create(:user, :admin) }
+        let(:Authorization) do
+          token, _ = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+          "Bearer #{token}"
+        end
+        run_test!
+      end
+
+      response(401, "missing or invalid bearer token") do
+        let(:Authorization) { "" }
+        run_test!
+      end
+
+      # The admin namespace's gate contract: authenticated non-admins
+      # get 404, never 403 — the namespace's existence is not
+      # advertised to probing.
+      response(404, "authenticated but not an admin") do
+        schema "$ref" => "#/components/schemas/Error"
+        let(:account) { create(:user) }
+        let(:Authorization) do
+          token, _ = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+          "Bearer #{token}"
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/apps/api/spec/integration/api/v1/me_spec.rb
+++ b/apps/api/spec/integration/api/v1/me_spec.rb
@@ -1,0 +1,28 @@
+require "swagger_helper"
+
+RSpec.describe "me", type: :request do
+  path "/api/v1/me" do
+    get("Read the caller's own identity payload") do
+      tags "Auth"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true,
+                description: "Bearer <jwt>"
+
+      response(200, "the caller's user payload (incl. is_admin)") do
+        schema "$ref" => "#/components/schemas/AuthResponse"
+        let(:account) { create(:user, password: "password123") }
+        let(:Authorization) do
+          token, _ = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+          "Bearer #{token}"
+        end
+        run_test!
+      end
+
+      response(401, "missing or invalid bearer token") do
+        let(:Authorization) { "" }
+        run_test!
+      end
+    end
+  end
+end

--- a/apps/api/spec/lib/admin_roster_spec.rb
+++ b/apps/api/spec/lib/admin_roster_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+require "stringio"
+
+# Guards the roster service behind admin:grant / admin:revoke /
+# admin:sync. The tasks run against production, so the contract that
+# matters is safety-on-rerun: granting twice is a no-op, unknown
+# emails are skipped (never pre-created — a stub would collide with a
+# later OAuth signup on the email unique index), and sync reports
+# per-email results so a partial roster is visible, not silent.
+RSpec.describe Biteworthy::AdminRoster do
+  let(:logger) { StringIO.new }
+  let(:roster) { described_class.new(logger: logger) }
+
+  describe "#grant" do
+    it "flags the user and is idempotent on re-run" do
+      user = create(:user)
+
+      expect(roster.grant(user.email)).to eq(:granted)
+      expect(user.reload.is_admin).to be true
+      expect(roster.grant(user.email)).to eq(:already_admin)
+      expect(user.reload.is_admin).to be true
+    end
+
+    it "normalizes case/whitespace before lookup (Devise stores downcased)" do
+      user = create(:user)
+
+      expect(roster.grant("  #{user.email.upcase}  ")).to eq(:granted)
+      expect(user.reload.is_admin).to be true
+    end
+
+    it "skips unknown emails without creating a user" do
+      expect { expect(roster.grant("nobody@example.com")).to eq(:missing) }
+        .not_to change(User, :count)
+      expect(logger.string).to include("no account for nobody@example.com")
+    end
+  end
+
+  describe "#revoke" do
+    it "unflags an admin and reports non-admins distinctly" do
+      user = create(:user, :admin)
+
+      expect(roster.revoke(user.email)).to eq(:revoked)
+      expect(user.reload.is_admin).to be false
+      expect(roster.revoke(user.email)).to eq(:not_admin)
+    end
+  end
+
+  describe "#sync" do
+    it "grants every known email and reports missing ones" do
+      known = create(:user)
+
+      results = roster.sync(" #{known.email} , ghost@example.com ,")
+
+      expect(results).to eq(known.email => :granted, "ghost@example.com" => :missing)
+      expect(known.reload.is_admin).to be true
+    end
+  end
+end

--- a/apps/api/spec/requests/api/v1/admin/base_gate_spec.rb
+++ b/apps/api/spec/requests/api/v1/admin/base_gate_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+# The /api/v1/admin/* gate is the single authorization line between
+# every admin capability (moderation, taxonomy edits, user promotion)
+# and the public internet. This matrix pins its three contractual
+# behaviors: 401 for the unauthenticated, an unrevealing 404 for
+# authenticated non-admins (the namespace must not advertise itself),
+# and 200 for admins. It also pins that /api/v1/me — the web /admin
+# guard's probe — reports is_admin truthfully for both roles.
+RSpec.describe "Api::V1::Admin gate", type: :request do
+  describe "GET /api/v1/admin/dashboard" do
+    it "returns 401 when unauthenticated" do
+      get "/api/v1/admin/dashboard"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 404 (not 403) for an authenticated non-admin" do
+      get "/api/v1/admin/dashboard", headers: auth_headers_for(create(:user))
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq("error" => "not_found")
+    end
+
+    it "returns 200 with the dashboard payload for an admin" do
+      get "/api/v1/admin/dashboard", headers: auth_headers_for(create(:user, :admin))
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["periods"].keys).to contain_exactly("today", "last_7_days", "last_30_days")
+      expect(body["community"]).to include("ceiling_cents")
+      expect(body["queues"]).to include(
+        "flagged_reviews", "pending_suggestions",
+        "community_published_restaurants", "staged_runs"
+      )
+    end
+  end
+
+  describe "GET /api/v1/me" do
+    it "reports is_admin: false for a regular user" do
+      get "/api/v1/me", headers: auth_headers_for(create(:user))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["user"]).to include("is_admin" => false)
+    end
+
+    it "reports is_admin: true for an admin" do
+      user = create(:user, :admin)
+      get "/api/v1/me", headers: auth_headers_for(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["user"]).to include(
+        "id" => user.id, "email" => user.email, "is_admin" => true
+      )
+    end
+
+    it "returns 401 when unauthenticated" do
+      get "/api/v1/me"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/apps/api/spec/swagger_helper.rb
+++ b/apps/api/spec/swagger_helper.rb
@@ -55,12 +55,13 @@ RSpec.configure do |config|
           },
           UserPayload: {
             type: :object,
-            required: %w[id email handle],
+            required: %w[id email handle is_admin],
             properties: {
               id:           { type: :string, format: :uuid },
               email:        { type: :string, format: :email },
               handle:       { type: :string },
               display_name: { type: :string, nullable: true },
+              is_admin:     { type: :boolean },
               provider:     { type: :string, nullable: true,
                               enum: %w[google_oauth2 apple] }
             }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -116,6 +116,235 @@
         }
       }
     },
+    "/api/v1/admin/dashboard": {
+      "get": {
+        "summary": "Ops dashboard: ingestion cost metrics, community spend, queue counts",
+        "tags": [
+          "Admin"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "description": "Bearer <jwt> for a user with is_admin",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "metrics buckets + community counters + queue counts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "target_cents_per_item",
+                    "periods",
+                    "community",
+                    "queues"
+                  ],
+                  "properties": {
+                    "target_cents_per_item": {
+                      "type": "number"
+                    },
+                    "periods": {
+                      "type": "object",
+                      "required": [
+                        "today",
+                        "last_7_days",
+                        "last_30_days"
+                      ],
+                      "properties": {
+                        "today": {
+                          "type": "object",
+                          "required": [
+                            "label",
+                            "run_count",
+                            "item_count",
+                            "total_cost_cents",
+                            "cost_per_item_cents",
+                            "cache_hit_rate"
+                          ],
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "run_count": {
+                              "type": "integer"
+                            },
+                            "item_count": {
+                              "type": "integer"
+                            },
+                            "total_cost_cents": {
+                              "type": "integer"
+                            },
+                            "cost_per_item_cents": {
+                              "type": "number"
+                            },
+                            "avg_latency_ms": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "p95_latency_ms": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "cache_hit_rate": {
+                              "type": "number"
+                            }
+                          }
+                        },
+                        "last_7_days": {
+                          "type": "object",
+                          "required": [
+                            "label",
+                            "run_count",
+                            "item_count",
+                            "total_cost_cents",
+                            "cost_per_item_cents",
+                            "cache_hit_rate"
+                          ],
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "run_count": {
+                              "type": "integer"
+                            },
+                            "item_count": {
+                              "type": "integer"
+                            },
+                            "total_cost_cents": {
+                              "type": "integer"
+                            },
+                            "cost_per_item_cents": {
+                              "type": "number"
+                            },
+                            "avg_latency_ms": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "p95_latency_ms": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "cache_hit_rate": {
+                              "type": "number"
+                            }
+                          }
+                        },
+                        "last_30_days": {
+                          "type": "object",
+                          "required": [
+                            "label",
+                            "run_count",
+                            "item_count",
+                            "total_cost_cents",
+                            "cost_per_item_cents",
+                            "cache_hit_rate"
+                          ],
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "run_count": {
+                              "type": "integer"
+                            },
+                            "item_count": {
+                              "type": "integer"
+                            },
+                            "total_cost_cents": {
+                              "type": "integer"
+                            },
+                            "cost_per_item_cents": {
+                              "type": "number"
+                            },
+                            "avg_latency_ms": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "p95_latency_ms": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "cache_hit_rate": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "community": {
+                      "type": "object",
+                      "required": [
+                        "runs_today",
+                        "spend_today_cents",
+                        "ceiling_cents"
+                      ],
+                      "properties": {
+                        "runs_today": {
+                          "type": "integer"
+                        },
+                        "spend_today_cents": {
+                          "type": "integer"
+                        },
+                        "ceiling_cents": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "queues": {
+                      "type": "object",
+                      "required": [
+                        "flagged_reviews",
+                        "pending_suggestions",
+                        "community_published_restaurants",
+                        "staged_runs"
+                      ],
+                      "properties": {
+                        "flagged_reviews": {
+                          "type": "integer"
+                        },
+                        "pending_suggestions": {
+                          "type": "integer"
+                        },
+                        "community_published_restaurants": {
+                          "type": "integer"
+                        },
+                        "staged_runs": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid bearer token"
+          },
+          "404": {
+            "description": "authenticated but not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/auth/login": {
       "post": {
         "summary": "Log in with email + password",
@@ -347,6 +576,45 @@
         "responses": {
           "204": {
             "description": "account deleted — personal data removed, menu-graph attribution nulled"
+          },
+          "401": {
+            "description": "missing or invalid bearer token"
+          }
+        }
+      }
+    },
+    "/api/v1/me": {
+      "get": {
+        "summary": "Read the caller's own identity payload",
+        "tags": [
+          "Auth"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "description": "Bearer <jwt>",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the caller's user payload (incl. is_admin)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "missing or invalid bearer token"
@@ -846,7 +1114,8 @@
         "required": [
           "id",
           "email",
-          "handle"
+          "handle",
+          "is_admin"
         ],
         "properties": {
           "id": {
@@ -863,6 +1132,9 @@
           "display_name": {
             "type": "string",
             "nullable": true
+          },
+          "is_admin": {
+            "type": "boolean"
           },
           "provider": {
             "type": "string",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,8 +33,29 @@ linear human path from "code complete" to launch.
 1. **[BLOCKED] Phase 5.9-wiring — generate binary assets + screenshot routes + EAS submit** (followup to #180). Needs Apple Developer ($99/yr) + Google Play Console ($25 one-time) + lawyer signoff on `/privacy` + `/terms` + designed icon-source.svg.
 2. **[BLOCKED] Phase 5.1.1-wiring — CI-driven `kamal deploy` on master push** (followup to #182). Needs first manual `kamal deploy` to prove the manual flow works before CI automation; that needs the Hetzner + Neon + GHCR provisioning per `docs/launch-readiness.md` step 1.
 
-**No remaining loop-shippable work.** Every loop-shippable launch piece
-is on master; the remaining queue is entirely human-credential-gated.
+**Admin backoffice workstream** (started 2026-07-30, session-driven —
+not the loop): move all admin capability into a first-class `/admin`
+section of `apps/web`, backed by a new `Api::V1::Admin` JSON namespace;
+Avo + the ERB `/admin/dashboard` are retired in the final PR. Sequence
+(A = API PR, W = web PR, interleaved so each capability is testable as
+it lands):
+
+- [x] A1 — admin auth foundation: `require_admin!` (404) base controller, `GET /api/v1/me`, `GET /api/v1/admin/dashboard`, `is_admin` in `UserPayload`, `admin:grant/revoke/sync` rake tasks
+- [ ] W1 — web /admin shell: server layout guard via `/me`, nav, header link, `adminProxy` (no-store), robots/noindex
+- [ ] W2 — ops dashboard page (cost buckets, community spend vs ceiling, queue badges)
+- [ ] A2 — admin ingestion moderation: cross-user runs index, re-extract (extracted from Avo action), confirm-community; rswag for the 4 existing ingestion endpoints
+- [ ] W3 — ingestion moderation UI (runs queue, item review, confirm-community)
+- [ ] A3 — review + suggestion moderation endpoints
+- [ ] W4 — review + suggestions queue pages
+- [ ] A4 — taxonomy CRUD (slug/path/family immutable; referenced deletes 409)
+- [ ] W5 — taxonomy editor pages
+- [ ] A5 — restaurant/item/user management (status writes incl. `removed`, `is_admin` toggle w/ self-demotion guard)
+- [ ] W6 — restaurants/items/users pages
+- [ ] F1 — retire Avo (gem, resources, ERB dashboard, `basicAuth` scheme, `ADMIN_USERNAME`/`ADMIN_PASSWORD`)
+
+Other than that workstream, **no remaining loop-shippable work.** Every
+loop-shippable launch piece is on master; the remaining queue is
+entirely human-credential-gated.
 
 ## Open follow-ups
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,8 @@ the Phase 5 pause) are archived in
 
 ---
 
+2026-07-30 — Web-admin workstream A1: admin auth foundation. New `Api::V1::Admin::BaseController` (`require_admin!` → unrevealing 404, matching the owner-or-404 precedent), `GET /api/v1/me` (re-reads the payload without `auth/refresh`'s jti rotation), `GET /api/v1/admin/dashboard` (JSON twin of the ERB cost dashboard + queue counts for nav badges), `is_admin` added to `user_payload`/`UserPayload` (required — regenerates web+mobile types, additive), `Biteworthy::AdminRoster` + `admin:grant/revoke/sync` rake tasks (idempotent; never pre-creates users). Kicks off the admin-backoffice workstream (see roadmap): full web /admin in `apps/web`, Avo retired at the end. Branch `feature/admin-auth-foundation`. MANUAL: set `ADMIN_EMAILS` in Kamal secrets + run `bin/rails admin:sync` after deploy.
+
 2026-07-30 — Mobile verify deck renders re-scan update cards: "Updates ‹name›" badge, description/price → diff lines, green `+slug` rows, "✓ Accept update" action; absent `match` field renders today's card (deploy-skew guard). Branch `feature/mobile-rescan-update-cards`. Closes out the re-scan dedup + diff/merge arc (API matching #463, apply #464, web #465).
 
 2026-07-30 — Web verify renders re-scan update cards: amber "Updates ‹name›" badge, strikethrough→new diff for description/prices, green `+slug` chips for added ingredients/tags, "Accept update" button label, "Already on the menu" for no-change matches. Absent `match` field falls back to today's create card (deploy-skew guard). Branch `feature/web-rescan-update-cards`.

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -67,6 +67,106 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/dashboard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Ops dashboard: ingestion cost metrics, community spend, queue counts */
+        get: {
+            parameters: {
+                query?: never;
+                header: {
+                    /** @description Bearer <jwt> for a user with is_admin */
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description metrics buckets + community counters + queue counts */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            target_cents_per_item: number;
+                            periods: {
+                                today: {
+                                    label: string;
+                                    run_count: number;
+                                    item_count: number;
+                                    total_cost_cents: number;
+                                    cost_per_item_cents: number;
+                                    avg_latency_ms?: number | null;
+                                    p95_latency_ms?: number | null;
+                                    cache_hit_rate: number;
+                                };
+                                last_7_days: {
+                                    label: string;
+                                    run_count: number;
+                                    item_count: number;
+                                    total_cost_cents: number;
+                                    cost_per_item_cents: number;
+                                    avg_latency_ms?: number | null;
+                                    p95_latency_ms?: number | null;
+                                    cache_hit_rate: number;
+                                };
+                                last_30_days: {
+                                    label: string;
+                                    run_count: number;
+                                    item_count: number;
+                                    total_cost_cents: number;
+                                    cost_per_item_cents: number;
+                                    avg_latency_ms?: number | null;
+                                    p95_latency_ms?: number | null;
+                                    cache_hit_rate: number;
+                                };
+                            };
+                            community: {
+                                runs_today: number;
+                                spend_today_cents: number;
+                                ceiling_cents: number;
+                            };
+                            queues: {
+                                flagged_reviews: number;
+                                pending_suggestions: number;
+                                community_published_restaurants: number;
+                                staged_runs: number;
+                            };
+                        };
+                    };
+                };
+                /** @description missing or invalid bearer token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description authenticated but not an admin */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Error"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/auth/login": {
         parameters: {
             query?: never;
@@ -286,6 +386,52 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read the caller's own identity payload */
+        get: {
+            parameters: {
+                query?: never;
+                header: {
+                    /** @description Bearer <jwt> */
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description the caller's user payload (incl. is_admin) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["AuthResponse"];
+                    };
+                };
+                /** @description missing or invalid bearer token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -531,6 +677,7 @@ export interface components {
             email: string;
             handle: string;
             display_name?: string | null;
+            is_admin: boolean;
             /** @enum {string|null} */
             provider?: "google_oauth2" | "apple" | null;
         };


### PR DESCRIPTION
## Summary

- Kicks off the web-admin backoffice workstream (full `/admin` in `apps/web`, Avo retired at the end — sequence in `docs/roadmap.md`): this PR is the auth foundation the rest builds on.
- `Api::V1::Admin::BaseController` gates the new namespace with `require_admin!` → unrevealing 404 for authenticated non-admins (owner-or-404 precedent); `GET /api/v1/me` lets clients re-read `is_admin` without `auth/refresh`'s jti rotation; `GET /api/v1/admin/dashboard` is the JSON twin of the ERB cost dashboard + queue counts for nav badges.
- `is_admin` joins every auth user payload (rswag `UserPayload` + regenerated api-types), and `admin:grant/revoke/sync` rake tasks (idempotent, never pre-create users) manage the roster — production sets `ADMIN_EMAILS` and runs `admin:sync` post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsQM2hexYk2HRR5kqoXNJn
