### PR TITLE
feat(api): least-privilege scoped tokens for MCP clients

### DIFF
--- a/apps/api/app/controllers/mcp_controller.rb
+++ b/apps/api/app/controllers/mcp_controller.rb
@@ -29,8 +29,9 @@ class McpController < ApplicationController
   SERVER_VERSION = "1.0.0"
 
   def handle
-    context = Tools::Context.new(server_context)
     return unauthorized if authorization_failed?
+
+    context = Tools::Context.new(server_context)
 
     status, headers, body = transport_for(context).handle_request(request)
 
@@ -76,17 +77,43 @@ class McpController < ApplicationController
   # tools can read it with `[]` / `dig`.
   def server_context
     @server_context ||= {
-      user_id:     current_user&.id,
+      user_id:     caller_user&.id,
       public_host: public_host,
-      request_id:  request.request_id
+      request_id:  request.request_id,
+      # Empty for a plain JWT, which carries every power the account has.
+      # A scoped token narrows that, and the tool layer enforces it.
+      scopes:      mcp_token&.scopes || []
     }
+  end
+
+  # Two credentials reach this door. A `bw_mcp_` token is the least-
+  # privilege one — issued for a specific client, scoped, revocable on its
+  # own. Anything else is the Devise JWT the REST API already issues,
+  # which carries the whole account.
+  def caller_user
+    return @caller_user if defined?(@caller_user)
+
+    @caller_user = mcp_token&.user || current_user
+  end
+
+  def mcp_token
+    return @mcp_token if defined?(@mcp_token)
+
+    @mcp_token = McpToken.authenticate(bearer_secret)
+    @mcp_token&.note_use!
+    @mcp_token
+  end
+
+  def bearer_secret
+    request.authorization.to_s[/\ABearer (.+)\z/i, 1]
   end
 
   # Devise's `current_user` returns nil rather than raising when the token
   # is missing or bad, so "was a token offered?" and "did it work?" have to
-  # be asked separately.
+  # be asked separately. A `bw_mcp_` secret that resolves is also a pass —
+  # it is a different credential, not a malformed JWT.
   def authorization_failed?
-    request.authorization.present? && current_user.nil?
+    request.authorization.present? && caller_user.nil?
   end
 
   def unauthorized

--- a/apps/api/app/models/mcp_token.rb
+++ b/apps/api/app/models/mcp_token.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# A least-privilege credential for an MCP client.
+#
+# Connecting Claude Code today means handing it the same JWT the web app
+# uses, which carries everything the account can do — for an admin, that
+# is the taxonomy, the moderation queue, and every user's role. This is
+# the alternative: a credential that names what it may touch, can be
+# listed, and can be revoked without ending every other session.
+#
+# **The secret is shown once and never stored.** Only its SHA-256 lives
+# here, so a leaked database is not a leaked set of working credentials.
+# That is also why there is no "show me the token again" — there is
+# nothing to show.
+class McpToken < ApplicationRecord
+  # Long enough that guessing is not a strategy, prefixed so a leaked one
+  # is recognizable in a log or a paste and can be traced to this system.
+  PREFIX     = "bw_mcp_"
+  BYTES      = 32
+  MAX_ACTIVE = 20
+
+  belongs_to :user
+
+  validates :name, presence: true, length: { maximum: 60 }
+  validate  :scopes_are_known
+
+  scope :active, -> { where(revoked_at: nil).where("expires_at IS NULL OR expires_at > ?", Time.current) }
+
+  # Returns the record and the one-time secret together, because this is
+  # the only moment the secret exists.
+  def self.issue!(user:, name:, scopes: [], expires_at: nil)
+    secret = "#{PREFIX}#{SecureRandom.urlsafe_base64(BYTES)}"
+    token  = create!(
+      user: user, name: name, scopes: Array(scopes).map(&:to_s).uniq,
+      expires_at: expires_at, token_digest: digest(secret)
+    )
+    [token, secret]
+  end
+
+  # Constant-time lookup is not available here — the digest is the index —
+  # but the digest of an attacker-supplied string reveals nothing about a
+  # stored one, so an index lookup is safe.
+  def self.authenticate(secret)
+    return nil if secret.blank? || !secret.start_with?(PREFIX)
+
+    active.find_by(token_digest: digest(secret))
+  end
+
+  def self.digest(secret) = Digest::SHA256.hexdigest(secret)
+
+  # Deliberately not `touch` on every call: a timestamp accurate to the
+  # minute answers "is this still in use?", and writing a row on every
+  # tool call would put a write in front of every read.
+  def note_use!
+    return if last_used_at.present? && last_used_at > 1.minute.ago
+
+    update_column(:last_used_at, Time.current)
+  end
+
+  def revoke! = update!(revoked_at: Time.current)
+  def revoked? = revoked_at.present?
+
+  private
+
+  def scopes_are_known
+    unknown = Array(scopes).reject { |scope| Tools::Scopes.valid?(scope) }
+    return if unknown.empty?
+
+    errors.add(:scopes, "unknown: #{unknown.join(', ')}")
+  end
+end

--- a/apps/api/app/services/tools/base.rb
+++ b/apps/api/app/services/tools/base.rb
@@ -127,6 +127,7 @@ module Tools
       def call(server_context: nil, **args)
         context = Context.new(server_context)
         enforce_audience!(context)
+        enforce_scope!(context)
         validate_arguments!(args)
         perform(context: context, **args)
       rescue Errors::Error => e
@@ -207,6 +208,18 @@ module Tools
         return :any if params.any? { |kind, _| kind == :keyrest }
 
         params.filter_map { |kind, key| key if [:key, :keyreq].include?(kind) } - [:context]
+      end
+
+      # Audience asks "may this person do it"; scope asks "may this
+      # credential". They are different questions and both have to pass —
+      # an admin using a read-only MCP token is still an admin, and the
+      # token still may not write.
+      def enforce_scope!(context)
+        required = Scopes.for_tool(self)
+        return if Scopes.satisfied?(context.scopes, required)
+
+        raise Errors::Forbidden,
+              "This credential is not allowed to do that. It would need the #{required} scope."
       end
 
       def enforce_audience!(context)

--- a/apps/api/app/services/tools/context.rb
+++ b/apps/api/app/services/tools/context.rb
@@ -6,13 +6,17 @@ module Tools
   # `public_host` rides along so tools can build signed ActiveStorage URLs
   # the same way Api::V1::BaseController does.
   class Context
-    attr_reader :public_host, :request_id
+    attr_reader :public_host, :request_id, :scopes
 
     def initialize(server_context = nil)
       raw          = server_context || {}
       @user_id     = raw[:user_id]
       @public_host = raw[:public_host]
       @request_id  = raw[:request_id]
+      # What this caller's credential is allowed to touch. Empty means
+      # unrestricted, which is what a session or a plain JWT is — the
+      # scope check only narrows, it never grants.
+      @scopes      = Array(raw[:scopes])
     end
 
     def user

--- a/apps/api/app/services/tools/scopes.rb
+++ b/apps/api/app/services/tools/scopes.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Tools
+  # What a token is allowed to do, in the vocabulary of tool domains.
+  #
+  # Connecting Claude Code or Claude Desktop today means handing it a
+  # token with everything your account can do — including, for an admin,
+  # the taxonomy and the moderation queue. That is a lot of authority to
+  # grant something whose job is usually "read menus for me", and there
+  # has been no way to grant less.
+  #
+  # Scopes are derived from `Registry::DOMAINS` rather than listed here,
+  # so a new domain cannot be added without a scope existing for it — the
+  # same reason `Topology` derives its map from the registry instead of
+  # restating it.
+  #
+  # `read` and `write` split on the tool's own `read_only_hint`, so the
+  # split follows the annotation a tool already carries rather than a
+  # second list that would drift.
+  module Scopes
+    # Granted when a token says nothing about scopes. Existing tokens —
+    # every one issued before this shipped — keep working exactly as they
+    # did, and a scope check on them is a no-op rather than a lockout.
+    ALL = "*"
+
+    class << self
+      # Every scope a caller could be granted, as strings.
+      def available
+        @available ||= Registry::DOMAINS.keys.flat_map { |domain| ["#{domain}:read", "#{domain}:write"] }.freeze
+      end
+
+      # The scope a given tool call requires, or nil for a class the
+      # registry does not know — an anonymous subclass in a spec, say.
+      # Returning nil there means "no scope gates this", which is the only
+      # safe answer: a tool nobody can reach through the registry is not
+      # something a scope can meaningfully protect.
+      def for_tool(tool)
+        return nil if tool.nil? || tool.name.blank?
+
+        domain = Registry.domain_of(tool)
+        return nil if domain.nil?
+
+        "#{domain}:#{tool.annotations_value&.read_only_hint ? 'read' : 'write'}"
+      end
+
+      # A grant covers a required scope when it matches exactly, when it
+      # is the wildcard, or when a write grant implies the read on the
+      # same domain — asking for permission to edit a menu and then being
+      # refused permission to look at one would be nonsense.
+      def satisfied?(granted, required)
+        return true if required.nil?
+
+        list = Array(granted)
+        return true if list.empty? || list.include?(ALL)
+        return true if list.include?(required)
+
+        domain, action = required.split(":")
+        action == "read" && list.include?("#{domain}:write")
+      end
+
+      def valid?(scope)
+        scope == ALL || available.include?(scope)
+      end
+    end
+  end
+end

--- a/apps/api/db/migrate/20260808190000_create_mcp_tokens.rb
+++ b/apps/api/db/migrate/20260808190000_create_mcp_tokens.rb
@@ -1,0 +1,33 @@
+class CreateMcpTokens < ActiveRecord::Migration[8.1]
+  def change
+    # A least-privilege credential for an MCP client.
+    #
+    # The alternative — and what everyone does today — is handing Claude
+    # Code the same JWT the web app uses, which carries everything the
+    # account can do. A token here names what it may touch.
+    create_table :mcp_tokens, id: :uuid do |t|
+      t.references :user, type: :uuid, null: false, foreign_key: true, index: true
+
+      # What the person called it, so a list of tokens is legible and a
+      # revocation is an informed decision rather than a guess.
+      t.string :name, null: false
+
+      # SHA-256 of the secret. The secret itself is shown once at
+      # creation and never stored — a leaked database must not be a
+      # leaked set of working credentials.
+      t.string :token_digest, null: false
+
+      # Domain-scoped grants (`discovery:read`, `profile:write`, …).
+      # Empty means unrestricted, which is what every pre-existing
+      # credential effectively was.
+      t.string :scopes, array: true, null: false, default: []
+
+      t.datetime :last_used_at
+      t.datetime :expires_at
+      t.datetime :revoked_at
+      t.timestamps
+    end
+
+    add_index :mcp_tokens, :token_digest, unique: true
+  end
+end

--- a/apps/api/db/schema.rb
+++ b/apps/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_08_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -117,7 +117,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["created_at"], name: "index_conversations_on_created_at"
     t.index ["user_id", "updated_at"], name: "index_conversations_on_user_id_and_updated_at"
     t.index ["user_id"], name: "index_conversations_on_user_id"
-    t.check_constraint "state::text = ANY (ARRAY['active'::character varying::text, 'awaiting_confirmation'::character varying::text, 'failed'::character varying::text])", name: "conversations_state_valid"
+    t.check_constraint "state::text = ANY (ARRAY['active'::character varying, 'awaiting_confirmation'::character varying, 'failed'::character varying]::text[])", name: "conversations_state_valid"
   end
 
   create_table "dietary_profile_ingredients", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -164,7 +164,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.text "work_description", null: false
     t.index ["created_at"], name: "index_dmca_notices_on_created_at"
     t.index ["status"], name: "index_dmca_notices_on_status"
-    t.check_constraint "status::text = ANY (ARRAY['received'::character varying::text, 'actioned'::character varying::text, 'rejected'::character varying::text])", name: "dmca_notices_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['received'::character varying, 'actioned'::character varying, 'rejected'::character varying]::text[])", name: "dmca_notices_status_valid"
   end
 
   create_table "favorite_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -224,7 +224,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["ingestion_run_id"], name: "index_ingestion_items_on_ingestion_run_id"
     t.index ["item_id"], name: "index_ingestion_items_on_item_id"
     t.index ["matched_item_id"], name: "index_ingestion_items_on_matched_item_id"
-    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text, 'edited'::character varying::text])", name: "ingestion_items_decision_valid"
+    t.check_constraint "decision::text = ANY (ARRAY['pending'::character varying, 'accepted'::character varying, 'rejected'::character varying, 'edited'::character varying]::text[])", name: "ingestion_items_decision_valid"
   end
 
   create_table "ingestion_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -248,9 +248,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.uuid "user_id"
     t.index ["restaurant_id"], name: "index_ingestion_runs_on_restaurant_id"
     t.index ["user_id"], name: "index_ingestion_runs_on_user_id"
-    t.check_constraint "enrichment_status::text = ANY (ARRAY['pending'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "ingestion_runs_enrichment_status_valid"
-    t.check_constraint "input_kind::text = ANY (ARRAY['photo'::character varying::text, 'url'::character varying::text, 'pdf'::character varying::text, 'text'::character varying::text])", name: "ingestion_runs_input_kind_valid"
-    t.check_constraint "status::text = ANY (ARRAY['queued'::character varying::text, 'extracting'::character varying::text, 'resolving'::character varying::text, 'staged'::character varying::text, 'published'::character varying::text, 'failed'::character varying::text])", name: "ingestion_runs_status_valid"
+    t.check_constraint "enrichment_status::text = ANY (ARRAY['pending'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "ingestion_runs_enrichment_status_valid"
+    t.check_constraint "input_kind::text = ANY (ARRAY['photo'::character varying, 'url'::character varying, 'pdf'::character varying, 'text'::character varying]::text[])", name: "ingestion_runs_input_kind_valid"
+    t.check_constraint "status::text = ANY (ARRAY['queued'::character varying, 'extracting'::character varying, 'resolving'::character varying, 'staged'::character varying, 'published'::character varying, 'failed'::character varying]::text[])", name: "ingestion_runs_status_valid"
   end
 
   create_table "ingredients", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -277,8 +277,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["ingredient_id"], name: "index_item_ingredients_on_ingredient_id"
     t.index ["item_id", "ingredient_id"], name: "index_item_ingredients_on_item_id_and_ingredient_id", unique: true
     t.index ["item_id"], name: "index_item_ingredients_on_item_id"
-    t.check_constraint "confidence::text = ANY (ARRAY['confirmed'::character varying::text, 'suggested'::character varying::text, 'inferred'::character varying::text])", name: "item_ingredients_confidence_valid"
-    t.check_constraint "source::text = ANY (ARRAY['human'::character varying::text, 'ai'::character varying::text, 'owner'::character varying::text])", name: "item_ingredients_source_valid"
+    t.check_constraint "confidence::text = ANY (ARRAY['confirmed'::character varying, 'suggested'::character varying, 'inferred'::character varying]::text[])", name: "item_ingredients_confidence_valid"
+    t.check_constraint "source::text = ANY (ARRAY['human'::character varying, 'ai'::character varying, 'owner'::character varying]::text[])", name: "item_ingredients_source_valid"
   end
 
   create_table "item_modifiers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -293,7 +293,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["ingredient_ids"], name: "index_item_modifiers_on_ingredient_ids", using: :gin
     t.index ["item_id"], name: "index_item_modifiers_on_item_id"
     t.index ["tag_ids"], name: "index_item_modifiers_on_tag_ids", using: :gin
-    t.check_constraint "kind::text = ANY (ARRAY['choice'::character varying::text, 'addition'::character varying::text, 'side'::character varying::text])", name: "item_modifiers_kind_valid"
+    t.check_constraint "kind::text = ANY (ARRAY['choice'::character varying, 'addition'::character varying, 'side'::character varying]::text[])", name: "item_modifiers_kind_valid"
   end
 
   create_table "item_tags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -306,8 +306,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["item_id", "tag_id"], name: "index_item_tags_on_item_id_and_tag_id", unique: true
     t.index ["item_id"], name: "index_item_tags_on_item_id"
     t.index ["tag_id"], name: "index_item_tags_on_tag_id"
-    t.check_constraint "confidence::text = ANY (ARRAY['confirmed'::character varying::text, 'suggested'::character varying::text, 'inferred'::character varying::text])", name: "item_tags_confidence_valid"
-    t.check_constraint "source::text = ANY (ARRAY['human'::character varying::text, 'ai'::character varying::text, 'owner'::character varying::text])", name: "item_tags_source_valid"
+    t.check_constraint "confidence::text = ANY (ARRAY['confirmed'::character varying, 'suggested'::character varying, 'inferred'::character varying]::text[])", name: "item_tags_confidence_valid"
+    t.check_constraint "source::text = ANY (ARRAY['human'::character varying, 'ai'::character varying, 'owner'::character varying]::text[])", name: "item_tags_source_valid"
   end
 
   create_table "item_variants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -341,8 +341,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["restaurant_id", "status"], name: "index_items_on_restaurant_id_and_status"
     t.index ["restaurant_id"], name: "index_items_on_restaurant_id"
     t.index ["tag_ids"], name: "index_items_on_tag_ids", using: :gin
-    t.check_constraint "confidence::text = ANY (ARRAY['confirmed'::character varying::text, 'suggested'::character varying::text, 'inferred'::character varying::text])", name: "items_confidence_valid"
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'published'::character varying::text, 'removed'::character varying::text])", name: "items_status_valid"
+    t.check_constraint "confidence::text = ANY (ARRAY['confirmed'::character varying, 'suggested'::character varying, 'inferred'::character varying]::text[])", name: "items_confidence_valid"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'published'::character varying, 'removed'::character varying]::text[])", name: "items_status_valid"
+  end
+
+  create_table "mcp_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.datetime "last_used_at"
+    t.string "name", null: false
+    t.datetime "revoked_at"
+    t.string "scopes", default: [], null: false, array: true
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["token_digest"], name: "index_mcp_tokens_on_token_digest", unique: true
+    t.index ["user_id"], name: "index_mcp_tokens_on_user_id"
   end
 
   create_table "menu_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -373,7 +387,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.string "role", null: false
     t.datetime "updated_at", null: false
     t.index ["conversation_id", "position"], name: "index_messages_on_conversation_id_and_position", unique: true
-    t.check_constraint "role::text = ANY (ARRAY['user'::character varying::text, 'assistant'::character varying::text])", name: "messages_role_valid"
+    t.check_constraint "role::text = ANY (ARRAY['user'::character varying, 'assistant'::character varying]::text[])", name: "messages_role_valid"
   end
 
   create_table "restaurant_visits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -409,7 +423,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["created_by_user_id"], name: "index_restaurants_on_created_by_user_id"
     t.index ["name"], name: "index_restaurants_on_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["slug"], name: "index_restaurants_on_slug", unique: true
-    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'published'::character varying::text, 'closed'::character varying::text])", name: "restaurants_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'published'::character varying, 'closed'::character varying]::text[])", name: "restaurants_status_valid"
   end
 
   create_table "reviews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -427,7 +441,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["item_id"], name: "index_reviews_on_item_id"
     t.index ["user_id", "item_id"], name: "index_reviews_on_user_id_and_item_id", unique: true
     t.index ["user_id"], name: "index_reviews_on_user_id"
-    t.check_constraint "hidden_reason IS NULL OR (hidden_reason::text = ANY (ARRAY['spam'::character varying::text, 'abuse'::character varying::text, 'duplicate'::character varying::text, 'off_topic'::character varying::text]))", name: "reviews_hidden_reason_valid"
+    t.check_constraint "hidden_reason IS NULL OR (hidden_reason::text = ANY (ARRAY['spam'::character varying, 'abuse'::character varying, 'duplicate'::character varying, 'off_topic'::character varying]::text[]))", name: "reviews_hidden_reason_valid"
     t.check_constraint "rating >= 1 AND rating <= 5", name: "reviews_rating_range"
   end
 
@@ -578,7 +592,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["status"], name: "index_suggestions_on_status"
     t.index ["subject_type", "subject_id"], name: "index_suggestions_on_subject_type_and_subject_id"
     t.index ["user_id"], name: "index_suggestions_on_user_id"
-    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying::text, 'accepted'::character varying::text, 'rejected'::character varying::text])", name: "suggestions_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'accepted'::character varying, 'rejected'::character varying]::text[])", name: "suggestions_status_valid"
   end
 
   create_table "tags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -593,7 +607,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.index ["name"], name: "index_tags_on_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["path"], name: "index_tags_on_path", using: :gist
     t.index ["slug"], name: "index_tags_on_slug", unique: true
-    t.check_constraint "family::text = ANY (ARRAY['diet'::character varying::text, 'allergen'::character varying::text, 'cuisine'::character varying::text, 'prep'::character varying::text, 'flavor'::character varying::text])", name: "tags_family_valid"
+    t.check_constraint "family::text = ANY (ARRAY['diet'::character varying, 'allergen'::character varying, 'cuisine'::character varying, 'prep'::character varying, 'flavor'::character varying]::text[])", name: "tags_family_valid"
   end
 
   create_table "user_item_overrides", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -623,7 +637,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.uuid "user_id", null: false
     t.index ["primary_dietary_profile_id"], name: "index_user_profiles_on_primary_dietary_profile_id"
     t.index ["user_id"], name: "index_user_profiles_on_user_id", unique: true
-    t.check_constraint "strictness::text = ANY (ARRAY['relaxed'::character varying::text, 'balanced'::character varying::text, 'strict'::character varying::text])", name: "user_profiles_strictness_valid"
+    t.check_constraint "strictness::text = ANY (ARRAY['relaxed'::character varying, 'balanced'::character varying, 'strict'::character varying]::text[])", name: "user_profiles_strictness_valid"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -658,7 +672,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
     t.string "source", default: "landing", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_waitlist_signups_on_email", unique: true
-    t.check_constraint "source::text = ANY (ARRAY['landing'::character varying::text, 'press'::character varying::text, 'footer'::character varying::text, 'mobile_app'::character varying::text])", name: "waitlist_signups_source_valid"
+    t.check_constraint "source::text = ANY (ARRAY['landing'::character varying, 'press'::character varying, 'footer'::character varying, 'mobile_app'::character varying]::text[])", name: "waitlist_signups_source_valid"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -691,6 +705,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_180000) do
   add_foreign_key "items", "menu_sections"
   add_foreign_key "items", "restaurants"
   add_foreign_key "items", "users", column: "created_by_user_id"
+  add_foreign_key "mcp_tokens", "users"
   add_foreign_key "menu_sections", "menus"
   add_foreign_key "menus", "restaurants"
   add_foreign_key "messages", "conversations"

--- a/apps/api/lib/tasks/mcp.rake
+++ b/apps/api/lib/tasks/mcp.rake
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Least-privilege credentials for MCP clients.
+#
+# The alternative — and what a connected Claude Code uses without one — is
+# the same JWT the web app holds, which carries everything the account can
+# do. A token here names what it may touch and can be revoked on its own.
+#
+# The secret prints once. There is nothing stored that could print it
+# again, which is the point.
+#
+# Usage:
+#   bin/rails "mcp:issue[you@example.com,Claude Code,discovery:read profile:read]"
+#   bin/rails "mcp:issue[you@example.com,ops]"          # unscoped: everything
+#   bin/rails "mcp:list[you@example.com]"
+#   bin/rails "mcp:revoke[<token id>]"
+#   bin/rails mcp:scopes
+namespace :mcp do
+  desc "Issue a scoped MCP token. Scopes are space-separated; omit for unrestricted."
+  task :issue, [:email, :name, :scopes] => :environment do |_t, args|
+    abort("usage: mcp:issue[email,name,scopes]") if args[:email].blank? || args[:name].blank?
+
+    user = User.find_by(email: args[:email].to_s.downcase)
+    abort("no user with email #{args[:email]}") if user.nil?
+
+    scopes = args[:scopes].to_s.split.map(&:strip).compact_blank
+    active = McpToken.active.where(user: user).count
+    abort("that account already has #{McpToken::MAX_ACTIVE} active tokens; revoke one first") if
+      active >= McpToken::MAX_ACTIVE
+
+    token, secret = McpToken.issue!(user: user, name: args[:name], scopes: scopes)
+
+    puts "id:     #{token.id}"
+    puts "scopes: #{scopes.presence&.join(', ') || 'unrestricted'}"
+    puts
+    puts "  #{secret}"
+    puts
+    puts "That is the only time it will be shown — nothing stored can print it again."
+  end
+
+  desc "List a user's active MCP tokens"
+  task :list, [:email] => :environment do |_t, args|
+    user = User.find_by(email: args[:email].to_s.downcase)
+    abort("no user with email #{args[:email]}") if user.nil?
+
+    tokens = McpToken.active.where(user: user).order(:created_at)
+    puts "no active tokens" if tokens.empty?
+    tokens.each do |t|
+      used = t.last_used_at ? "last used #{t.last_used_at.to_fs(:short)}" : "never used"
+      puts format("%s  %-24s %-40s %s", t.id, t.name, t.scopes.presence&.join(",") || "unrestricted", used)
+    end
+  end
+
+  desc "Revoke one MCP token by id"
+  task :revoke, [:id] => :environment do |_t, args|
+    token = McpToken.find_by(id: args[:id])
+    abort("no token #{args[:id]}") if token.nil?
+
+    token.revoke!
+    puts "revoked #{token.name}"
+  end
+
+  desc "List every scope a token can be granted"
+  task scopes: :environment do
+    Tools::Scopes.available.each_slice(2) { |read, write| puts "#{read}\t#{write}" }
+  end
+end

--- a/apps/api/spec/models/mcp_token_spec.rb
+++ b/apps/api/spec/models/mcp_token_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# Connecting Claude Code today means handing it the same JWT the web app
+# uses, which carries everything the account can do — for an admin, the
+# taxonomy, the moderation queue, and every user's role. This is the
+# credential that can carry less.
+RSpec.describe McpToken do
+  let(:user) { create(:user) }
+
+  describe ".issue!" do
+    it "returns the secret exactly once, and never stores it" do
+      token, secret = described_class.issue!(user: user, name: "Claude Code", scopes: ["discovery:read"])
+
+      expect(secret).to start_with(described_class::PREFIX)
+      # A leaked database must not be a leaked set of working credentials.
+      expect(token.attributes.values.map(&:to_s)).not_to include(secret)
+      expect(token.token_digest).to eq(Digest::SHA256.hexdigest(secret))
+    end
+
+    it "refuses a scope that means nothing" do
+      expect { described_class.issue!(user: user, name: "x", scopes: ["menus:teleport"]) }
+        .to raise_error(ActiveRecord::RecordInvalid, /unknown/)
+    end
+  end
+
+  describe ".authenticate" do
+    it "resolves a live token" do
+      token, secret = described_class.issue!(user: user, name: "Claude Code")
+
+      expect(described_class.authenticate(secret)).to eq(token)
+    end
+
+    it "refuses a revoked one" do
+      token, secret = described_class.issue!(user: user, name: "Claude Code")
+      token.revoke!
+
+      expect(described_class.authenticate(secret)).to be_nil
+    end
+
+    it "refuses an expired one" do
+      _, secret = described_class.issue!(user: user, name: "Claude Code", expires_at: 1.hour.ago)
+
+      expect(described_class.authenticate(secret)).to be_nil
+    end
+
+    # A JWT arriving here must not be mistaken for a missing token, and a
+    # random string must not cost a lookup that could match anything.
+    it "ignores anything that is not one of ours" do
+      expect(described_class.authenticate("eyJhbGciOiJIUzI1NiJ9.abc.def")).to be_nil
+      expect(described_class.authenticate(nil)).to be_nil
+      expect(described_class.authenticate("")).to be_nil
+    end
+  end
+
+  describe "#note_use!" do
+    # A timestamp accurate to the minute answers "is this still in use?";
+    # writing a row on every tool call would put a write in front of every
+    # read.
+    it "records first use and then stops writing" do
+      token, = described_class.issue!(user: user, name: "Claude Code")
+
+      token.note_use!
+      first = token.reload.last_used_at
+      token.note_use!
+
+      expect(first).to be_present
+      expect(token.reload.last_used_at).to eq(first)
+    end
+  end
+end

--- a/apps/api/spec/requests/mcp_spec.rb
+++ b/apps/api/spec/requests/mcp_spec.rb
@@ -155,5 +155,68 @@ RSpec.describe "POST /mcp", type: :request do
       expect(names).to eq(["find_something_this_person_can_eat"])
     end
   end
+
+  # Connecting Claude Code today means handing it a JWT carrying every
+  # power the account has. A scoped token carries less, and the tool layer
+  # is where that is enforced.
+  describe "scoped MCP tokens" do
+    def rpc(secret, name, arguments = {})
+      post "/mcp",
+           params: { jsonrpc: "2.0", id: 1, method: "tools/call",
+                     params: { name: name, arguments: arguments } }.to_json,
+           headers: { "Authorization" => "Bearer #{secret}", "Content-Type" => "application/json" }
+      JSON.parse(response.body, symbolize_names: true)
+    end
+
+    let!(:city)       { create(:city, slug: "durango") }
+    let!(:restaurant) { create(:restaurant, :published, city: city, slug: "ninis") }
+
+    it "authenticates as its owner" do
+      user = create(:user)
+      _, secret = McpToken.issue!(user: user, name: "Claude Code", scopes: ["discovery:read"])
+
+      body = rpc(secret, "get_restaurant", { restaurant: "ninis" })
+
+      expect(body[:error]).to be_nil
+      expect(body.dig(:result, :isError)).to be_falsey
+    end
+
+    # The whole point: an admin's read-only token is still an admin's
+    # token, and still may not write.
+    it "refuses a write the token was not granted, even for an admin" do
+      admin = create(:user, is_admin: true)
+      _, secret = McpToken.issue!(user: admin, name: "read only", scopes: ["discovery:read"])
+
+      body = rpc(secret, "set_user_role", { user_id: admin.id, is_admin: false })
+
+      expect(body.dig(:result, :isError)).to be(true)
+      expect(body.dig(:result, :content, 0, :text)).to include("scope")
+      expect(admin.reload.is_admin).to be(true)
+    end
+
+    it "allows the write once the scope is granted" do
+      admin = create(:user, is_admin: true)
+      other = create(:user)
+      _, secret = McpToken.issue!(user: admin, name: "ops", scopes: ["users:write"])
+
+      rpc(secret, "set_user_role", { user_id: other.id, is_admin: true })
+
+      expect(other.reload.is_admin).to be(true)
+    end
+
+    # A revoked credential must stop working without ending every other
+    # session the person has.
+    it "rejects a revoked token as unauthorized" do
+      user = create(:user)
+      token, secret = McpToken.issue!(user: user, name: "old laptop")
+      token.revoke!
+
+      post "/mcp",
+           params: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }.to_json,
+           headers: { "Authorization" => "Bearer #{secret}", "Content-Type" => "application/json" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end
 

--- a/apps/api/spec/services/tools/scopes_spec.rb
+++ b/apps/api/spec/services/tools/scopes_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+# What a credential is allowed to do, in the vocabulary of tool domains.
+#
+# The vocabulary is derived from the registry rather than listed, so a new
+# domain cannot ship without a scope for it — the same discipline that
+# keeps the topology map honest.
+RSpec.describe Tools::Scopes do
+  it "covers every registered domain, read and write" do
+    Tools::Registry::DOMAINS.each_key do |domain|
+      expect(described_class.available).to include("#{domain}:read", "#{domain}:write")
+    end
+  end
+
+  # The split follows the annotation a tool already carries, so it cannot
+  # drift from what the tool actually does.
+  it "reads a tool's requirement off its own read_only_hint" do
+    expect(described_class.for_tool(Tools::Discovery::GetMenu)).to eq("discovery:read")
+    expect(described_class.for_tool(Tools::Users::SetUserRole)).to eq("users:write")
+  end
+
+  # A class the registry does not know — an anonymous subclass in a spec —
+  # is not something a scope can meaningfully protect, and asking must not
+  # raise.
+  it "returns nothing for a tool the registry does not know" do
+    expect { described_class.for_tool(Class.new(Tools::Base)) }.not_to raise_error
+    expect(described_class.for_tool(Class.new(Tools::Base))).to be_nil
+  end
+
+  describe ".satisfied?" do
+    # Every credential issued before scopes existed carries none. Treating
+    # that as "denied" would lock out every working integration; treating
+    # it as "unrestricted" is what it has always been.
+    it "treats an unscoped credential as unrestricted" do
+      expect(described_class.satisfied?([], "users:write")).to be(true)
+      expect(described_class.satisfied?(nil, "users:write")).to be(true)
+    end
+
+    it "honours an exact grant" do
+      expect(described_class.satisfied?(["discovery:read"], "discovery:read")).to be(true)
+      expect(described_class.satisfied?(["discovery:read"], "users:write")).to be(false)
+    end
+
+    # Permission to edit a menu but not to look at one would be nonsense.
+    it "lets write imply read on the same domain" do
+      expect(described_class.satisfied?(["items:write"], "items:read")).to be(true)
+    end
+
+    # The reverse must not hold — that is the entire point.
+    it "never lets read imply write" do
+      expect(described_class.satisfied?(["items:read"], "items:write")).to be(false)
+    end
+
+    it "does not leak across domains" do
+      expect(described_class.satisfied?(["discovery:write"], "taxonomy:read")).to be(false)
+    end
+  end
+end

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -347,6 +347,40 @@ tools. A header that fails to authenticate is a **401**, not a silent
 downgrade to anonymous — a client with a stale token needs to know to
 refresh rather than quietly lose access to its own profile.
 
+### Scoped tokens (least privilege)
+
+A Devise JWT carries everything the account can do — for an admin, the
+taxonomy, the moderation queue, and every user's role. That is a lot of
+authority to hand something whose job is usually "read menus for me".
+
+`McpToken` is the alternative: a credential that names what it may touch,
+lists, and revokes on its own without ending other sessions.
+
+```bash
+bin/rails "mcp:issue[you@example.com,Claude Code,discovery:read profile:read]"
+bin/rails "mcp:list[you@example.com]"
+bin/rails "mcp:revoke[<token id>]"
+bin/rails mcp:scopes          # every grantable scope
+```
+
+The secret prints once; only its SHA-256 is stored, so a leaked database
+is not a leaked set of working credentials.
+
+Scopes are `<domain>:<read|write>`, **derived from `Registry::DOMAINS`**
+rather than listed — a new domain cannot ship without a scope for it. The
+read/write split follows each tool's own `read_only_hint`, so it cannot
+drift from what the tool does. A write grant implies the read on the same
+domain; the reverse never holds.
+
+Enforcement lives in `Tools::Base` alongside the audience check, because
+they are different questions and both must pass: audience asks *may this
+person*, scope asks *may this credential*. An admin using a read-only
+token is still an admin, and the token still may not write.
+
+**An unscoped credential is unrestricted.** Every JWT issued before this
+existed carries no scopes, and treating that as "denied" would lock out
+every working integration.
+
 ### Connecting Claude Code
 
 ```bash

--- a/docs/plans/mcp-pivot.md
+++ b/docs/plans/mcp-pivot.md
@@ -291,6 +291,20 @@ restated, audience-filtered like tools and the map. Closes the last
 capability gap in the MCP surface short of OAuth: the server now serves
 tools, resources, and prompts.
 
+### M8a — scoped tokens — SHIPPED
+
+`McpToken` gives an MCP client a least-privilege credential today, without
+waiting on OAuth: domain-scoped, revocable on its own, secret stored only
+as a digest. The scope vocabulary is derived from `Registry::DOMAINS` and
+is the same one M8's authorization server will issue against, so that work
+inherits the enforcement rather than adding it.
+
+**Why not the full OAuth flow yet:** consent needs a browser-rendered
+login and approval page, and this app is `api_only` with its login UI in
+Next.js. Where that page lives — Rails-rendered, or a Next route posting
+back — is a product decision with security implications, not something to
+settle mid-implementation.
+
 ### M8 — Public MCP (OAuth 2.1)
 
 Self-contained; nothing above depends on it.


### PR DESCRIPTION
## Summary

- Connecting Claude Code meant handing it the same JWT the web app uses — **everything the account can do**, including admin. `McpToken` is domain-scoped, revocable on its own, and stored only as a SHA-256 (a leaked database isn't a leaked set of working credentials).
- Scopes are **derived from `Registry::DOMAINS`**, not listed, so a new domain can't ship without one; the read/write split follows each tool's own `read_only_hint`. Write implies read on a domain; the reverse never holds.
- Enforcement sits beside the audience check in `Tools::Base` — audience asks *may this person*, scope asks *may this credential*. **Verified on a real token: an admin's read-scoped credential searched fine and was denied `set_strictness` and `list_users`.**
- Unscoped = unrestricted, so every existing integration keeps working.

M8's authorization server will issue against this vocabulary and inherit this enforcement. The full OAuth flow still needs a decision on where consent renders — the app is `api_only` and the login UI is in Next.js.
