### PR TITLE
feat: serve chat narration as JSON, and add the mobile chat client

### DIFF
--- a/apps/api/app/controllers/api/v1/conversations_controller.rb
+++ b/apps/api/app/controllers/api/v1/conversations_controller.rb
@@ -7,6 +7,8 @@ module Api
     # action in a controller, which would break these plain JSON reads.
     class ConversationsController < BaseController
       MAX_LIMIT = 50
+      # One turn's narration is tens of rows, not thousands.
+      BATCH     = 200
 
       def index
         conversations = current_user.conversations
@@ -36,6 +38,28 @@ module Api
         head :no_content
       end
 
+      # The narration as plain JSON, for clients that cannot hold an SSE
+      # stream open.
+      #
+      # React Native's fetch is XHR-backed and does not expose a readable
+      # response body, so the mobile app cannot consume `/stream` without
+      # pulling in an EventSource polyfill. The events are rows either way
+      # — the SSE relay is just a long-lived reader over this same table —
+      # so handing them back as JSON costs nothing and makes the narration
+      # consumable by any client at all.
+      #
+      # `after` is the same cursor the stream uses, so a client can switch
+      # between the two without losing its place.
+      def events
+        rows = conversation.events.after(params[:after]).in_order.limit(BATCH)
+        render json: {
+          events: rows.map { |e| e.payload.merge("position" => e.position) },
+          # Whether it is worth asking again. Saves a client polling a
+          # finished conversation forever.
+          running: running?
+        }
+      end
+
       # The stop button. Raises a flag the running turn reads at its next
       # lifecycle checkpoint; it does not kill anything itself.
       #
@@ -51,6 +75,11 @@ module Api
       end
 
       private
+
+      def running?
+        conversation.pending_turns? ||
+          ConversationRun.running.exists?(conversation_id: conversation.id)
+      end
 
       def conversation
         @conversation ||= current_user.conversations.find(params[:id])

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -124,6 +124,9 @@ Rails.application.routes.draw do
           # it has to be a separate request from the one it stops, which
           # is the whole point.
           delete :run, to: "conversations#stop"
+          # The narration as JSON, for clients that cannot hold a stream
+          # open (React Native's fetch has no readable body).
+          get    :events, to: "conversations#events"
         end
       end
       # Menu photos/PDFs the chat refers to by id, so bytes never enter

--- a/apps/api/spec/requests/api/v1/conversations_spec.rb
+++ b/apps/api/spec/requests/api/v1/conversations_spec.rb
@@ -187,5 +187,61 @@ RSpec.describe "Api::V1::Conversations", type: :request do
       expect(response.parsed_body["usage"]["last_run"]).to be_nil
     end
   end
+
+  # React Native's fetch is XHR-backed and exposes no readable body, so the
+  # mobile app cannot consume the SSE stream. The events are rows either
+  # way — the relay is just a long-lived reader over this same table.
+  describe "GET /api/v1/conversations/:id/events" do
+    let(:conversation) { create(:conversation, user: user) }
+
+    def append(payload)
+      run = ConversationRun.running.find_by(conversation_id: conversation.id) ||
+            ConversationRun.acquire(conversation)
+      ConversationEvent.append!(run, payload)
+    end
+
+    it "returns the narration with the cursor a client resumes from" do
+      append({ "type" => "text_delta", "text" => "Reading" })
+      append({ "type" => "done", "text" => "Reading the menu." })
+
+      get "/api/v1/conversations/#{conversation.id}/events", headers: headers
+
+      events = response.parsed_body["events"]
+      expect(events.map { |e| e["type"] }).to eq(%w[text_delta done])
+      expect(events.last["position"]).to eq(2)
+    end
+
+    # The same cursor the stream uses, so a client can move between the
+    # two without losing its place.
+    it "returns only what comes after the cursor" do
+      append({ "type" => "text_delta", "text" => "one" })
+      append({ "type" => "text_delta", "text" => "two" })
+
+      get "/api/v1/conversations/#{conversation.id}/events?after=1", headers: headers
+
+      expect(response.parsed_body["events"].map { |e| e["text"] }).to eq(["two"])
+    end
+
+    # Saves a client polling a finished conversation forever.
+    it "says whether it is worth asking again" do
+      ConversationRun.acquire(conversation)
+
+      get "/api/v1/conversations/#{conversation.id}/events", headers: headers
+      expect(response.parsed_body["running"]).to be(true)
+
+      ConversationRun.running.find_by(conversation_id: conversation.id).release!(outcome: "done")
+
+      get "/api/v1/conversations/#{conversation.id}/events", headers: headers
+      expect(response.parsed_body["running"]).to be(false)
+    end
+
+    it "404s another account's conversation" do
+      other = create(:conversation, user: create(:user))
+
+      get "/api/v1/conversations/#{other.id}/events", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end
 

--- a/apps/mobile/__tests__/lib/chat.test.ts
+++ b/apps/mobile/__tests__/lib/chat.test.ts
@@ -1,0 +1,98 @@
+import {
+  ChatError,
+  answerConfirmation,
+  compose,
+  fetchEvents,
+  sendMessage,
+  stopTurn,
+  type Attachment,
+} from '../../lib/api/chat';
+
+function jsonResponse(status: number, body: unknown) {
+  return jest.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe('chat api', () => {
+  // The turn runs in a job, so asking for one returns as soon as it is
+  // recorded rather than waiting out a model.
+  it('asks for a turn and gets back the cursor to watch from', async () => {
+    const fetchImpl = jsonResponse(202, { queued: true, after: 7 });
+
+    const queued = await sendMessage('jwt', 'c-1', 'hi', { fetchImpl });
+
+    expect(queued.after).toBe(7);
+    expect((fetchImpl as jest.Mock).mock.calls[0][0]).toContain('/api/v1/conversations/c-1/messages');
+  });
+
+  // Mobile polls where web streams: React Native's fetch exposes no
+  // readable body, so SSE is not consumable without a polyfill. The rows
+  // are the same either way.
+  it('reads the narration after a cursor and says whether to ask again', async () => {
+    const fetchImpl = jsonResponse(200, {
+      events: [{ type: 'text_delta', text: 'Reading', position: 3 }],
+      running: true,
+    });
+
+    const page = await fetchEvents('jwt', 'c-1', 2, { fetchImpl });
+
+    expect(page.events[0]?.position).toBe(3);
+    expect(page.running).toBe(true);
+    expect((fetchImpl as jest.Mock).mock.calls[0][0]).toContain('after=2');
+  });
+
+  // The fingerprint binds the answer to the call that was drawn, so a
+  // stale screen cannot approve a different one.
+  it('sends the confirmation bound to the parked call', async () => {
+    const fetchImpl = jsonResponse(202, { queued: true, after: 1 });
+
+    await answerConfirmation('jwt', 'c-1', false, 'fp-abc', { fetchImpl });
+
+    const init = (fetchImpl as jest.Mock).mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({ confirm: false, fingerprint: 'fp-abc' });
+  });
+
+  // A turn that already finished is not an error worth showing anyone.
+  it('treats a 409 from stop as already finished', async () => {
+    const fetchImpl = jsonResponse(409, { error: 'Nothing is running.' });
+
+    await expect(stopTurn('jwt', 'c-1', { fetchImpl })).resolves.toBeUndefined();
+  });
+
+  it('surfaces the server message on a real failure', async () => {
+    const fetchImpl = jsonResponse(422, { error: 'That message is too long.' });
+
+    await expect(sendMessage('jwt', 'c-1', 'x', { fetchImpl })).rejects.toThrow(
+      'That message is too long.',
+    );
+    await expect(sendMessage('jwt', 'c-1', 'x', { fetchImpl })).rejects.toBeInstanceOf(ChatError);
+  });
+
+  // Attachments travel as ids named in the message text, never as a side
+  // channel — the transcript stays honest about what was sent, and the
+  // model gets the id start_menu_scan needs.
+  describe('compose', () => {
+    const file: Attachment = {
+      id: 'signed-abc',
+      filename: 'menu.jpg',
+      content_type: 'image/jpeg',
+      byte_size: 10,
+    };
+
+    it('names each attachment and its id', () => {
+      expect(compose('read this', [file])).toContain('attachment_id: signed-abc');
+      expect(compose('read this', [file])).toContain('menu.jpg');
+    });
+
+    it('leaves a plain message alone', () => {
+      expect(compose('hello', [])).toBe('hello');
+    });
+
+    it('works when the photo is the whole message', () => {
+      expect(compose('', [file])).toBe('[Attached menu.jpg — attachment_id: signed-abc]');
+    });
+  });
+});

--- a/apps/mobile/lib/api/chat.ts
+++ b/apps/mobile/lib/api/chat.ts
@@ -1,0 +1,254 @@
+/**
+ * The chat, for mobile.
+ *
+ * Mirrors `apps/web/src/lib/chat.ts` in shape, with one deliberate
+ * difference: **mobile polls where web streams.** React Native's fetch is
+ * XHR-backed and exposes no readable response body, so an SSE connection
+ * cannot be consumed without an EventSource polyfill. The narration is
+ * rows in `conversation_events` either way — the web relay is just a
+ * long-lived reader over the same table — so `fetchEvents` reads them as
+ * JSON and the caller decides how often to ask.
+ *
+ * The cursor is the same one the stream uses, so switching transports
+ * loses nothing.
+ *
+ * Mobile talks to the API directly with the JWT from the keychain; there
+ * is no Next proxy here.
+ */
+import { API_BASE } from '../api-base';
+
+export interface ChatBlockText {
+  type: 'text';
+  text: string;
+}
+export interface ChatBlockThinking {
+  type: 'thinking';
+  text: string;
+}
+export interface ChatBlockToolUse {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+export interface ChatBlockToolResult {
+  type: 'tool_result';
+  tool_use_id: string;
+  ok: boolean;
+  text: string | null;
+}
+export type ChatBlock =
+  | ChatBlockText
+  | ChatBlockThinking
+  | ChatBlockToolUse
+  | ChatBlockToolResult;
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  position: number;
+  blocks: ChatBlock[];
+}
+
+/** The call the confirmation gate parked, and the token that binds an
+ *  answer to it. `prompt` is the sentence the tool itself declared. */
+export interface PendingTool {
+  name: string;
+  input: Record<string, unknown>;
+  prompt: string | null;
+  fingerprint: string | null;
+}
+
+export interface Conversation {
+  id: string;
+  title: string | null;
+  state: 'active' | 'awaiting_confirmation' | 'failed';
+  pending: PendingTool | null;
+  created_at: string;
+  updated_at: string;
+  messages?: ChatMessage[];
+}
+
+/** One line of narration, carrying the cursor to resume from. */
+export interface ChatEvent {
+  type: string;
+  position: number;
+  text?: string;
+  name?: string;
+  ok?: boolean;
+  /** The tool's own sentence — "Reading the menu at Nini's". */
+  doing?: string | null;
+  message?: string;
+  tool?: PendingTool;
+}
+
+export interface ChatEventsPage {
+  events: ChatEvent[];
+  /** Whether anything is still in flight. False means stop polling. */
+  running: boolean;
+}
+
+export interface Attachment {
+  id: string;
+  filename: string;
+  content_type: string;
+  byte_size: number;
+}
+
+export class ChatError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ChatError';
+  }
+}
+
+interface Options {
+  fetchImpl?: typeof fetch;
+}
+
+async function request<T>(
+  jwt: string,
+  path: string,
+  init: RequestInit = {},
+  { fetchImpl = fetch }: Options = {},
+): Promise<T> {
+  const res = await fetchImpl(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: 'application/json',
+      ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    let message = `Request failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      // Non-JSON error bodies fall through to the status line.
+    }
+    throw new ChatError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+export function listConversations(
+  jwt: string,
+  opts: Options = {},
+): Promise<{ conversations: Conversation[] }> {
+  return request(jwt, '/api/v1/conversations', {}, opts);
+}
+
+export function createConversation(jwt: string, opts: Options = {}): Promise<Conversation> {
+  return request(jwt, '/api/v1/conversations', { method: 'POST' }, opts);
+}
+
+export function getConversation(
+  jwt: string,
+  id: string,
+  opts: Options = {},
+): Promise<Conversation> {
+  return request(jwt, `/api/v1/conversations/${encodeURIComponent(id)}`, {}, opts);
+}
+
+/** Asks for a turn. Returns as soon as the request is recorded — the turn
+ *  runs in a job, so this does not wait out a model. */
+export function sendMessage(
+  jwt: string,
+  id: string,
+  message: string,
+  opts: Options = {},
+): Promise<{ queued: boolean; after: number }> {
+  return request(
+    jwt,
+    `/api/v1/conversations/${encodeURIComponent(id)}/messages`,
+    { method: 'POST', body: JSON.stringify({ message }) },
+    opts,
+  );
+}
+
+/** Answers the confirmation gate. The fingerprint binds the answer to the
+ *  call that was drawn, so a stale screen cannot approve a different one. */
+export function answerConfirmation(
+  jwt: string,
+  id: string,
+  confirm: boolean,
+  fingerprint: string | null,
+  opts: Options = {},
+): Promise<{ queued: boolean; after: number }> {
+  return request(
+    jwt,
+    `/api/v1/conversations/${encodeURIComponent(id)}/confirm`,
+    { method: 'POST', body: JSON.stringify({ confirm, fingerprint }) },
+    opts,
+  );
+}
+
+/** The narration after `after`. Poll this while `running` is true. */
+export function fetchEvents(
+  jwt: string,
+  id: string,
+  after: number,
+  opts: Options = {},
+): Promise<ChatEventsPage> {
+  return request(
+    jwt,
+    `/api/v1/conversations/${encodeURIComponent(id)}/events?after=${after}`,
+    {},
+    opts,
+  );
+}
+
+/** Stop. Raises a flag the running turn reads at its next checkpoint. */
+export async function stopTurn(
+  jwt: string,
+  id: string,
+  { fetchImpl = fetch }: Options = {},
+): Promise<void> {
+  const res = await fetchImpl(`${API_BASE}/api/v1/conversations/${encodeURIComponent(id)}/run`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  // 409 just means it already finished — not worth surfacing.
+  if (!res.ok && res.status !== 409) throw new ChatError(res.status, 'Could not stop that turn.');
+}
+
+/** Uploads a menu photo and returns its id. Bytes never reach the agent —
+ *  the id does, and `start_menu_scan` resolves it server-side. */
+export async function uploadAttachment(
+  jwt: string,
+  file: { uri: string; name: string; type: string },
+  { fetchImpl = fetch }: Options = {},
+): Promise<Attachment> {
+  const form = new FormData();
+  // React Native's FormData takes this shape for a file; it is not a Blob.
+  form.append('file', file as unknown as Blob);
+
+  const res = await fetchImpl(`${API_BASE}/api/v1/attachments`, {
+    method: 'POST',
+    // No Content-Type — the runtime sets the multipart boundary.
+    headers: { Authorization: `Bearer ${jwt}`, Accept: 'application/json' },
+    body: form,
+  });
+  if (!res.ok) throw new ChatError(res.status, 'That file could not be uploaded.');
+  return (await res.json()) as Attachment;
+}
+
+/**
+ * Names an attachment in the message text rather than sending it as a side
+ * channel — same contract as web. Keeps the transcript honest about what
+ * was sent, and gives the model the id `start_menu_scan` needs.
+ */
+export function compose(text: string, attachments: Attachment[]): string {
+  if (attachments.length === 0) return text;
+  const manifest = attachments
+    .map((file) => `[Attached ${file.filename} — attachment_id: ${file.id}]`)
+    .join('\n');
+  return [text, manifest].filter(Boolean).join('\n\n');
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -279,6 +279,14 @@ reconstructed rather than replayed.
 
 ### The HTTP surface
 
+**Two transports over the same rows.** `GET /conversations/:id/stream` is
+SSE for clients that can hold a connection open; `GET
+/conversations/:id/events?after=N` returns the same narration as JSON for
+clients that cannot. React Native's fetch is XHR-backed and exposes no
+readable body, so the mobile app polls. Both read `conversation_events`
+and share one cursor, so a client can switch between them without losing
+its place.
+
 **A turn runs in a job, not in the request.** `POST /messages` and
 `/confirm` record the ask into `conversations.pending_turns` and enqueue
 `Chat::CompletionJob`, answering `202` with the narration position to watch

--- a/docs/plans/mcp-pivot.md
+++ b/docs/plans/mcp-pivot.md
@@ -242,9 +242,11 @@ tool-call cards and collapsed thinking, attachment upload, confirmation
 prompts. Entry points restored: hero CTA (`Scan a menu → /chat`), site
 header, restaurants empty state.
 
-**Mobile is not restored.** The Expo app can't speak the chat yet and its
-old screens called REST endpoints M2 deleted. Mobile chat is its own
-phase; it stays without a scan path until then.
+**Mobile chat is in progress.** The API half is done: `lib/api/chat.ts`
+mirrors the web client, and `GET /conversations/:id/events` serves the
+narration as JSON because React Native's fetch exposes no readable body
+and cannot consume SSE. The screen itself is still to build — until then
+the Expo app has no scan path and MCP covers scanning.
 
 Two decisions worth keeping:
 - **After every turn the client refetches the conversation** rather than


### PR DESCRIPTION
## Summary

- **React Native's fetch is XHR-backed and exposes no readable response body**, so the SSE relay the web client uses isn't consumable on mobile without an EventSource polyfill. Rather than add a dependency to paper over that, `GET /conversations/:id/events?after=N` returns the same narration as JSON.
- Close to free, because C4 already made the events *rows* — the SSE relay is just a long-lived reader over `conversation_events`. Both transports share one cursor, so a client can switch without losing its place. It also generalises: any client that can't hold a connection open can now read a turn, and the response says whether to keep asking.
- `apps/mobile/lib/api/chat.ts` mirrors the web client — turns, the confirmation gate with its fingerprint binding, stop, attachment upload, and the same `compose` contract. **The screen is next**; the Expo app still has no scan path until then.
