### PR TITLE
feat(web): admin usage pills and chat analytics events

### DIFF
--- a/apps/api/app/controllers/api/v1/conversations_controller.rb
+++ b/apps/api/app/controllers/api/v1/conversations_controller.rb
@@ -24,7 +24,11 @@ module Api
       # The reconnect path: a dropped stream loses nothing, because every
       # turn was persisted as it happened.
       def show
-        render json: Chat::Serializer.conversation(conversation, messages: true)
+        # Usage detail is for whoever operates the tools, not for a diner —
+        # it is spend and cache accounting, and it is the only part of this
+        # payload that is not about the conversation itself.
+        render json: Chat::Serializer.conversation(conversation, messages: true,
+                                                                 usage: current_user.is_admin?)
       end
 
       def destroy

--- a/apps/api/app/services/chat/serializer.rb
+++ b/apps/api/app/services/chat/serializer.rb
@@ -15,7 +15,7 @@ module Chat
     RENDERED_BLOCKS = %w[text thinking tool_use tool_result].freeze
 
     class << self
-      def conversation(conversation, messages: false)
+      def conversation(conversation, messages: false, usage: false)
         payload = {
           id:         conversation.id,
           title:      conversation.title,
@@ -24,6 +24,7 @@ module Chat
           created_at: conversation.created_at.iso8601,
           updated_at: conversation.updated_at.iso8601
         }
+        payload = payload.merge(usage: usage_for(conversation)) if usage
         messages ? payload.merge(messages: conversation.messages.map { |m| message(m) }) : payload
       end
 
@@ -37,6 +38,29 @@ module Chat
       end
 
       private
+
+      # What a turn actually cost, for the person operating the tools.
+      #
+      # Admin-only, and deliberately so: this is the spend and cache
+      # detail that decides whether the chat is affordable, not something
+      # a diner has any use for. `api_cost_cents` answers "are we over
+      # budget"; the per-round token split answers "where is the money
+      # going", which is the question C3 added those columns for.
+      def usage_for(conversation)
+        run = ConversationRun.where(conversation_id: conversation.id).order(:created_at).last
+        {
+          cost_cents: conversation.api_cost_cents,
+          last_run: run && {
+            outcome:           run.outcome,
+            state:             run.state,
+            rounds:            run.rounds,
+            input_tokens:      run.input_tokens,
+            output_tokens:     run.output_tokens,
+            cache_read_tokens: run.cache_read_tokens,
+            duration_ms:       run.duration_ms
+          }
+        }
+      end
 
       # The tool call the loop parked on, so a reloaded page can redraw
       # the confirmation prompt instead of stranding the conversation.

--- a/apps/api/spec/requests/api/v1/conversations_spec.rb
+++ b/apps/api/spec/requests/api/v1/conversations_spec.rb
@@ -150,5 +150,42 @@ RSpec.describe "Api::V1::Conversations", type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  # Spend and cache accounting is for whoever operates the tools. It is
+  # the one part of this payload that is not about the conversation, and
+  # a diner has no use for it.
+  describe "usage detail" do
+    let(:conversation) { create(:conversation, user: user, api_cost_cents: 12) }
+
+    it "is withheld from an ordinary caller" do
+      get "/api/v1/conversations/#{conversation.id}", headers: headers
+
+      expect(response.parsed_body).not_to have_key("usage")
+    end
+
+    it "reports the last run's token split to an admin" do
+      admin = create(:user, is_admin: true)
+      convo = create(:conversation, user: admin, api_cost_cents: 34)
+      run   = ConversationRun.acquire(convo)
+      run.record_round!("input_tokens" => 10, "output_tokens" => 5, "cache_read_input_tokens" => 7_550)
+      run.release!(outcome: "done")
+
+      get "/api/v1/conversations/#{convo.id}", headers: auth_headers_for(admin)
+
+      usage = response.parsed_body["usage"]
+      expect(usage["cost_cents"]).to eq(34)
+      expect(usage.dig("last_run", "cache_read_tokens")).to eq(7_550)
+      expect(usage.dig("last_run", "outcome")).to eq("done")
+    end
+
+    it "reads as empty rather than broken before any turn has run" do
+      admin = create(:user, is_admin: true)
+      convo = create(:conversation, user: admin)
+
+      get "/api/v1/conversations/#{convo.id}", headers: auth_headers_for(admin)
+
+      expect(response.parsed_body["usage"]["last_run"]).to be_nil
+    end
+  end
 end
 

--- a/apps/web/src/app/chat/_ChatClient.tsx
+++ b/apps/web/src/app/chat/_ChatClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTracker } from '../_PostHogProvider';
 import {
   NotSignedInError,
   createConversation,
@@ -14,6 +15,7 @@ import {
   watchTurn,
   type Attachment,
   type ChatEvent,
+  type ChatUsage,
   type ChatMessage,
   type Conversation,
   type ConversationSummary,
@@ -27,6 +29,7 @@ const EMPTY_TURN: LiveTurn = { thinking: '', text: '', tools: [] };
 
 export function ChatClient(): ReactElement {
   const router = useRouter();
+  const tracker = useTracker();
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [active, setActive] = useState<Conversation | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -136,12 +139,29 @@ export function ChatClient(): ReactElement {
     setBusy(true);
     setError(null);
     setLive(EMPTY_TURN);
+    const startedAt = Date.now();
+    let tools = 0;
+    let outcome = 'error';
     try {
       const { after } = await ask();
-      await watchTurn(id, after, consume);
+      await watchTurn(id, after, (event) => {
+        if (event.type === 'tool_use') tools += 1;
+        if (event.type === 'done') outcome = 'done';
+        if (event.type === 'awaiting_confirmation') outcome = 'awaiting_confirmation';
+        consume(event);
+      });
     } catch (e) {
       onFailure(e);
     } finally {
+      // Counts and outcome only — never the message, never which tools.
+      // A tool name on an identified event would say this account edited
+      // a dietary profile, which is the health-adjacency the taxonomy
+      // already strips from profile_set.
+      tracker.track('chat_turn_completed', {
+        outcome,
+        tool_count: tools,
+        duration_ms: Date.now() - startedAt,
+      });
       setLive(null);
       setBusy(false);
       // The turn was persisted as it ran, so this reconciles whether it
@@ -166,6 +186,7 @@ export function ChatClient(): ReactElement {
       if (!conversation) {
         conversation = await createConversation();
         adopt(conversation);
+        tracker.track('chat_started', { surface: 'web' });
       }
     } catch (e) {
       onFailure(e);
@@ -182,6 +203,7 @@ export function ChatClient(): ReactElement {
     const id = active.id;
     const { fingerprint } = pending;
     setPending(null);
+    tracker.track('chat_confirmed', { approved });
     await run(id, () => answerConfirmation(id, approved, fingerprint));
   };
 
@@ -219,6 +241,7 @@ export function ChatClient(): ReactElement {
             busy={busy}
             onAnswer={(approved) => void answer(approved)}
           />
+          {active?.usage ? <UsagePills usage={active.usage} /> : null}
           {error ? (
             <p role="alert" data-testid="chat-error" className="mt-bw-4 text-bw-sm text-danger">
               {error}
@@ -240,6 +263,36 @@ export function ChatClient(): ReactElement {
         ) : null}
         <Composer disabled={busy || pending !== null} onSend={(t, a) => void send(t, a)} />
       </main>
+    </div>
+  );
+}
+
+/**
+ * What the last turn cost. Rendered only when the server sent it, which
+ * it does only for admins — the visibility decision lives server-side, so
+ * there is nothing here to get wrong.
+ */
+function UsagePills({ usage }: { usage: ChatUsage }): ReactElement {
+  const run = usage.last_run;
+  const pills = [
+    `${usage.cost_cents}¢ total`,
+    run ? `${run.rounds} rounds` : null,
+    run ? `${run.cache_read_tokens.toLocaleString()} cached` : null,
+    run ? `${run.input_tokens.toLocaleString()} in / ${run.output_tokens.toLocaleString()} out` : null,
+    run?.duration_ms ? `${(run.duration_ms / 1000).toFixed(1)}s` : null,
+    run?.outcome && run.outcome !== 'done' ? run.outcome : null,
+  ].filter((p): p is string => p !== null);
+
+  return (
+    <div data-testid="usage-pills" className="mt-bw-4 flex flex-wrap gap-bw-1">
+      {pills.map((pill) => (
+        <span
+          key={pill}
+          className="rounded-bw-md bg-zinc-100 px-bw-2 py-bw-1 text-bw-xs text-zinc-500"
+        >
+          {pill}
+        </span>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/app/chat/__tests__/ChatClient.test.tsx
+++ b/apps/web/src/app/chat/__tests__/ChatClient.test.tsx
@@ -236,6 +236,47 @@ describe('ChatClient', () => {
     inFlight.release();
   });
 
+  // Spend accounting is admin-only, and the server decides — the client
+  // renders what it was sent and nothing more, so there is no visibility
+  // check here to get wrong.
+  describe('usage pills', () => {
+    it('shows the last turn\'s cost when the server sent it', async () => {
+      getConversation.mockResolvedValue({
+        ...answered('ok'),
+        usage: {
+          cost_cents: 34,
+          last_run: {
+            outcome: 'done',
+            state: 'done',
+            rounds: 3,
+            input_tokens: 1200,
+            output_tokens: 400,
+            cache_read_tokens: 7550,
+            duration_ms: 8200,
+          },
+        },
+      });
+
+      render(<ChatClient />);
+      await type('hi');
+
+      const pills = await screen.findByTestId('usage-pills');
+      expect(pills).toHaveTextContent('34¢ total');
+      expect(pills).toHaveTextContent('7,550 cached');
+      expect(pills).toHaveTextContent('8.2s');
+    });
+
+    it('renders nothing when the server withheld it', async () => {
+      getConversation.mockResolvedValue(answered('ok'));
+
+      render(<ChatClient />);
+      await type('hi');
+
+      await screen.findByText('ok');
+      expect(screen.queryByTestId('usage-pills')).not.toBeInTheDocument();
+    });
+  });
+
   it('shows an error event without losing the conversation', async () => {
     watchTurn.mockImplementation(async (_id, _after, onEvent) => {
       onEvent({ type: 'error', message: 'This conversation has reached its spend limit.' });

--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -42,8 +42,24 @@ export interface ConversationSummary {
   updated_at: string;
 }
 
+/** Spend and cache accounting. Present only for admins — the server
+ *  decides, so a non-admin never receives it to begin with. */
+export interface ChatUsage {
+  cost_cents: number;
+  last_run: {
+    outcome: string | null;
+    state: string;
+    rounds: number;
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_tokens: number;
+    duration_ms: number | null;
+  } | null;
+}
+
 export interface Conversation extends ConversationSummary {
   messages: ChatMessage[];
+  usage?: ChatUsage;
 }
 
 export interface Attachment {

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -148,3 +148,18 @@ Fired on any failure — both client-side gates and API errors — so drop-off i
 - Server-side `RecordRestaurantVisitJob` enrichment to also fire `restaurant_tap` to PostHog's server endpoint (so the funnel survives ad-blockers)
 
 The split keeps each PR small + reviewable. The abstraction shipping first means subsequent wiring PRs are call-site-only — no risk of taxonomy drift.
+
+### Chat events (added with the chat-engine arc)
+
+| Event | Props | Notes |
+|---|---|---|
+| `chat_started` | `surface` | Fires once per conversation created. |
+| `chat_turn_completed` | `outcome`, `tool_count`, `duration_ms` | One completed turn. |
+| `chat_confirmed` | `approved` | A person answered the confirmation gate. |
+
+**These deliberately carry no message text and no tool names.** The same
+reasoning that stripped the dietary profile off `profile_set` applies, and
+is easier to miss here: a tool name like `update_avoid_lists` on an
+identified event says this account edited a dietary profile, which is
+health-adjacent even without the contents. Counts and outcome give the
+funnel what it needs — did the turn work, how long, how much did it do.

--- a/docs/plans/chat-engine.md
+++ b/docs/plans/chat-engine.md
@@ -286,13 +286,21 @@ working, and a model narrating its own calls would describe what it intends
 rather than what is happening. Clients fall back to the humanized name when
 a tool declares nothing.
 
-**Deliberately not shipped here**, because each is a self-contained piece of
-UI work with no dependency on the engine:
-- Resource chips in the transcript (tool results already carry the ids).
-- Admin debug pills (per-round tokens and run id are on `conversation_runs`
-  as of C3 — the data exists, the surface does not).
-- Chat events in `packages/analytics`. Add-only when it happens: renaming
-  an existing event breaks the launch funnels.
+**Admin debug pills and chat analytics followed** in a separate PR: the
+conversation payload carries a `usage` object for admins only (the server
+decides, so the client has no visibility check to get wrong), and three
+add-only events — `chat_started`, `chat_turn_completed`, `chat_confirmed`
+— joined the taxonomy. Those events carry **no message text and no tool
+names**: a tool name like `update_avoid_lists` on an identified event says
+this account edited a dietary profile, which is the same health-adjacency
+the taxonomy already strips from `profile_set`.
+
+**Resource chips remain unbuilt**, and deliberately. Tool results carry
+their payload as a JSON text blob, so chips would mean the client guessing
+at each tool's response shape — brittle, and wrong the first time a tool
+changes its output. The honest version is a per-tool declaration alongside
+`running_description`, which is worth doing when someone wants the chips,
+not before.
 
 ---
 

--- a/packages/analytics/src/__tests__/index.test.ts
+++ b/packages/analytics/src/__tests__/index.test.ts
@@ -22,6 +22,9 @@ describe('EVENTS taxonomy', () => {
         'auth_started',
         'auth_completed',
         'auth_failed',
+        'chat_started',
+        'chat_turn_completed',
+        'chat_confirmed',
       ].sort(),
     );
   });

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -58,6 +58,11 @@ export const EVENTS = {
   auth_started:         'auth_started',
   auth_completed:       'auth_completed',
   auth_failed:          'auth_failed',
+  // Chat — the product's primary surface since the MCP pivot. These are
+  // add-only: renaming any event above breaks the launch dashboards.
+  chat_started:         'chat_started',
+  chat_turn_completed:  'chat_turn_completed',
+  chat_confirmed:       'chat_confirmed',
 } as const;
 
 export type EventName = keyof typeof EVENTS;
@@ -104,6 +109,31 @@ export interface EventPropsMap {
     restaurant_slug: string;
     /** Where the tap came from: home, search, durango_diet, history. */
     from: string;
+  };
+  chat_started: {
+    surface: 'web' | 'ios' | 'android';
+  };
+  /**
+   * One completed turn.
+   *
+   * **Deliberately carries no message text and no tool names.** The same
+   * reasoning that stripped the dietary profile off `profile_set` applies
+   * here and is easier to miss: a tool name like `update_avoid_lists` on
+   * an identified event says this account edited a dietary profile, which
+   * is health-adjacent even without the contents. Counts and outcome give
+   * the funnel what it needs — did the turn work, how long, how much did
+   * it do — without any of that.
+   */
+  chat_turn_completed: {
+    /** done | awaiting_confirmation | error */
+    outcome: string;
+    /** How many tools ran. Not which ones. */
+    tool_count: number;
+    duration_ms: number;
+  };
+  /** Whether a person approved a call the gate parked. Never which call. */
+  chat_confirmed: {
+    approved: boolean;
   };
   filter_changed: {
     /** What changed: strictness | preset | manual_avoid | manual_unavoid. */


### PR DESCRIPTION
## Summary

- The conversation payload carries a `usage` object — total spend plus the last run's rounds, token split, cache reads, duration — **for admins only, decided server-side**, so the client renders what it was sent and has no visibility check of its own to get wrong. Surfaces the columns C3 added that nothing had read.
- Three add-only analytics events: `chat_started`, `chat_turn_completed`, `chat_confirmed`. They carry **no message text and no tool names** — a tool name like `update_avoid_lists` on an identified event says this account edited a dietary profile, the same health-adjacency the taxonomy already strips from `profile_set`.
- Resource chips stay unbuilt on purpose: tool results are JSON text blobs, so chips would mean the client guessing at each tool's response shape. The honest version is a per-tool declaration alongside `running_description`.
