### PR TITLE
feat(api): serve the topology's workflows as MCP prompts

### DIFF
--- a/apps/api/app/controllers/mcp_controller.rb
+++ b/apps/api/app/controllers/mcp_controller.rb
@@ -53,6 +53,10 @@ class McpController < ApplicationController
         # The tool map, so a client that reads resources can learn how the
         # tools compose without spending a turn on describe_capabilities.
         resources:      [Tools::TopologyResource],
+        # The same workflows as things a person can pick before typing —
+        # "Scan a menu into the database" beats a blank box and 44 tools.
+        # Generated from the topology, so they cannot drift from it.
+        prompts:        Tools::WorkflowPrompts.for(context),
         server_context: server_context
       ),
       stateless: true,

--- a/apps/api/app/services/tools/workflow_prompts.rb
+++ b/apps/api/app/services/tools/workflow_prompts.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Tools
+  # The topology's workflows, offered as MCP prompts.
+  #
+  # A Claude Desktop or Claude Code user sees prompts as things they can
+  # pick before typing anything — "Scan a menu into the database" is a
+  # better starting point than a blank box and forty-four tools. We already
+  # know those workflows: `Tools::Topology::WORKFLOWS` names each one, its
+  # tool sequence, and the single thing about it that surprises people.
+  #
+  # **Generated from that constant, never restated.** A prompt that drifts
+  # from the topology would be documentation that lies to a model at
+  # runtime — the exact failure the topology spec was written to prevent.
+  # Adding a workflow gets a prompt for free; editing one updates both.
+  #
+  # Audience-filtered like everything else: a workflow is offered only to a
+  # caller who can run every step, so `prompts/list` never suggests a route
+  # that dead-ends in `forbidden` — same rule `Registry.for` applies to
+  # tools and `Topology.for` applies to the map.
+  module WorkflowPrompts
+    class << self
+      def all
+        @all ||= Topology::WORKFLOWS.map { |workflow| build(workflow) }.freeze
+      end
+
+      def for(context)
+        allowed = context.admin? ? %i[public user admin] : (context.signed_in? ? %i[public user] : [:public])
+        all.select { |prompt| allowed.include?(prompt.workflow_audience) }
+      end
+
+      private
+
+      # Slugged from the name so the wire identifier is stable and readable
+      # — `scan_a_menu_into_the_database`, not an index.
+      def slug_for(name)
+        name.downcase.gsub(/[^a-z0-9]+/, "_").delete_prefix("_").delete_suffix("_")
+      end
+
+      def build(workflow)
+        flow = workflow
+        Class.new(MCP::Prompt) do
+          prompt_name slug_for_name = Tools::WorkflowPrompts.send(:slug_for, flow[:name])
+          title flow[:name]
+          description "#{flow[:note]} Tools, in order: #{flow[:steps].join(' → ')}."
+
+          define_singleton_method(:workflow_audience) { flow[:audience] }
+          define_singleton_method(:workflow_steps)    { flow[:steps] }
+          define_singleton_method(:slug)              { slug_for_name }
+
+          define_singleton_method(:template) do |_args, server_context: nil|
+            MCP::Prompt::Result.new(
+              description: flow[:name],
+              messages: [
+                MCP::Prompt::Message.new(
+                  role: "user",
+                  content: MCP::Content::Text.new(
+                    <<~TEXT.strip
+                      #{flow[:name]}.
+
+                      The tools for this, in the order they usually go: #{flow[:steps].join(' → ')}.
+
+                      #{flow[:note]}
+
+                      Ask me for anything you need before starting.
+                    TEXT
+                  )
+                )
+              ]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/api/spec/requests/mcp_spec.rb
+++ b/apps/api/spec/requests/mcp_spec.rb
@@ -125,4 +125,35 @@ RSpec.describe "POST /mcp", type: :request do
       expect(body.dig("result", "contents", 0, "text")).to include("moderate_review")
     end
   end
+
+  # A client sees prompts as things a person can pick before typing —
+  # "Scan a menu into the database" beats a blank box and forty-four tools.
+  describe "prompts/list" do
+    def prompts_for(headers)
+      post "/mcp",
+           params: { jsonrpc: "2.0", id: 1, method: "prompts/list", params: {} }.to_json,
+           headers: headers.merge("Content-Type" => "application/json")
+      JSON.parse(response.body, symbolize_names: true).dig(:result, :prompts) || []
+    end
+
+    it "offers the signed-in workflows to a signed-in caller" do
+      names = prompts_for(auth_headers_for(create(:user))).map { |p| p[:name] }
+
+      expect(names).to include("scan_a_menu_into_the_database")
+    end
+
+    # Same rule as tools/list: never mention what the caller cannot run.
+    it "never mentions an admin workflow to a non-admin" do
+      names = prompts_for(auth_headers_for(create(:user))).map { |p| p[:name] }
+
+      expect(names).not_to include("moderate")
+    end
+
+    it "offers an anonymous caller only what is public" do
+      names = prompts_for({}).map { |p| p[:name] }
+
+      expect(names).to eq(["find_something_this_person_can_eat"])
+    end
+  end
 end
+

--- a/apps/api/spec/services/tools/workflow_prompts_spec.rb
+++ b/apps/api/spec/services/tools/workflow_prompts_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+# The topology's workflows, offered as things a client can pick before
+# typing. Generated from `Topology::WORKFLOWS` rather than restated, so
+# these mostly guard the generation staying honest.
+RSpec.describe Tools::WorkflowPrompts do
+  let(:anonymous) { Tools::Context.new({}) }
+  let(:signed_in) { Tools::Context.new({ user_id: create(:user).id }) }
+  let(:admin)     { Tools::Context.new({ user_id: create(:user, is_admin: true).id }) }
+
+  it "offers one prompt per declared workflow" do
+    expect(described_class.all.length).to eq(Tools::Topology::WORKFLOWS.length)
+  end
+
+  it "gives every prompt a stable, readable wire name" do
+    names = described_class.all.map(&:name_value)
+
+    expect(names).to include("scan_a_menu_into_the_database")
+    expect(names.uniq.length).to eq(names.length)
+    expect(names).to all(match(/\A[a-z0-9_]+\z/))
+  end
+
+  # Same rule the registry and the topology map apply: a workflow is
+  # offered only to a caller who can run every step, so a client is never
+  # handed a route that dead-ends in `forbidden`.
+  describe "audience filtering" do
+    it "offers an anonymous caller only the public workflow" do
+      expect(described_class.for(anonymous).map(&:workflow_audience).uniq).to eq([:public])
+    end
+
+    it "adds the signed-in workflows once there is a user" do
+      audiences = described_class.for(signed_in).map(&:workflow_audience).uniq
+
+      expect(audiences).to contain_exactly(:public, :user)
+    end
+
+    it "gives an admin every workflow" do
+      expect(described_class.for(admin).length).to eq(Tools::Topology::WORKFLOWS.length)
+    end
+  end
+
+  # The failure this guards is a prompt that tells a model to call a tool
+  # that does not exist — documentation lying at runtime, which is exactly
+  # what the topology spec was written to prevent.
+  it "names only tools that are actually registered" do
+    known = Tools::Registry.all.map(&:name_value)
+
+    described_class.all.each do |prompt|
+      expect(prompt.workflow_steps - known).to be_empty, "#{prompt.name_value} names unknown tools"
+    end
+  end
+
+  it "renders a message carrying the workflow's sequence and its caveat" do
+    prompt = described_class.all.find { |p| p.name_value == "scan_a_menu_into_the_database" }
+
+    text = prompt.template({}).messages.first.content.to_h[:text]
+
+    expect(text).to include("start_menu_scan")
+    expect(text).to include("accept_staged_items is the ONLY step that publishes")
+  end
+end

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -131,6 +131,22 @@ Notes that bite:
   and `start_menu_scan` returns a scan id for the caller to poll. A tool
   that blocks for a minute times out real clients.
 
+## Workflow prompts
+
+The same workflows are offered over MCP as **prompts** — things a person
+picks in Claude Desktop before typing anything. "Scan a menu into the
+database" is a better starting point than a blank box and forty-four
+tools.
+
+`Tools::WorkflowPrompts` **generates** them from `Topology::WORKFLOWS`;
+nothing is restated. A prompt that drifted from the topology would be
+documentation lying to a model at runtime, which is the failure the
+topology spec exists to prevent. Adding a workflow gets a prompt for free.
+
+Audience-filtered like everything else: a workflow is offered only to a
+caller who can run every step, so `prompts/list` never suggests a route
+that dead-ends in `forbidden`.
+
 ## The topology
 
 Forty-four tool descriptions say what each call means in isolation. They do

--- a/docs/plans/mcp-pivot.md
+++ b/docs/plans/mcp-pivot.md
@@ -279,6 +279,14 @@ Refactor the discovery + profile controllers into thin adapters over the same
 tool classes. Re-run `bin/openapi-export` and the api-types codegen **in the
 same PR** — `ci-js.yml` fails on drift.
 
+### M-prompts — workflow prompts — SHIPPED
+
+`prompts/list` and `prompts/get` over the same ten workflows the topology
+already declares, generated from `Topology::WORKFLOWS` rather than
+restated, audience-filtered like tools and the map. Closes the last
+capability gap in the MCP surface short of OAuth: the server now serves
+tools, resources, and prompts.
+
 ### M8 — Public MCP (OAuth 2.1)
 
 Self-contained; nothing above depends on it.


### PR DESCRIPTION
## Summary

- The MCP server served tools and resources but not **prompts** — the thing a Claude Desktop user picks *before* typing. "Scan a menu into the database" beats a blank box and forty-four tools.
- `Tools::WorkflowPrompts` **generates** them from `Topology::WORKFLOWS` rather than restating them. A prompt that drifted from the topology would be documentation lying to a model at runtime — the exact failure the topology spec exists to prevent. Adding a workflow gets a prompt for free.
- Audience-filtered by the same rule as tools and the map: offered only to a caller who can run **every** step, so `prompts/list` never suggests a route that dead-ends in `forbidden`. A spec asserts every step names a tool that actually exists.
