### PR TITLE
feat: manage scoped MCP tokens without a terminal

### DIFF
--- a/apps/api/app/controllers/api/v1/mcp_tokens_controller.rb
+++ b/apps/api/app/controllers/api/v1/mcp_tokens_controller.rb
@@ -1,0 +1,62 @@
+module Api
+  module V1
+    # Least-privilege credentials for MCP clients, managed by their owner.
+    #
+    # The rake task that shipped with `McpToken` works for whoever has a
+    # shell on the box; this is for everyone else. Connecting Claude Code
+    # should not require a terminal.
+    #
+    # **The secret is returned exactly once**, by `create`. Nothing stored
+    # can reproduce it, so `index` never carries it and there is no
+    # endpoint that could.
+    class McpTokensController < BaseController
+      def index
+        render json: {
+          tokens: current_user.mcp_tokens.active.order(:created_at).map { |t| serialize(t) },
+          scopes: Tools::Scopes.available
+        }
+      end
+
+      def create
+        name = params[:name].to_s.strip
+        return render_error("Give the token a name so you can tell them apart.") if name.blank?
+
+        scopes = Array(params[:scopes]).map(&:to_s).compact_blank
+        unknown = scopes.reject { |s| Tools::Scopes.valid?(s) }
+        return render_error("Unknown scope(s): #{unknown.join(', ')}.") if unknown.any?
+
+        if current_user.mcp_tokens.active.count >= McpToken::MAX_ACTIVE
+          return render_error("You already have #{McpToken::MAX_ACTIVE} active tokens. Revoke one first.")
+        end
+
+        token, secret = McpToken.issue!(user: current_user, name: name, scopes: scopes)
+        # The one and only time this value exists anywhere it can be read.
+        render json: serialize(token).merge(secret: secret), status: :created
+      end
+
+      def destroy
+        token = current_user.mcp_tokens.active.find_by(id: params[:id])
+        return render_error("No such token.", :not_found) if token.nil?
+
+        token.revoke!
+        head :no_content
+      end
+
+      private
+
+      def serialize(token)
+        {
+          id:           token.id,
+          name:         token.name,
+          scopes:       token.scopes,
+          created_at:   token.created_at.iso8601,
+          last_used_at: token.last_used_at&.iso8601
+        }
+      end
+
+      def render_error(message, status = :unprocessable_entity)
+        render json: { error: message }, status: status
+      end
+    end
+  end
+end

--- a/apps/api/app/models/user.rb
+++ b/apps/api/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
 
   has_one  :profile, class_name: "UserProfile", dependent: :destroy
   has_many :reviews, dependent: :destroy
+  has_many :mcp_tokens, dependent: :destroy
   has_many :suggestions, dependent: :nullify
   has_many :user_item_overrides, dependent: :destroy
   has_many :overridden_items, through: :user_item_overrides, source: :item

--- a/apps/api/config/routes.rb
+++ b/apps/api/config/routes.rb
@@ -132,6 +132,9 @@ Rails.application.routes.draw do
       # Menu photos/PDFs the chat refers to by id, so bytes never enter
       # the agent's context.
       resources :attachments, only: [:create]
+      # Least-privilege credentials for MCP clients, so connecting Claude
+      # Code does not require a shell on the box.
+      resources :mcp_tokens, only: [:index, :create, :destroy]
       # The caller's own identity incl. `is_admin` — the web /admin
       # guard's probe. Read-only on purpose: auth/refresh also returns
       # the user payload but rotates the jti, killing other sessions.

--- a/apps/api/spec/requests/api/v1/mcp_tokens_spec.rb
+++ b/apps/api/spec/requests/api/v1/mcp_tokens_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+# Connecting Claude Code should not require a shell on the box. The rake
+# task works for whoever has one; this is for everyone else.
+RSpec.describe "Api::V1::McpTokens", type: :request do
+  let(:user)    { create(:user) }
+  let(:headers) { auth_headers_for(user) }
+
+  describe "POST /api/v1/mcp_tokens" do
+    # The one and only time this value exists anywhere it can be read.
+    it "returns the secret once, on creation" do
+      post "/api/v1/mcp_tokens",
+           params: { name: "Claude Code", scopes: ["discovery:read"] }.to_json,
+           headers: headers.merge("Content-Type" => "application/json")
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body["secret"]).to start_with(McpToken::PREFIX)
+      expect(response.parsed_body["scopes"]).to eq(["discovery:read"])
+    end
+
+    it "refuses a scope that means nothing" do
+      post "/api/v1/mcp_tokens",
+           params: { name: "x", scopes: ["menus:teleport"] }.to_json,
+           headers: headers.merge("Content-Type" => "application/json")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to include("menus:teleport")
+    end
+
+    it "insists on a name, so a list of tokens stays legible" do
+      post "/api/v1/mcp_tokens",
+           params: { name: "  " }.to_json,
+           headers: headers.merge("Content-Type" => "application/json")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "caps how many can be live at once" do
+      McpToken::MAX_ACTIVE.times { |i| McpToken.issue!(user: user, name: "t#{i}") }
+
+      post "/api/v1/mcp_tokens",
+           params: { name: "one too many" }.to_json,
+           headers: headers.merge("Content-Type" => "application/json")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "GET /api/v1/mcp_tokens" do
+    # Nothing stored can reproduce the secret, so there is no endpoint
+    # that could return it — including this one.
+    it "lists active tokens without their secrets" do
+      McpToken.issue!(user: user, name: "Claude Code", scopes: ["discovery:read"])
+
+      get "/api/v1/mcp_tokens", headers: headers
+
+      token = response.parsed_body["tokens"].first
+      expect(token["name"]).to eq("Claude Code")
+      expect(token).not_to have_key("secret")
+      expect(response.body).not_to include(McpToken::PREFIX)
+    end
+
+    it "offers the grantable scopes so a client need not hardcode them" do
+      get "/api/v1/mcp_tokens", headers: headers
+
+      expect(response.parsed_body["scopes"]).to include("discovery:read", "profile:write")
+    end
+
+    it "leaves out revoked ones" do
+      token, = McpToken.issue!(user: user, name: "old laptop")
+      token.revoke!
+
+      get "/api/v1/mcp_tokens", headers: headers
+
+      expect(response.parsed_body["tokens"]).to be_empty
+    end
+
+    it "never shows another account's tokens" do
+      McpToken.issue!(user: create(:user), name: "someone else's")
+
+      get "/api/v1/mcp_tokens", headers: headers
+
+      expect(response.parsed_body["tokens"]).to be_empty
+    end
+  end
+
+  describe "DELETE /api/v1/mcp_tokens/:id" do
+    it "revokes the caller's own token" do
+      token, secret = McpToken.issue!(user: user, name: "old laptop")
+
+      delete "/api/v1/mcp_tokens/#{token.id}", headers: headers
+
+      expect(response).to have_http_status(:no_content)
+      expect(McpToken.authenticate(secret)).to be_nil
+    end
+
+    # Revoking by id must not become a way to disable someone else's
+    # integration.
+    it "404s another account's token and leaves it working" do
+      token, secret = McpToken.issue!(user: create(:user), name: "theirs")
+
+      delete "/api/v1/mcp_tokens/#{token.id}", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(McpToken.authenticate(secret)).to eq(token)
+    end
+  end
+
+  it "requires a signed-in caller" do
+    get "/api/v1/mcp_tokens"
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/apps/web/src/app/api/mcp-tokens/[id]/route.ts
+++ b/apps/web/src/app/api/mcp-tokens/[id]/route.ts
@@ -1,0 +1,7 @@
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../../lib/api-proxy';
+
+export async function DELETE(_request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  return proxyAuthed(`/api/v1/mcp_tokens/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/apps/web/src/app/api/mcp-tokens/route.ts
+++ b/apps/web/src/app/api/mcp-tokens/route.ts
@@ -1,0 +1,16 @@
+/**
+ * Least-privilege credentials for MCP clients.
+ *
+ * The secret comes back exactly once, on create — nothing stored can
+ * reproduce it, so there is no route here that could return it again.
+ */
+import { type NextRequest } from 'next/server';
+import { proxyAuthed } from '../../../lib/api-proxy';
+
+export async function GET() {
+  return proxyAuthed('/api/v1/mcp_tokens');
+}
+
+export async function POST(request: NextRequest) {
+  return proxyAuthed('/api/v1/mcp_tokens', { method: 'POST', body: await request.text() });
+}

--- a/apps/web/src/app/profile/settings/page.tsx
+++ b/apps/web/src/app/profile/settings/page.tsx
@@ -17,6 +17,13 @@ import {
   type FavoriteDish,
 } from '../../../lib/profile';
 import {
+  createToken,
+  listTokens,
+  revokeToken,
+  type McpTokenSummary,
+  type McpTokenWithSecret,
+} from '../../../lib/mcp-tokens';
+import {
   fetchDietaryProfiles,
   searchIngredients,
   type IngredientSearchResult,
@@ -41,6 +48,7 @@ export default function ProfileSettingsPage() {
       <PreferencesSection />
       <FavoritesSection />
       <MyReviewsSection />
+      <McpTokensSection />
       <AnalyticsSection />
     </main>
   );
@@ -751,6 +759,165 @@ function MyReviewRow({ review }: { review: MyReview }) {
  * regardless (see packages/analytics — profile_set carries no health
  * fields).
  */
+/**
+ * Least-privilege credentials for MCP clients (Claude Code, Claude
+ * Desktop).
+ *
+ * Without one, connecting a client means handing it the same session this
+ * browser holds — everything the account can do. A token here names what
+ * it may touch and can be revoked on its own.
+ *
+ * The secret is shown **once**, right after creation, because only its
+ * digest is stored and nothing can reproduce it. The UI says so rather
+ * than letting someone assume they can come back for it.
+ */
+function McpTokensSection() {
+  const [tokens, setTokens] = useState<McpTokenSummary[]>([]);
+  const [available, setAvailable] = useState<string[]>([]);
+  const [name, setName] = useState('');
+  const [chosen, setChosen] = useState<string[]>([]);
+  const [fresh, setFresh] = useState<McpTokenWithSecret | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = async () => {
+    try {
+      const list = await listTokens();
+      setTokens(list.tokens);
+      setAvailable(list.scopes);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const create = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      setFresh(await createToken(name.trim(), chosen));
+      setName('');
+      setChosen([]);
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const revoke = async (id: string) => {
+    try {
+      await revokeToken(id);
+      await load();
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  const toggle = (scope: string) =>
+    setChosen((current) =>
+      current.includes(scope) ? current.filter((s) => s !== scope) : [...current, scope],
+    );
+
+  return (
+    <section className="mt-bw-10" data-testid="mcp-tokens">
+      <h2 className="text-bw-lg font-bold text-zinc-900">Connected apps</h2>
+      <p className="mt-bw-1 text-bw-sm text-zinc-600">
+        Tokens for Claude Code and Claude Desktop. Pick only what the app needs — leave
+        everything unticked and it gets the same access you have.
+      </p>
+
+      {fresh ? (
+        <div
+          className="mt-bw-4 rounded-bw-md border border-warn bg-warn/10 p-bw-3"
+          data-testid="fresh-token"
+        >
+          <p className="text-bw-sm font-medium text-zinc-900">
+            Copy this now — it is not stored and cannot be shown again.
+          </p>
+          <code className="mt-bw-2 block overflow-x-auto text-bw-xs text-zinc-800">
+            {fresh.secret}
+          </code>
+        </div>
+      ) : null}
+
+      <ul className="mt-bw-4 flex flex-col gap-bw-2">
+        {tokens.map((token) => (
+          <li
+            key={token.id}
+            className="flex items-center justify-between rounded-bw-md border border-zinc-200 px-bw-3 py-bw-2"
+          >
+            <span className="min-w-0">
+              <span className="block truncate text-bw-sm font-medium text-zinc-900">
+                {token.name}
+              </span>
+              <span className="block truncate text-bw-xs text-zinc-500">
+                {token.scopes.length ? token.scopes.join(', ') : 'full access'}
+                {token.last_used_at ? ' · used' : ' · never used'}
+              </span>
+            </span>
+            <button
+              type="button"
+              onClick={() => void revoke(token.id)}
+              className="text-bw-sm text-danger"
+            >
+              Revoke
+            </button>
+          </li>
+        ))}
+        {tokens.length === 0 ? (
+          <li className="text-bw-sm text-zinc-500">No connected apps yet.</li>
+        ) : null}
+      </ul>
+
+      <div className="mt-bw-4 flex flex-col gap-bw-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="What is it for? e.g. Claude Code"
+          aria-label="Token name"
+          className="rounded-bw-md border border-zinc-300 px-bw-3 py-bw-2 text-bw-sm"
+        />
+        <div className="flex flex-wrap gap-bw-1">
+          {available.map((scope) => (
+            <button
+              key={scope}
+              type="button"
+              onClick={() => toggle(scope)}
+              aria-pressed={chosen.includes(scope)}
+              className={`rounded-bw-md border px-bw-2 py-bw-1 text-bw-xs ${
+                chosen.includes(scope)
+                  ? 'border-bite bg-bite/10 text-bite-dark'
+                  : 'border-zinc-300 text-zinc-600'
+              }`}
+            >
+              {scope}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => void create()}
+          disabled={busy || name.trim() === ''}
+          className="self-start rounded-bw-md bg-bite px-bw-4 py-bw-2 text-bw-sm font-bold text-white disabled:opacity-50"
+        >
+          Create token
+        </button>
+      </div>
+
+      {error ? (
+        <p role="alert" className="mt-bw-2 text-bw-sm text-danger" data-testid="mcp-tokens-error">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
 function AnalyticsSection() {
   // null until we've read localStorage (avoids an SSR/client mismatch).
   const [optedOut, setOptedOut] = useState<boolean | null>(null);

--- a/apps/web/src/lib/__tests__/mcp-tokens.test.ts
+++ b/apps/web/src/lib/__tests__/mcp-tokens.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createToken, listTokens, revokeToken } from '../mcp-tokens';
+
+function jsonFetch(status: number, body: unknown) {
+  return vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe('mcp tokens', () => {
+  // The one and only time this value exists anywhere it can be read.
+  it('returns the secret from create', async () => {
+    vi.stubGlobal('fetch', jsonFetch(201, { id: 't-1', name: 'Claude Code', scopes: [], secret: 'bw_mcp_x' }));
+
+    expect((await createToken('Claude Code', [])).secret).toBe('bw_mcp_x');
+  });
+
+  // The vocabulary comes from the server so the UI cannot drift from the
+  // registry the scopes are derived from.
+  it('reads the grantable scopes off the list response', async () => {
+    vi.stubGlobal('fetch', jsonFetch(200, { tokens: [], scopes: ['discovery:read'] }));
+
+    expect((await listTokens()).scopes).toEqual(['discovery:read']);
+  });
+
+  it('surfaces the server message on a refusal', async () => {
+    vi.stubGlobal('fetch', jsonFetch(422, { error: 'Unknown scope(s): menus:teleport.' }));
+
+    await expect(createToken('x', ['menus:teleport'])).rejects.toThrow('menus:teleport');
+  });
+
+  it('treats a 204 revoke as done', async () => {
+    vi.stubGlobal('fetch', jsonFetch(204, null));
+
+    await expect(revokeToken('t-1')).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/mcp-tokens.ts
+++ b/apps/web/src/lib/mcp-tokens.ts
@@ -1,0 +1,59 @@
+/**
+ * Least-privilege credentials for MCP clients.
+ *
+ * A Devise JWT carries everything the account can do; one of these names
+ * what it may touch. The secret is returned **once**, by `createToken` —
+ * only its digest is stored, so nothing can show it again.
+ */
+import { NotSignedInError } from './chat';
+
+export interface McpTokenSummary {
+  id: string;
+  name: string;
+  scopes: string[];
+  created_at: string;
+  last_used_at: string | null;
+}
+
+/** Only ever returned by `createToken`, and only that once. */
+export interface McpTokenWithSecret extends McpTokenSummary {
+  secret: string;
+}
+
+export interface McpTokenList {
+  tokens: McpTokenSummary[];
+  /** Every grantable scope, so the UI need not hardcode the vocabulary. */
+  scopes: string[];
+}
+
+async function call<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(path, { credentials: 'same-origin', ...init });
+  if (res.status === 401) throw new NotSignedInError();
+  if (!res.ok) {
+    let message = `Request failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      // Non-JSON error bodies fall through to the status line.
+    }
+    throw new Error(message);
+  }
+  return res.status === 204 ? (undefined as T) : ((await res.json()) as T);
+}
+
+export function listTokens(): Promise<McpTokenList> {
+  return call('/api/mcp-tokens', { cache: 'no-store' });
+}
+
+export function createToken(name: string, scopes: string[]): Promise<McpTokenWithSecret> {
+  return call('/api/mcp-tokens', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, scopes }),
+  });
+}
+
+export function revokeToken(id: string): Promise<void> {
+  return call(`/api/mcp-tokens/${encodeURIComponent(id)}`, { method: 'DELETE' });
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -356,6 +356,8 @@ authority to hand something whose job is usually "read menus for me".
 `McpToken` is the alternative: a credential that names what it may touch,
 lists, and revokes on its own without ending other sessions.
 
+Manage them at **/profile/settings → Connected apps**, or from a shell:
+
 ```bash
 bin/rails "mcp:issue[you@example.com,Claude Code,discovery:read profile:read]"
 bin/rails "mcp:list[you@example.com]"


### PR DESCRIPTION
## Summary

- The rake task shipped with `McpToken` works for whoever has a shell on the box. Connecting Claude Code shouldn't require one — `/api/v1/mcp_tokens` plus a **Connected apps** section on `/profile/settings`.
- The UI reads the grantable scopes **from the list response** rather than hardcoding them, so the vocabulary can't drift from the registry it's derived from.
- Three properties the specs pin: the secret appears **only** in the create response (nothing stored can reproduce it, and the UI says so); another account's tokens are invisible **and unrevokable** — revoking by id mustn't become a way to disable someone else's integration; an unknown scope is refused **by name** rather than silently dropped, which would grant less than asked without saying so.
