### PR TITLE
feat: resume a turn that outlives one connection

### DIFF
--- a/apps/api/app/controllers/api/v1/conversation_turns_controller.rb
+++ b/apps/api/app/controllers/api/v1/conversation_turns_controller.rb
@@ -18,9 +18,11 @@ module Api
       include ActionController::Live
 
       MAX_MESSAGE_CHARS = 20_000
-      # How long a reader waits on a quiet conversation before we close and
-      # let it reconnect. Long enough not to churn, short enough that a
-      # half-dead connection is noticed.
+      # How long one connection lasts before we close it and hand the
+      # client a cursor to resume from. A thread is held for the length of
+      # a turn, not the length of a session — the client opens a stream
+      # only while a turn is in flight — so this bounds how long a single
+      # thread can be held by one reader, not how long a turn may run.
       STREAM_SECONDS    = 300
       POLL_SECONDS      = 0.2
       # A silent minute reads as a hang to every proxy in the path.
@@ -91,7 +93,7 @@ module Api
           # A terminal event ends the turn. Stay open only if something is
           # still queued behind it, so a finished conversation does not
           # hold a connection for five minutes.
-          break if events.any? { |e| terminal?(e) } && !more_coming?
+          return if events.any? { |e| terminal?(e) } && !more_coming?
 
           if events.empty?
             if Time.current - last_beat >= KEEPALIVE_SECONDS
@@ -103,6 +105,13 @@ module Api
             last_beat = Time.current
           end
         end
+
+        # Fell out on the deadline with the turn still going. A menu scan
+        # legitimately outlives one connection, and without this the client
+        # cannot tell "the turn ended" from "your connection did" — it
+        # would stop watching and redraw a half-finished turn as final.
+        # Handing back the cursor makes the next connection a resume.
+        write_event({ type: "reconnect", after: position }) if !@disconnected && more_coming?
       end
 
       def terminal?(event)

--- a/apps/api/spec/requests/api/v1/conversation_turns_spec.rb
+++ b/apps/api/spec/requests/api/v1/conversation_turns_spec.rb
@@ -275,4 +275,42 @@ RSpec.describe "Api::V1::ConversationTurns", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  # A menu scan legitimately outlives one connection. Without a cursor the
+  # client cannot tell "the turn ended" from "your connection did", and it
+  # would redraw a half-finished turn as final.
+  describe "a turn that outlives one connection" do
+    before do
+      script(say("Hello there."))
+      send_message("hi")
+      work
+    end
+
+    it "hands back a resume cursor instead of just closing" do
+      stub_const("Api::V1::ConversationTurnsController::STREAM_SECONDS", 0)
+      # Still queued, so the relay knows the turn is not over.
+      conversation.enqueue_turn!("kind" => "message", "text" => "and another")
+
+      get "/api/v1/conversations/#{conversation.id}/stream",
+          headers: headers.merge("Last-Event-ID" => "0")
+
+      last = response.body.split("\n\n").filter_map do |chunk|
+        data = chunk.lines.filter_map { |l| l.delete_prefix("data:").strip if l.start_with?("data:") }.join
+        JSON.parse(data) if data.present?
+      end.last
+
+      expect(last["type"]).to eq("reconnect")
+      expect(last["after"]).to be_present
+    end
+
+    # A finished conversation must close cleanly — a spurious reconnect
+    # would have the client reopen a stream forever.
+    it "does not ask for a reconnect once the turn is done" do
+      get "/api/v1/conversations/#{conversation.id}/stream",
+          headers: headers.merge("Last-Event-ID" => "0")
+
+      expect(response.body).not_to include('"type":"reconnect"')
+    end
+  end
 end
+

--- a/apps/web/src/app/chat/_ChatClient.tsx
+++ b/apps/web/src/app/chat/_ChatClient.tsx
@@ -27,6 +27,9 @@ import { Transcript, type LiveTurn } from './_Transcript';
 
 const EMPTY_TURN: LiveTurn = { thinking: '', text: '', tools: [] };
 
+/** Enough hops for a very long scan; a bound, not an expectation. */
+const MAX_RECONNECTS = 20;
+
 export function ChatClient(): ReactElement {
   const router = useRouter();
   const tracker = useTracker();
@@ -144,12 +147,22 @@ export function ChatClient(): ReactElement {
     let outcome = 'error';
     try {
       const { after } = await ask();
-      await watchTurn(id, after, (event) => {
-        if (event.type === 'tool_use') tools += 1;
-        if (event.type === 'done') outcome = 'done';
-        if (event.type === 'awaiting_confirmation') outcome = 'awaiting_confirmation';
-        consume(event);
-      });
+      // A turn can outlive one connection — a menu scan legitimately runs
+      // past the server's window. Each hop resumes from the position the
+      // server handed back, so the narration is continuous on screen and
+      // the reconnect is invisible. Capped so a server stuck asking for
+      // reconnects cannot spin the client forever.
+      let cursor = after;
+      for (let hop = 0; hop < MAX_RECONNECTS; hop += 1) {
+        const resume = await watchTurn(id, cursor, (event) => {
+          if (event.type === 'tool_use') tools += 1;
+          if (event.type === 'done') outcome = 'done';
+          if (event.type === 'awaiting_confirmation') outcome = 'awaiting_confirmation';
+          consume(event);
+        });
+        if (resume === null) break;
+        cursor = resume;
+      }
     } catch (e) {
       onFailure(e);
     } finally {

--- a/apps/web/src/app/chat/__tests__/ChatClient.test.tsx
+++ b/apps/web/src/app/chat/__tests__/ChatClient.test.tsx
@@ -71,7 +71,7 @@ beforeEach(() => {
   // separately, so tests drive the two halves independently.
   sendMessage.mockResolvedValue({ queued: true, after: 0 });
   answerConfirmation.mockResolvedValue({ queued: true, after: 0 });
-  watchTurn.mockResolvedValue(undefined);
+  watchTurn.mockResolvedValue(null);
   stopTurn.mockResolvedValue(undefined);
 });
 
@@ -275,6 +275,29 @@ describe('ChatClient', () => {
       await screen.findByText('ok');
       expect(screen.queryByTestId('usage-pills')).not.toBeInTheDocument();
     });
+  });
+
+  // A menu scan legitimately outlives one connection. The reconnect has to
+  // be invisible: the narration continues on screen and the turn is not
+  // treated as finished.
+  it('resumes from the cursor when a turn outlives one connection', async () => {
+    watchTurn
+      .mockImplementationOnce(async (_id: string, _after: number, onEvent: (e: ChatEvent) => void) => {
+        onEvent({ type: 'text_delta', text: 'Reading ' });
+        return 7; // server closed mid-turn, resume from position 7
+      })
+      .mockImplementationOnce(async (_id: string, after: number, onEvent: (e: ChatEvent) => void) => {
+        expect(after).toBe(7);
+        onEvent({ type: 'done', text: 'Reading the menu.' });
+        return null;
+      });
+    getConversation.mockResolvedValue(answered('Reading the menu.'));
+
+    render(<ChatClient />);
+    await type('scan this');
+
+    await waitFor(() => expect(watchTurn).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Reading the menu.')).toBeInTheDocument();
   });
 
   it('shows an error event without losing the conversation', async () => {

--- a/apps/web/src/lib/__tests__/chat.test.ts
+++ b/apps/web/src/lib/__tests__/chat.test.ts
@@ -151,4 +151,26 @@ describe('chat client', () => {
     // Setting Content-Type by hand would drop the multipart boundary.
     expect(init.headers).toBeUndefined();
   });
+
+  // The reconnect event is transport bookkeeping — the transcript should
+  // never see it, and the caller learns about it as a return value.
+  it('swallows the reconnect event and returns the cursor', async () => {
+    vi.stubGlobal(
+      'fetch',
+      sseFetch([frame({ type: 'text_delta', text: 'hi' }), frame({ type: 'reconnect', after: 12 })]),
+    );
+
+    const seen: ChatEvent[] = [];
+    const resume = await watchTurn('c-1', 0, (e) => seen.push(e));
+
+    expect(resume).toBe(12);
+    expect(seen.map((e) => e.type)).toEqual(['text_delta']);
+  });
+
+  it('returns null when the turn genuinely ended', async () => {
+    vi.stubGlobal('fetch', sseFetch([frame({ type: 'done', text: 'ok' })]));
+
+    expect(await watchTurn('c-1', 0, () => {})).toBeNull();
+  });
 });
+

--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -79,6 +79,7 @@ export type ChatEvent =
   | { type: 'done'; text: string | null }
   | { type: 'stopped'; message: string }
   | { type: 'awaiting_confirmation'; tool: PendingTool }
+  | { type: 'reconnect'; after: number }
   | { type: 'error'; message: string };
 
 /** Thrown when the session cookie is missing or stale, so callers can
@@ -196,18 +197,32 @@ export async function stopTurn(id: string): Promise<void> {
  *
  *  Because the events are stored rather than only sent, calling this again
  *  with the last position seen resumes where the previous reader stopped —
- *  a dropped connection costs nothing but the reconnect. */
-export function watchTurn(
+ *  a dropped connection costs nothing but the reconnect.
+ *
+ *  Resolves with a position when the server closed the connection while
+ *  the turn was still running (a menu scan can outlive one connection),
+ *  and with `null` when the turn is genuinely over. The `reconnect` event
+ *  is swallowed here rather than passed on: it is transport bookkeeping,
+ *  and nothing rendering the transcript should have to know about it. */
+export async function watchTurn(
   id: string,
   after: number,
   onEvent: (event: ChatEvent) => void,
   signal?: AbortSignal,
-): Promise<void> {
-  return stream(
+): Promise<number | null> {
+  let resume: number | null = null;
+  await stream(
     `/api/chat/conversations/${encodeURIComponent(id)}/stream?after=${after}`,
-    onEvent,
+    (event) => {
+      if (event.type === 'reconnect') {
+        resume = event.after;
+        return;
+      }
+      onEvent(event);
+    },
     signal,
   );
+  return resume;
 }
 
 async function stream(


### PR DESCRIPTION
## Summary

- The relay closed after `STREAM_SECONDS` with no signal, so a client couldn't tell "the turn ended" from "your connection did" — it stopped watching and redrew a half-finished turn as final. A menu scan legitimately runs past that window.
- The relay now writes `{type: "reconnect", after: N}` on the deadline and the client reopens from that cursor. Swallowed inside `watchTurn` and returned as a value — transport bookkeeping shouldn't reach the transcript. Hops are capped.
- **Also corrects an overstatement in my own C4 notes:** "five concurrent readers saturate the Puma pool" was wrong. The client opens a stream only *inside* a turn, so an idle tab holds no thread — the ceiling is five concurrent *in-flight turns*.
