### PR TITLE
feat(api): sweep uploads that were never scanned

### DIFF
--- a/apps/api/app/jobs/purge_unscanned_attachments_job.rb
+++ b/apps/api/app/jobs/purge_unscanned_attachments_job.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Uploads that were never scanned.
+#
+# `POST /api/v1/attachments` writes a blob and hands back a signed id so
+# the bytes never enter the agent's context. If the person then closes the
+# tab — or the model never calls `start_menu_scan` — that blob is attached
+# to nothing and stays in storage forever. Nothing else in the app deletes
+# it, because nothing else knows it exists.
+#
+# `unattached` is a safe signal here rather than a guess, and it is worth
+# writing down why, because the failure mode is deleting someone's menu
+# photo. Two facts, both checkable:
+#
+#   * A scanned upload becomes attached — `IngestionRun has_many_attached
+#     :inputs`, written by `run.inputs.attach`.
+#   * `AttachmentsController` is the **only** place in the app that creates
+#     a detached blob. Everything else goes through `attach(io:)`, which
+#     creates the blob already attached.
+#
+# So an unattached blob past the grace window can only be a chat upload
+# nobody ever scanned.
+#
+# The age floor is the whole safety story. An upload that is seconds old
+# is almost certainly mid-flight — the person is still typing the message
+# that will reference it — so a day of grace separates "abandoned" from
+# "in progress" without needing to track intent.
+class PurgeUnscannedAttachmentsJob < ApplicationJob
+  queue_as :default
+
+  GRACE_HOURS_DEFAULT = 24
+  # Bounds the enqueue burst. A backlog drains over successive runs rather
+  # than flooding the queue in one go.
+  MAX_PER_RUN = 500
+
+  def perform
+    cutoff = grace_hours.hours.ago
+    purged = 0
+
+    ActiveStorage::Blob.unattached
+                       .where(created_at: ...cutoff)
+                       .order(:created_at)
+                       .limit(MAX_PER_RUN)
+                       .find_each do |blob|
+      # purge_later so a slow storage backend cannot stall the sweep; the
+      # row and the file both go.
+      blob.purge_later
+      purged += 1
+    end
+
+    Rails.logger.info("[retention] purged #{purged} unscanned attachments") if purged.positive?
+    purged
+  end
+
+  private
+
+  def grace_hours
+    Integer(ENV.fetch("ATTACHMENT_PURGE_GRACE_HOURS", GRACE_HOURS_DEFAULT))
+  end
+end

--- a/apps/api/config/recurring.yml
+++ b/apps/api/config/recurring.yml
@@ -10,6 +10,13 @@ production:
     class: PurgeOrphanedRestaurantVisitsJob
     queue: default
     schedule: "every day at 4am"
+  # Uploads that were never scanned. Nothing else deletes them, because
+  # nothing else knows they exist — see the job for why `unattached` is a
+  # safe signal rather than a guess.
+  purge_unscanned_attachments:
+    class: PurgeUnscannedAttachmentsJob
+    queue: default
+    schedule: "every day at 4:20am"
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12

--- a/apps/api/spec/jobs/purge_unscanned_attachments_job_spec.rb
+++ b/apps/api/spec/jobs/purge_unscanned_attachments_job_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+# An upload that was never scanned is invisible to everything else in the
+# app — no record references it, so nothing else would ever delete it.
+#
+# The dangerous direction here is deleting too much: these are people's
+# menu photos, and a blob attached to a real scan must never be swept.
+RSpec.describe PurgeUnscannedAttachmentsJob do
+  # The job enqueues purges rather than performing them, so a slow storage
+  # backend cannot stall the sweep. Draining them here is what makes these
+  # assert on the blob actually being gone.
+  include ActiveJob::TestHelper
+
+  def blob(created_at:, filename: "menu.jpg")
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("bytes"), filename: filename, content_type: "image/jpeg"
+    ).tap { |b| b.update_column(:created_at, created_at) }
+  end
+
+  it "purges an upload nobody ever scanned" do
+    orphan = blob(created_at: 3.days.ago)
+
+    expect { perform_enqueued_jobs { described_class.perform_now } }
+      .to change { ActiveStorage::Blob.exists?(orphan.id) }.from(true).to(false)
+  end
+
+  # The age floor is the whole safety story: an upload seconds old is
+  # almost certainly mid-flight, with the person still typing the message
+  # that will reference it.
+  it "leaves a fresh upload alone" do
+    fresh = blob(created_at: 5.minutes.ago)
+
+    perform_enqueued_jobs { described_class.perform_now }
+
+    expect(ActiveStorage::Blob.exists?(fresh.id)).to be(true)
+  end
+
+  # The one that matters. A scanned upload is attached to its run, and
+  # sweeping it would destroy the input of a real menu scan.
+  it "never touches a blob attached to a scan, however old" do
+    run      = create(:ingestion_run)
+    attached = blob(created_at: 1.year.ago)
+    run.inputs.attach(attached)
+
+    perform_enqueued_jobs { described_class.perform_now }
+
+    expect(ActiveStorage::Blob.exists?(attached.id)).to be(true)
+  end
+
+  # A backlog drains over successive runs rather than flooding the queue.
+  it "bounds how many it enqueues in one pass" do
+    stub_const("#{described_class}::MAX_PER_RUN", 2)
+    3.times { blob(created_at: 3.days.ago) }
+
+    expect(described_class.perform_now).to eq(2)
+  end
+
+  it "reports nothing to do without raising" do
+    expect(described_class.perform_now).to eq(0)
+  end
+end

--- a/docs/plans/mcp-pivot.md
+++ b/docs/plans/mcp-pivot.md
@@ -313,7 +313,10 @@ Self-contained; nothing above depends on it.
   The UI prevents it by disabling the composer while streaming; the server
   does not. A `running` state plus a check-and-set would fix it and costs a
   migration — worth it once more than one client drives a conversation.
-- **Uploaded blobs are never swept.** An attachment that is uploaded and
-  never scanned stays in storage forever. Bounded today by the per-user
-  scan quota and rack-attack, but a periodic purge of unattached blobs
-  older than a day is the real answer.
+- ~~**Uploaded blobs are never swept.**~~ **Done.**
+  `PurgeUnscannedAttachmentsJob` runs daily and purges unattached blobs
+  past a 24h grace window. `unattached` is a safe signal because
+  `AttachmentsController` is the only place in the app that creates a
+  detached blob, and a scanned upload becomes attached to its
+  `IngestionRun` — so an old unattached blob can only be an abandoned
+  chat upload.


### PR DESCRIPTION
## Summary

- An upload that was never scanned was attached to nothing and stayed in storage forever — invisible to the rest of the app, because nothing else knew it existed. Closes the last open question from the MCP pivot plan.
- The work was establishing that deleting is *safe*, since the failure mode is destroying someone's menu photo. Two checkable facts, both written into the job: a scanned upload **becomes attached** (`run.inputs.attach`), and `AttachmentsController` is the **only** place in the app that creates a detached blob. So an old unattached blob can only be an abandoned chat upload.
- 24h grace separates "abandoned" from "mid-flight". Purges are enqueued (a slow storage backend can't stall the sweep) and capped per run (a backlog drains over days).
