### PR TITLE
fix(api): pin the dashboard's community-run exclusion; sweep stale Avo comments

### DIFF
--- a/apps/api/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/apps/api/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -1,11 +1,9 @@
 module Api
   module V1
     module Admin
-      # GET /api/v1/admin/dashboard — JSON twin of the Phase 2.9 ERB
-      # dashboard (Ingestion::CostMetrics buckets + the community
-      # counters), plus queue counts the web admin renders as nav
-      # badges. The ERB version at /admin/dashboard is retired with
-      # Avo once the web admin has full parity.
+      # GET /api/v1/admin/dashboard — Ingestion::CostMetrics buckets +
+      # the community counters + queue counts for the web admin
+      # (successor to the Phase 2.9 ERB dashboard, retired with Avo).
       class DashboardsController < BaseController
         def show
           render json: {

--- a/apps/api/app/models/review.rb
+++ b/apps/api/app/models/review.rb
@@ -63,7 +63,6 @@ class Review < ApplicationRecord
   end
 
   # Whether the body looks like spam under the lightweight heuristic.
-  # Public so specs + the Avo "rerun heuristic" action can call it.
   def suspicious?
     text = body.to_s
     return false if text.strip.empty?

--- a/apps/api/app/services/biteworthy/durango_seed.rb
+++ b/apps/api/app/services/biteworthy/durango_seed.rb
@@ -13,7 +13,7 @@ require "csv"
 # Idempotent: a row whose Restaurant already has a non-failed
 # IngestionRun in `:staged` or `:published` is skipped (the runner
 # logs `[skip]`). To re-run a failed restaurant, mark its old runs
-# as `:failed` (Avo can do this) or delete them — the next seed
+# as `:failed` (web /admin or console) or delete them — the next seed
 # call will pick the row up.
 #
 # Doesn't auto-publish the run. The Phase 2.5 swipe-verify queue

--- a/apps/api/config/deploy.yml
+++ b/apps/api/config/deploy.yml
@@ -110,7 +110,6 @@ env:
     - DEVISE_JWT_SECRET_KEY
     # AI ingestion (Phase 2.1+)
     - ANTHROPIC_API_KEY
-    # Avo admin (Phase 1.5)
     # SMTP — Resend API key (username "resend" is non-secret, in env.clear)
     - SMTP_PASSWORD
     # ActiveStorage on Cloudflare R2 (Phase 5.3)

--- a/apps/api/spec/requests/api/v1/admin/base_gate_spec.rb
+++ b/apps/api/spec/requests/api/v1/admin/base_gate_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe "Api::V1::Admin gate", type: :request do
         "community_published_restaurants", "staged_runs"
       )
     end
+
+    # This exclusion previously lived in the deleted ERB dashboard spec;
+    # it's the number that tells an admin how much of today's spend is
+    # community scanning vs their own — counting admins would hide a
+    # runaway community day.
+    it "counts community runs separately from admin runs, but sums everyone's spend" do
+      admin   = create(:user, :admin)
+      scanner = create(:user)
+      create(:ingestion_run, user: scanner, api_cost_cents: 30)
+      create(:ingestion_run, user: admin, api_cost_cents: 50)
+
+      get "/api/v1/admin/dashboard", headers: auth_headers_for(admin)
+
+      body = response.parsed_body
+      expect(body["community"]).to include(
+        "runs_today" => 1, "spend_today_cents" => 80
+      )
+    end
   end
 
   describe "GET /api/v1/me" do


### PR DESCRIPTION
## Summary

- Follow-up to #481 from its deletion audit: the dashboard's `runs_today` admin-exclusion lost its only value-level test with the deleted ERB dashboard spec — a request spec now pins community-only counting (1 scanner + 1 admin run → `runs_today: 1`, `spend_today_cents: 80`).
- Sweeps the stale Avo comments the deletion orphaned (deploy.yml, dashboards controller docstring, durango-seed operator note, review.rb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsQM2hexYk2HRR5kqoXNJn
