### PR TITLE
fix(api): close the IPv4-mapped IPv6 hole in the SSRF guard

### DIFF
--- a/apps/api/app/services/url_fetcher.rb
+++ b/apps/api/app/services/url_fetcher.rb
@@ -13,8 +13,10 @@ require "uri"
 # document, and Phase 2 isn't trying to do JS-rendered scraping.
 #
 # Hard limits:
-#   * 10 MB max — protects the API server from accidentally fetching
-#     a multi-hundred-meg PDF.
+#   * 10 MB max. Enforced on Content-Length before the request when the
+#     server declares one, and on the body afterwards when it does not —
+#     an undeclared response is still fully buffered before it can be
+#     rejected, so this bounds what we *use*, not always what we download.
 #   * Follows up to 3 redirects, re-validating each hop against the
 #     SSRF blocklist (cloud metadata + RFC1918 + loopback + …).
 #   * 15-second timeout.
@@ -44,7 +46,10 @@ class UrlFetcher
   ].freeze
 
   BLOCKED_IPV6 = [
+    IPAddr.new("::/128"),           # unspecified — routes to localhost
     IPAddr.new("::1/128"),
+    IPAddr.new("64:ff9b::/96"),     # NAT64 well-known prefix: embeds an
+                                    # IPv4 address this check cannot see
     IPAddr.new("fc00::/7"),         # unique-local
     IPAddr.new("fe80::/10"),        # link-local
     IPAddr.new("ff00::/8"),         # multicast
@@ -90,6 +95,9 @@ class UrlFetcher
         raise FetchError.new("non_2xx", status: response.status)
       end
 
+      declared = response.headers["content-length"].to_s
+      raise FetchError.new("response_too_large") if declared.present? && declared.to_i > MAX_BYTES
+
       body = response.body.to_s
       raise FetchError.new("response_too_large") if body.bytesize > MAX_BYTES
 
@@ -112,12 +120,24 @@ class UrlFetcher
     raise FetchError.new("dns_failed") if addresses.empty?
 
     addresses.each do |addr|
-      ip      = IPAddr.new(addr)
+      ip      = normalize(IPAddr.new(addr))
       blocked = ip.ipv4? ? BLOCKED_IPV4 : BLOCKED_IPV6
       raise FetchError.new("blocked_address") if blocked.any? { |range| range.include?(ip) }
     end
   rescue URI::InvalidURIError, IPAddr::InvalidAddressError
     raise FetchError.new("invalid_url")
+  end
+
+  # An IPv4-mapped IPv6 address is an IPv4 address wearing a hat:
+  # `::ffff:169.254.169.254` reaches cloud metadata, `::ffff:127.0.0.1`
+  # reaches loopback, `::ffff:10.0.0.1` reaches the internal network. Ruby
+  # reports all three as `ipv4? == false`, so without this they were
+  # checked against the IPv6 list — which has no mapped range — and sailed
+  # straight through every guard below.
+  def normalize(ip)
+    ip.ipv4_mapped? ? ip.native : ip
+  rescue StandardError
+    ip
   end
 
   def resolve_addresses(host)

--- a/apps/api/spec/services/url_fetcher_spec.rb
+++ b/apps/api/spec/services/url_fetcher_spec.rb
@@ -94,6 +94,39 @@ RSpec.describe UrlFetcher do
           .to raise_error(UrlFetcher::FetchError, /blocked_address/)
       end
 
+      # An IPv4-mapped IPv6 address is an IPv4 address wearing a hat, and
+      # Ruby reports it as `ipv4? == false` — so every one of these was
+      # checked against the IPv6 list, which has no mapped range, and
+      # reached its target through all of the guards above. This is the
+      # bypass, written out one target at a time.
+      it "rejects IPv4-mapped IPv6 addresses" do
+        {
+          "cloud metadata" => "[::ffff:169.254.169.254]",
+          "loopback"       => "[::ffff:127.0.0.1]",
+          "RFC1918"        => "[::ffff:10.0.0.1]",
+          "expanded form"  => "[0:0:0:0:0:ffff:7f00:1]"
+        }.each do |label, host|
+          expect { described_class.fetch("http://#{host}/menu") }
+            .to raise_error(UrlFetcher::FetchError, /blocked_address/), "#{label} (#{host}) got through"
+        end
+      end
+
+      it "rejects the IPv6 unspecified address and the NAT64 prefix" do
+        expect { described_class.fetch("http://[::]/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+        expect { described_class.fetch("http://[64:ff9b::7f00:1]/menu") }
+          .to raise_error(UrlFetcher::FetchError, /blocked_address/)
+      end
+
+      # A public IPv6 host must still work — the normalization must not
+      # turn the allowlist into a blocklist of everything.
+      it "still allows an ordinary IPv6 host" do
+        stub_request(:get, "http://[2606:4700:4700::1111]/menu")
+          .to_return(status: 200, body: "<html></html>", headers: { "Content-Type" => "text/html" })
+
+        expect { described_class.fetch("http://[2606:4700:4700::1111]/menu") }.not_to raise_error
+      end
+
       it "rejects IPv6 loopback" do
         expect { described_class.fetch("http://[::1]/menu") }
           .to raise_error(UrlFetcher::FetchError, /blocked_address/)

--- a/docs/plans/mcp-pivot.md
+++ b/docs/plans/mcp-pivot.md
@@ -307,8 +307,15 @@ Self-contained; nothing above depends on it.
 
 - **Chat cost per conversation** on `claude-opus-5` is unmeasured. `effort`
   is the dial; measure before the UI makes it easy to spend.
-- **`Ingestion::UrlFetcher` needs an SSRF review** (private-IP and redirect
-  handling) now that an agent can steer which URL gets fetched.
+- ~~**`UrlFetcher` needs an SSRF review** now that an agent can steer which
+  URL gets fetched.~~ **Done.** The redirect handling was already sound —
+  every hop re-validates, and there is no follow-redirects middleware. The
+  blocklist had a hole: an IPv4-mapped IPv6 address (`::ffff:169.254.169.254`)
+  reports `ipv4? == false` in Ruby, so it was checked against the IPv6 list,
+  which had no mapped range, and reached cloud metadata through every guard.
+  Mapped addresses are normalized to IPv4 before the check now, and `::` and
+  the NAT64 prefix are blocked. DNS rebinding between check and connect
+  remains possible and remains documented as such.
 - **Two turns fired concurrently on one conversation would interleave.**
   The UI prevents it by disabling the composer while streaming; the server
   does not. A `running` state plus a check-and-set would fix it and costs a


### PR DESCRIPTION
## Summary

- `start_menu_scan` lets a model steer which URL gets fetched, which is what made this worth reviewing. Most of the guard held up — every redirect hop re-validates, no follow-redirects middleware, IPv4 blocklist is thorough.
- **One complete bypass:** `IPAddr.new("::ffff:169.254.169.254").ipv4?` is **false** in Ruby, so IPv4-mapped addresses were checked against the IPv6 list — which had no mapped range — and reached cloud metadata through every guard. Loopback and RFC1918 were reachable the same way.
- Mapped addresses normalize via `IPAddr#native` before the check; `::` and the NAT64 prefix `64:ff9b::/96` added. The spec was **confirmed to fail without the fix** — a security test that can't fail is worse than none.
- Also corrected a comment that overclaimed the 10 MB cap: it ran after the body was buffered. `Content-Length` is now rejected before reading when declared.
