### PR TITLE
docs(api): rswag specs for the chat and MCP-token endpoints

### DIFF
--- a/apps/api/spec/integration/api/v1/conversations_spec.rb
+++ b/apps/api/spec/integration/api/v1/conversations_spec.rb
@@ -1,0 +1,204 @@
+require "swagger_helper"
+
+# The chat's HTTP surface. These are the source of `docs/openapi.json` and
+# therefore of `packages/api-types` — the web and mobile chat clients hand-
+# wrote their types until this existed, which is exactly the drift the
+# generated-types rule is meant to prevent.
+RSpec.describe "conversations", type: :request do
+  let(:account) { create(:user, password: "password123") }
+  let(:Authorization) do
+    token, = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+    "Bearer #{token}"
+  end
+
+  path "/api/v1/conversations" do
+    get("List the caller's conversations, newest first") do
+      tags "Chat"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(200, "the caller's conversations") do
+        schema type: :object,
+               required: %w[conversations],
+               properties: {
+                 conversations: { type: :array, items: { "$ref" => "#/components/schemas/Conversation" } }
+               }
+        before { create(:conversation, user: account, title: "What can I eat at Ninis?") }
+        run_test!
+      end
+
+      response(401, "missing or invalid bearer token") do
+        let(:Authorization) { "" }
+        run_test!
+      end
+    end
+
+    post("Open an empty conversation") do
+      tags "Chat"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(201, "the new conversation") do
+        schema "$ref" => "#/components/schemas/Conversation"
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/conversations/{id}" do
+    parameter name: :id, in: :path, type: :string, format: :uuid, required: true
+
+    get("Replay a conversation") do
+      tags "Chat"
+      description "The reconnect path: a dropped stream loses nothing, because every turn " \
+                  "is persisted as it runs. `usage` is present only for admins."
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(200, "the conversation and its transcript") do
+        schema "$ref" => "#/components/schemas/Conversation"
+        let(:id) { create(:conversation, user: account).id }
+        run_test!
+      end
+
+      response(404, "another account's conversation") do
+        let(:id) { create(:conversation, user: create(:user)).id }
+        run_test!
+      end
+    end
+
+    delete("Delete a conversation and its transcript") do
+      tags "Chat"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(204, "deleted") do
+        let(:id) { create(:conversation, user: account).id }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/conversations/{id}/messages" do
+    parameter name: :id, in: :path, type: :string, format: :uuid, required: true
+
+    post("Ask for a turn") do
+      tags "Chat"
+      description "Records the request and hands off to a background job — no model call " \
+                  "happens in this request. Watch the narration with /stream or /events."
+      consumes "application/json"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: %w[message],
+        properties: {
+          message: { type: :string, maxLength: 20_000 },
+          context: {
+            type: :object,
+            description: "Where the user is standing, so \"what can I eat here\" is answerable.",
+            properties: { path: { type: :string }, restaurant: { type: :string } }
+          }
+        }
+      }
+
+      response(202, "queued") do
+        schema "$ref" => "#/components/schemas/TurnQueued"
+        let(:id)   { create(:conversation, user: account).id }
+        let(:body) { { message: "What can I eat at Ninis?" } }
+        run_test!
+      end
+
+      response(422, "empty or over-long message") do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id)   { create(:conversation, user: account).id }
+        let(:body) { { message: "  " } }
+        run_test!
+      end
+
+      response(409, "a confirmation is still parked") do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) do
+          create(:conversation, user: account, state: "awaiting_confirmation",
+                                pending_tool_call: { "results" => [], "queue" => [{ "name" => "delete_review" }] }).id
+        end
+        let(:body) { { message: "never mind" } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/conversations/{id}/confirm" do
+    parameter name: :id, in: :path, type: :string, format: :uuid, required: true
+
+    post("Answer a parked destructive call") do
+      tags "Chat"
+      description "`fingerprint` binds the answer to the call that was drawn, so a stale " \
+                  "client cannot approve whatever happens to be parked now."
+      consumes "application/json"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: %w[confirm],
+        properties: {
+          confirm:     { type: :boolean },
+          fingerprint: { type: :string, nullable: true }
+        }
+      }
+
+      response(409, "nothing is waiting") do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id)   { create(:conversation, user: account).id }
+        let(:body) { { confirm: true } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/conversations/{id}/events" do
+    parameter name: :id, in: :path, type: :string, format: :uuid, required: true
+    parameter name: :after, in: :query, type: :integer, required: false,
+              description: "Narration cursor. Same one /stream uses."
+
+    get("Read a turn's narration as JSON") do
+      tags "Chat"
+      description "For clients that cannot hold a stream open — React Native's fetch " \
+                  "exposes no readable body. Poll while `running` is true."
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(200, "narration after the cursor") do
+        schema "$ref" => "#/components/schemas/ChatEventsPage"
+        let(:id)    { create(:conversation, user: account).id }
+        let(:after) { 0 }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/conversations/{id}/run" do
+    parameter name: :id, in: :path, type: :string, format: :uuid, required: true
+
+    delete("Stop the running turn") do
+      tags "Chat"
+      description "Raises a flag the turn reads at its next checkpoint. Necessarily a " \
+                  "separate request from the one that started it."
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(409, "nothing is running") do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { create(:conversation, user: account).id }
+        run_test!
+      end
+    end
+  end
+end

--- a/apps/api/spec/integration/api/v1/mcp_tokens_spec.rb
+++ b/apps/api/spec/integration/api/v1/mcp_tokens_spec.rb
@@ -1,0 +1,84 @@
+require "swagger_helper"
+
+RSpec.describe "mcp_tokens", type: :request do
+  let(:account) { create(:user, password: "password123") }
+  let(:Authorization) do
+    token, = Warden::JWTAuth::UserEncoder.new.call(account, :user, nil)
+    "Bearer #{token}"
+  end
+
+  path "/api/v1/mcp_tokens" do
+    get("List the caller's active MCP tokens") do
+      tags "MCP"
+      description "Never carries a secret — only the digest is stored, so there is nothing " \
+                  "an endpoint could return. `scopes` lists every grantable scope so a " \
+                  "client need not hardcode the vocabulary."
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(200, "active tokens and the grantable scopes") do
+        schema type: :object,
+               required: %w[tokens scopes],
+               properties: {
+                 tokens: { type: :array, items: { "$ref" => "#/components/schemas/McpToken" } },
+                 scopes: { type: :array, items: { type: :string } }
+               }
+        before { McpToken.issue!(user: account, name: "Claude Code", scopes: ["discovery:read"]) }
+        run_test!
+      end
+    end
+
+    post("Issue a scoped MCP token") do
+      tags "MCP"
+      description "The only response that ever carries the secret. Omit `scopes` for a " \
+                  "credential with the same access as the account."
+      consumes "application/json"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+      parameter name: :body, in: :body, schema: {
+        type: :object,
+        required: %w[name],
+        properties: {
+          name:   { type: :string, maxLength: 60 },
+          scopes: { type: :array, items: { type: :string }, description: "e.g. discovery:read" }
+        }
+      }
+
+      response(201, "the token, with its one-time secret") do
+        schema "$ref" => "#/components/schemas/McpToken"
+        let(:body) { { name: "Claude Code", scopes: ["discovery:read"] } }
+        run_test!
+      end
+
+      response(422, "unknown scope, missing name, or too many active tokens") do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:body) { { name: "x", scopes: ["menus:teleport"] } }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/mcp_tokens/{id}" do
+    parameter name: :id, in: :path, type: :string, format: :uuid, required: true
+
+    delete("Revoke one token, without ending other sessions") do
+      tags "MCP"
+      produces "application/json"
+      security [bearerAuth: []]
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      response(204, "revoked") do
+        let(:id) { McpToken.issue!(user: account, name: "old laptop").first.id }
+        run_test!
+      end
+
+      response(404, "another account's token") do
+        schema "$ref" => "#/components/schemas/ErrorResponse"
+        let(:id) { McpToken.issue!(user: create(:user), name: "theirs").first.id }
+        run_test!
+      end
+    end
+  end
+end

--- a/apps/api/spec/swagger_helper.rb
+++ b/apps/api/spec/swagger_helper.rb
@@ -180,6 +180,143 @@ RSpec.configure do |config|
                               enum: %w[google_oauth2 apple] }
             }
           },
+          # ── Chat ────────────────────────────────────────────────
+          ChatBlock: {
+            type: :object,
+            description: "One Anthropic content block, as a client renders it. " \
+                         "Thinking signatures are dropped — they are meaningless to a client " \
+                         "and the bulkiest thing in the record.",
+            required: %w[type],
+            properties: {
+              type:        { type: :string, enum: %w[text thinking tool_use tool_result] },
+              text:        { type: :string, nullable: true },
+              id:          { type: :string, nullable: true },
+              name:        { type: :string, nullable: true },
+              input:       { type: :object, nullable: true },
+              tool_use_id: { type: :string, nullable: true },
+              ok:          { type: :boolean, nullable: true }
+            }
+          },
+          ChatMessage: {
+            type: :object,
+            required: %w[id role position blocks],
+            properties: {
+              id:       { type: :string, format: :uuid },
+              role:     { type: :string, enum: %w[user assistant] },
+              position: { type: :integer },
+              blocks:   { type: :array, items: { "$ref" => "#/components/schemas/ChatBlock" } }
+            }
+          },
+          PendingTool: {
+            type: :object,
+            description: "The call the confirmation gate parked. `prompt` is the sentence the " \
+                         "tool itself declared; `fingerprint` must be echoed on /confirm so an " \
+                         "answer can only settle the call it was drawn for.",
+            required: %w[name input prompt fingerprint],
+            properties: {
+              name:        { type: :string },
+              input:       { type: :object },
+              prompt:      { type: :string, nullable: true },
+              fingerprint: { type: :string, nullable: true }
+            }
+          },
+          Conversation: {
+            type: :object,
+            required: %w[id state created_at updated_at],
+            properties: {
+              id:         { type: :string, format: :uuid },
+              title:      { type: :string, nullable: true },
+              state:      { type: :string, enum: %w[active awaiting_confirmation failed] },
+              pending:    { nullable: true, allOf: [{ "$ref" => "#/components/schemas/PendingTool" }] },
+              created_at: { type: :string, format: :"date-time" },
+              updated_at: { type: :string, format: :"date-time" },
+              messages:   { type: :array, items: { "$ref" => "#/components/schemas/ChatMessage" } },
+              usage:      { "$ref" => "#/components/schemas/ChatUsage" }
+            }
+          },
+          ChatUsage: {
+            type: :object,
+            description: "Spend and cache accounting. Present only for admins — the server " \
+                         "decides, so a non-admin never receives it.",
+            required: %w[cost_cents],
+            properties: {
+              cost_cents: { type: :integer },
+              last_run: {
+                type: :object, nullable: true,
+                required: %w[state rounds input_tokens output_tokens cache_read_tokens],
+                properties: {
+                  outcome:           { type: :string, nullable: true },
+                  state:             { type: :string },
+                  rounds:            { type: :integer },
+                  input_tokens:      { type: :integer },
+                  output_tokens:     { type: :integer },
+                  cache_read_tokens: { type: :integer },
+                  duration_ms:       { type: :integer, nullable: true }
+                }
+              }
+            }
+          },
+          ChatEvent: {
+            type: :object,
+            description: "One line of a turn's narration, carrying the cursor to resume from.",
+            required: %w[type position],
+            properties: {
+              type:     { type: :string },
+              position: { type: :integer },
+              text:     { type: :string, nullable: true },
+              name:     { type: :string, nullable: true },
+              ok:       { type: :boolean, nullable: true },
+              doing:    { type: :string, nullable: true, description: "The tool's own progress sentence." },
+              message:  { type: :string, nullable: true },
+              tool:     { nullable: true, allOf: [{ "$ref" => "#/components/schemas/PendingTool" }] }
+            }
+          },
+          ChatEventsPage: {
+            type: :object,
+            required: %w[events running],
+            properties: {
+              events:  { type: :array, items: { "$ref" => "#/components/schemas/ChatEvent" } },
+              running: { type: :boolean, description: "False means stop polling." }
+            }
+          },
+          TurnQueued: {
+            type: :object,
+            required: %w[queued after],
+            properties: {
+              queued: { type: :boolean },
+              after:  { type: :integer, description: "Narration position to watch from." }
+            }
+          },
+          Attachment: {
+            type: :object,
+            required: %w[id filename content_type byte_size],
+            properties: {
+              id:           { type: :string, description: "Signed blob id. Bytes never enter the agent's context." },
+              filename:     { type: :string },
+              content_type: { type: :string },
+              byte_size:    { type: :integer }
+            }
+          },
+          McpToken: {
+            type: :object,
+            description: "A least-privilege credential for an MCP client. The secret is " \
+                         "returned only by create — nothing stored can reproduce it.",
+            required: %w[id name scopes created_at],
+            properties: {
+              id:           { type: :string, format: :uuid },
+              name:         { type: :string },
+              scopes:       { type: :array, items: { type: :string },
+                              description: "Empty means unrestricted." },
+              created_at:   { type: :string, format: :"date-time" },
+              last_used_at: { type: :string, format: :"date-time", nullable: true },
+              secret:       { type: :string, nullable: true, description: "Only ever present on create." }
+            }
+          },
+          ErrorResponse: {
+            type: :object,
+            required: %w[error],
+            properties: { error: { type: :string } }
+          },
           AuthResponse: {
             type: :object,
             required: %w[user],

--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -8,6 +8,11 @@
  * block shapes the events used.
  */
 
+import type {
+  ChatUsage as ApiChatUsage,
+  PendingTool as ApiPendingTool,
+} from '@biteworthy/api-types';
+
 export type ChatBlock =
   | { type: 'text'; text: string }
   | { type: 'thinking'; text: string }
@@ -21,17 +26,18 @@ export interface ChatMessage {
   blocks: ChatBlock[];
 }
 
-export interface PendingTool {
-  name: string;
-  input: Record<string, unknown>;
-  /** The sentence the tool itself declared. Null when it declared none,
-   *  in which case the client falls back to a generic prompt — what a
-   *  person approves is never phrased by the model asking for it. */
-  prompt: string | null;
-  /** Binds an answer to this exact call. Echoed back on confirm so a tab
-   *  left open on an earlier prompt cannot approve whatever is parked now. */
-  fingerprint: string | null;
-}
+/**
+ * The call the confirmation gate parked.
+ *
+ * `prompt` is the sentence the tool itself declared — what a person
+ * approves is never phrased by the model asking for it. `fingerprint`
+ * binds an answer to this exact call, so a tab left open on an earlier
+ * prompt cannot approve whatever is parked now.
+ *
+ * Imported from the generated types rather than restated: `codegen:check`
+ * fails if this stops matching the rswag spec it came from.
+ */
+export type PendingTool = ApiPendingTool;
 
 export interface ConversationSummary {
   id: string;
@@ -43,19 +49,10 @@ export interface ConversationSummary {
 }
 
 /** Spend and cache accounting. Present only for admins — the server
- *  decides, so a non-admin never receives it to begin with. */
-export interface ChatUsage {
-  cost_cents: number;
-  last_run: {
-    outcome: string | null;
-    state: string;
-    rounds: number;
-    input_tokens: number;
-    output_tokens: number;
-    cache_read_tokens: number;
-    duration_ms: number | null;
-  } | null;
-}
+ *  decides, so a non-admin never receives it to begin with.
+ *
+ *  Generated from the rswag spec, not restated here. */
+export type ChatUsage = ApiChatUsage;
 
 export interface Conversation extends ConversationSummary {
   messages: ChatMessage[];

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4871,22 +4871,11 @@
         }
       }
     },
-    "/api/v1/ingestion_runs/{ingestion_run_id}/items": {
-      "parameters": [
-        {
-          "name": "ingestion_run_id",
-          "in": "path",
-          "format": "uuid",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        }
-      ],
+    "/api/v1/conversations": {
       "get": {
-        "summary": "List a run's staged items (owner or admin)",
+        "summary": "List the caller's conversations, newest first",
         "tags": [
-          "Ingestion"
+          "Chat"
         ],
         "security": [
           {
@@ -4905,19 +4894,19 @@
         ],
         "responses": {
           "200": {
-            "description": "items in position order",
+            "description": "the caller's conversations",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "required": [
-                    "items"
+                    "conversations"
                   ],
                   "properties": {
-                    "items": {
+                    "conversations": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/IngestionItemPayload"
+                        "$ref": "#/components/schemas/Conversation"
                       }
                     }
                   }
@@ -4925,12 +4914,38 @@
               }
             }
           },
-          "403": {
-            "description": "not the run's creator and not an admin",
+          "401": {
+            "description": "missing or invalid bearer token"
+          }
+        }
+      },
+      "post": {
+        "summary": "Open an empty conversation",
+        "tags": [
+          "Chat"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "the new conversation",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/Conversation"
                 }
               }
             }
@@ -4938,17 +4953,8 @@
         }
       }
     },
-    "/api/v1/ingestion_runs/{ingestion_run_id}/items/{id}": {
+    "/api/v1/conversations/{id}": {
       "parameters": [
-        {
-          "name": "ingestion_run_id",
-          "in": "path",
-          "format": "uuid",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        },
         {
           "name": "id",
           "in": "path",
@@ -4959,11 +4965,12 @@
           }
         }
       ],
-      "patch": {
-        "summary": "Decide a staged item: accept / edit / reject / undo",
+      "get": {
+        "summary": "Replay a conversation",
         "tags": [
-          "Ingestion"
+          "Chat"
         ],
+        "description": "The reconnect path: a dropped stream loses nothing, because every turn is persisted as it runs. `usage` is present only for admins.",
         "security": [
           {
             "bearerAuth": []
@@ -4981,32 +4988,107 @@
         ],
         "responses": {
           "200": {
-            "description": "the updated item",
+            "description": "the conversation and its transcript",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IngestionItemPayload"
+                  "$ref": "#/components/schemas/Conversation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "another account's conversation"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a conversation and its transcript",
+        "tags": [
+          "Chat"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          }
+        }
+      }
+    },
+    "/api/v1/conversations/{id}/messages": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "format": "uuid",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Ask for a turn",
+        "tags": [
+          "Chat"
+        ],
+        "description": "Records the request and hands off to a background job — no model call happens in this request. Watch the narration with /stream or /events.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnQueued"
                 }
               }
             }
           },
           "422": {
-            "description": "unknown decision value",
+            "description": "empty or over-long message",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "allowed": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "a confirmation is still parked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -5018,172 +5100,22 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "decision"
+                  "message"
                 ],
-                "description": "decision: accepted promotes (admin ⇒ confirmed joins, community ⇒ suggested); pending undoes a prior decision. Edit fields apply before an accept so the promoted Item carries the human's tweaks — fixing a bad extraction here beats correcting the live menu later. Every payload array replaces the stored one wholesale: send the complete array, omit the key to leave it alone, send [] to clear the staged row. Prices on a MATCHED card are the exception: an empty array clears the staged payload but leaves the live item's variants alone (an empty scan means 'no prices seen').",
                 "properties": {
-                  "decision": {
+                  "message": {
                     "type": "string",
-                    "enum": [
-                      "accepted",
-                      "edited",
-                      "rejected",
-                      "pending"
-                    ]
+                    "maxLength": 20000
                   },
-                  "name": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "ingredients_payload": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "slug"
-                      ],
-                      "properties": {
-                        "slug": {
-                          "type": "string",
-                          "description": "must match an Ingredient slug; unknown slugs are skipped at promote"
-                        },
-                        "confidence": {
-                          "type": "number"
-                        },
-                        "source": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "tags_payload": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "slug"
-                      ],
-                      "properties": {
-                        "slug": {
-                          "type": "string",
-                          "description": "must match a Tag slug; unknown slugs are skipped at promote"
-                        },
-                        "confidence": {
-                          "type": "number"
-                        },
-                        "source": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "prices_payload": {
-                    "type": "array",
-                    "description": "Materialized as ItemVariants at promote, in array order. Rows without price_cents are dropped; price_cents must be a non-negative integer (422 otherwise).",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "size": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "price_cents": {
-                          "type": "integer",
-                          "nullable": true
-                        }
-                      }
-                    }
-                  },
-                  "addons_payload": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "name"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "price_cents": {
-                          "type": "integer",
-                          "nullable": true
-                        },
-                        "source": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "unresolved_ingredients": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "unresolved_tags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/ingestion_runs/{ingestion_run_id}/items/accept_all": {
-      "parameters": [
-        {
-          "name": "ingestion_run_id",
-          "in": "path",
-          "format": "uuid",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        }
-      ],
-      "post": {
-        "summary": "Bulk-accept every still-pending item",
-        "tags": [
-          "Ingestion"
-        ],
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "all items after the bulk accept",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "items"
-                  ],
-                  "properties": {
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/IngestionItemPayload"
+                  "context": {
+                    "type": "object",
+                    "description": "Where the user is standing, so \"what can I eat here\" is answerable.",
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "restaurant": {
+                        "type": "string"
                       }
                     }
                   }
@@ -5194,7 +5126,7 @@
         }
       }
     },
-    "/api/v1/ingestion_runs/{id}": {
+    "/api/v1/conversations/{id}/confirm": {
       "parameters": [
         {
           "name": "id",
@@ -5206,10 +5138,304 @@
           }
         }
       ],
-      "get": {
-        "summary": "Read a run's status + counters (owner or admin)",
+      "post": {
+        "summary": "Answer a parked destructive call",
         "tags": [
-          "Ingestion"
+          "Chat"
+        ],
+        "description": "`fingerprint` binds the answer to the call that was drawn, so a stale client cannot approve whatever happens to be parked now.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "409": {
+            "description": "nothing is waiting",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "confirm"
+                ],
+                "properties": {
+                  "confirm": {
+                    "type": "boolean"
+                  },
+                  "fingerprint": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/conversations/{id}/events": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "format": "uuid",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "after",
+          "in": "query",
+          "required": false,
+          "description": "Narration cursor. Same one /stream uses.",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Read a turn's narration as JSON",
+        "tags": [
+          "Chat"
+        ],
+        "description": "For clients that cannot hold a stream open — React Native's fetch exposes no readable body. Poll while `running` is true.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "narration after the cursor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatEventsPage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/conversations/{id}/run": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "format": "uuid",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "summary": "Stop the running turn",
+        "tags": [
+          "Chat"
+        ],
+        "description": "Raises a flag the turn reads at its next checkpoint. Necessarily a separate request from the one that started it.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "409": {
+            "description": "nothing is running",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp_tokens": {
+      "get": {
+        "summary": "List the caller's active MCP tokens",
+        "tags": [
+          "MCP"
+        ],
+        "description": "Never carries a secret — only the digest is stored, so there is nothing an endpoint could return. `scopes` lists every grantable scope so a client need not hardcode the vocabulary.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "active tokens and the grantable scopes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "tokens",
+                    "scopes"
+                  ],
+                  "properties": {
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/McpToken"
+                      }
+                    },
+                    "scopes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Issue a scoped MCP token",
+        "tags": [
+          "MCP"
+        ],
+        "description": "The only response that ever carries the secret. Omit `scopes` for a credential with the same access as the account.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "the token, with its one-time secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpToken"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unknown scope, missing name, or too many active tokens",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "maxLength": 60
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "e.g. discovery:read"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mcp_tokens/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "format": "uuid",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "delete": {
+        "summary": "Revoke one token, without ending other sessions",
+        "tags": [
+          "MCP"
         ],
         "security": [
           {
@@ -5221,29 +5447,21 @@
             "name": "Authorization",
             "in": "header",
             "required": true,
-            "description": "Bearer <jwt> — the run's creator or an admin",
             "schema": {
               "type": "string"
             }
           }
         ],
         "responses": {
-          "200": {
-            "description": "the run",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IngestionRunPayload"
-                }
-              }
-            }
+          "204": {
+            "description": "revoked"
           },
           "404": {
-            "description": "someone else's run (deliberately not 403), or unknown id",
+            "description": "another account's token",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -6084,6 +6302,360 @@
               "google_oauth2",
               "apple"
             ]
+          }
+        }
+      },
+      "ChatBlock": {
+        "type": "object",
+        "description": "One Anthropic content block, as a client renders it. Thinking signatures are dropped — they are meaningless to a client and the bulkiest thing in the record.",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text",
+              "thinking",
+              "tool_use",
+              "tool_result"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "input": {
+            "type": "object",
+            "nullable": true
+          },
+          "tool_use_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "ok": {
+            "type": "boolean",
+            "nullable": true
+          }
+        }
+      },
+      "ChatMessage": {
+        "type": "object",
+        "required": [
+          "id",
+          "role",
+          "position",
+          "blocks"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "assistant"
+            ]
+          },
+          "position": {
+            "type": "integer"
+          },
+          "blocks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatBlock"
+            }
+          }
+        }
+      },
+      "PendingTool": {
+        "type": "object",
+        "description": "The call the confirmation gate parked. `prompt` is the sentence the tool itself declared; `fingerprint` must be echoed on /confirm so an answer can only settle the call it was drawn for.",
+        "required": [
+          "name",
+          "input",
+          "prompt",
+          "fingerprint"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "input": {
+            "type": "object"
+          },
+          "prompt": {
+            "type": "string",
+            "nullable": true
+          },
+          "fingerprint": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Conversation": {
+        "type": "object",
+        "required": [
+          "id",
+          "state",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "active",
+              "awaiting_confirmation",
+              "failed"
+            ]
+          },
+          "pending": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PendingTool"
+              }
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            }
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ChatUsage"
+          }
+        }
+      },
+      "ChatUsage": {
+        "type": "object",
+        "description": "Spend and cache accounting. Present only for admins — the server decides, so a non-admin never receives it.",
+        "required": [
+          "cost_cents"
+        ],
+        "properties": {
+          "cost_cents": {
+            "type": "integer"
+          },
+          "last_run": {
+            "type": "object",
+            "nullable": true,
+            "required": [
+              "state",
+              "rounds",
+              "input_tokens",
+              "output_tokens",
+              "cache_read_tokens"
+            ],
+            "properties": {
+              "outcome": {
+                "type": "string",
+                "nullable": true
+              },
+              "state": {
+                "type": "string"
+              },
+              "rounds": {
+                "type": "integer"
+              },
+              "input_tokens": {
+                "type": "integer"
+              },
+              "output_tokens": {
+                "type": "integer"
+              },
+              "cache_read_tokens": {
+                "type": "integer"
+              },
+              "duration_ms": {
+                "type": "integer",
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
+      "ChatEvent": {
+        "type": "object",
+        "description": "One line of a turn's narration, carrying the cursor to resume from.",
+        "required": [
+          "type",
+          "position"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "ok": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "doing": {
+            "type": "string",
+            "nullable": true,
+            "description": "The tool's own progress sentence."
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "tool": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PendingTool"
+              }
+            ]
+          }
+        }
+      },
+      "ChatEventsPage": {
+        "type": "object",
+        "required": [
+          "events",
+          "running"
+        ],
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatEvent"
+            }
+          },
+          "running": {
+            "type": "boolean",
+            "description": "False means stop polling."
+          }
+        }
+      },
+      "TurnQueued": {
+        "type": "object",
+        "required": [
+          "queued",
+          "after"
+        ],
+        "properties": {
+          "queued": {
+            "type": "boolean"
+          },
+          "after": {
+            "type": "integer",
+            "description": "Narration position to watch from."
+          }
+        }
+      },
+      "Attachment": {
+        "type": "object",
+        "required": [
+          "id",
+          "filename",
+          "content_type",
+          "byte_size"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Signed blob id. Bytes never enter the agent's context."
+          },
+          "filename": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          },
+          "byte_size": {
+            "type": "integer"
+          }
+        }
+      },
+      "McpToken": {
+        "type": "object",
+        "description": "A least-privilege credential for an MCP client. The secret is returned only by create — nothing stored can reproduce it.",
+        "required": [
+          "id",
+          "name",
+          "scopes",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Empty means unrestricted."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_used_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "secret": {
+            "type": "string",
+            "nullable": true,
+            "description": "Only ever present on create."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
           }
         }
       },

--- a/packages/api-types/src/generated.ts
+++ b/packages/api-types/src/generated.ts
@@ -2603,17 +2603,89 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/ingestion_runs/{ingestion_run_id}/items": {
+    "/api/v1/conversations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the caller's conversations, newest first */
+        get: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description the caller's conversations */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            conversations: components["schemas"]["Conversation"][];
+                        };
+                    };
+                };
+                /** @description missing or invalid bearer token */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /** Open an empty conversation */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description the new conversation */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Conversation"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/conversations/{id}": {
         parameters: {
             query?: never;
             header?: never;
             path: {
                 /** Format: uuid */
-                ingestion_run_id: string;
+                id: string;
             };
             cookie?: never;
         };
-        /** List a run's staged items (owner or admin) */
+        /**
+         * Replay a conversation
+         * @description The reconnect path: a dropped stream loses nothing, because every turn is persisted as it runs. `usage` is present only for admins.
+         */
         get: {
             parameters: {
                 query?: never;
@@ -2622,62 +2694,34 @@ export interface paths {
                 };
                 path: {
                     /** Format: uuid */
-                    ingestion_run_id: string;
+                    id: string;
                 };
                 cookie?: never;
             };
             requestBody?: never;
             responses: {
-                /** @description items in position order */
+                /** @description the conversation and its transcript */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            items: components["schemas"]["IngestionItemPayload"][];
-                        };
+                        "application/json": components["schemas"]["Conversation"];
                     };
                 };
-                /** @description not the run's creator and not an admin */
-                403: {
+                /** @description another account's conversation */
+                404: {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
+                    content?: never;
                 };
             };
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/ingestion_runs/{ingestion_run_id}/items/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** Format: uuid */
-                ingestion_run_id: string;
-                /** Format: uuid */
-                id: string;
-            };
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Decide a staged item: accept / edit / reject / undo */
-        patch: {
+        /** Delete a conversation and its transcript */
+        delete: {
             parameters: {
                 query?: never;
                 header: {
@@ -2685,85 +2729,42 @@ export interface paths {
                 };
                 path: {
                     /** Format: uuid */
-                    ingestion_run_id: string;
-                    /** Format: uuid */
                     id: string;
                 };
                 cookie?: never;
             };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** @enum {string} */
-                        decision: "accepted" | "edited" | "rejected" | "pending";
-                        name?: string;
-                        description?: string;
-                        ingredients_payload?: {
-                            /** @description must match an Ingredient slug; unknown slugs are skipped at promote */
-                            slug: string;
-                            confidence?: number;
-                            source?: string;
-                        }[];
-                        tags_payload?: {
-                            /** @description must match a Tag slug; unknown slugs are skipped at promote */
-                            slug: string;
-                            confidence?: number;
-                            source?: string;
-                        }[];
-                        /** @description Materialized as ItemVariants at promote, in array order. Rows without price_cents are dropped; price_cents must be a non-negative integer (422 otherwise). */
-                        prices_payload?: {
-                            size?: string | null;
-                            price_cents?: number | null;
-                        }[];
-                        addons_payload?: {
-                            name: string;
-                            price_cents?: number | null;
-                            source?: string;
-                        }[];
-                        unresolved_ingredients?: string[];
-                        unresolved_tags?: string[];
-                    };
-                };
-            };
+            requestBody?: never;
             responses: {
-                /** @description the updated item */
-                200: {
+                /** @description deleted */
+                204: {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content: {
-                        "application/json": components["schemas"]["IngestionItemPayload"];
-                    };
-                };
-                /** @description unknown decision value */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error?: string;
-                            allowed?: string[];
-                        };
-                    };
+                    content?: never;
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
-    "/api/v1/ingestion_runs/{ingestion_run_id}/items/accept_all": {
+    "/api/v1/conversations/{id}/messages": {
         parameters: {
             query?: never;
             header?: never;
             path: {
                 /** Format: uuid */
-                ingestion_run_id: string;
+                id: string;
             };
             cookie?: never;
         };
         get?: never;
         put?: never;
-        /** Bulk-accept every still-pending item */
+        /**
+         * Ask for a turn
+         * @description Records the request and hands off to a background job — no model call happens in this request. Watch the narration with /stream or /events.
+         */
         post: {
             parameters: {
                 query?: never;
@@ -2772,21 +2773,48 @@ export interface paths {
                 };
                 path: {
                     /** Format: uuid */
-                    ingestion_run_id: string;
+                    id: string;
                 };
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        message: string;
+                        /** @description Where the user is standing, so "what can I eat here" is answerable. */
+                        context?: {
+                            path?: string;
+                            restaurant?: string;
+                        };
+                    };
+                };
+            };
             responses: {
-                /** @description all items after the bulk accept */
-                200: {
+                /** @description queued */
+                202: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": {
-                            items: components["schemas"]["IngestionItemPayload"][];
-                        };
+                        "application/json": components["schemas"]["TurnQueued"];
+                    };
+                };
+                /** @description a confirmation is still parked */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description empty or over-long message */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
                     };
                 };
             };
@@ -2797,7 +2825,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/ingestion_runs/{id}": {
+    "/api/v1/conversations/{id}/confirm": {
         parameters: {
             query?: never;
             header?: never;
@@ -2807,12 +2835,74 @@ export interface paths {
             };
             cookie?: never;
         };
-        /** Read a run's status + counters (owner or admin) */
-        get: {
+        get?: never;
+        put?: never;
+        /**
+         * Answer a parked destructive call
+         * @description `fingerprint` binds the answer to the call that was drawn, so a stale client cannot approve whatever happens to be parked now.
+         */
+        post: {
             parameters: {
                 query?: never;
                 header: {
-                    /** @description Bearer <jwt> — the run's creator or an admin */
+                    Authorization: string;
+                };
+                path: {
+                    /** Format: uuid */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        confirm: boolean;
+                        fingerprint?: string | null;
+                    };
+                };
+            };
+            responses: {
+                /** @description nothing is waiting */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/conversations/{id}/events": {
+        parameters: {
+            query?: {
+                /** @description Narration cursor. Same one /stream uses. */
+                after?: number;
+            };
+            header?: never;
+            path: {
+                /** Format: uuid */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Read a turn's narration as JSON
+         * @description For clients that cannot hold a stream open — React Native's fetch exposes no readable body. Poll while `running` is true.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Narration cursor. Same one /stream uses. */
+                    after?: number;
+                };
+                header: {
                     Authorization: string;
                 };
                 path: {
@@ -2823,22 +2913,13 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description the run */
+                /** @description narration after the cursor */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["IngestionRunPayload"];
-                    };
-                };
-                /** @description someone else's run (deliberately not 403), or unknown id */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
+                        "application/json": components["schemas"]["ChatEventsPage"];
                     };
                 };
             };
@@ -2846,6 +2927,190 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/conversations/{id}/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** Format: uuid */
+                id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Stop the running turn
+         * @description Raises a flag the turn reads at its next checkpoint. Necessarily a separate request from the one that started it.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path: {
+                    /** Format: uuid */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description nothing is running */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp_tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the caller's active MCP tokens
+         * @description Never carries a secret — only the digest is stored, so there is nothing an endpoint could return. `scopes` lists every grantable scope so a client need not hardcode the vocabulary.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description active tokens and the grantable scopes */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            tokens: components["schemas"]["McpToken"][];
+                            scopes: string[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Issue a scoped MCP token
+         * @description The only response that ever carries the secret. Omit `scopes` for a credential with the same access as the account.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        name: string;
+                        /** @description e.g. discovery:read */
+                        scopes?: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description the token, with its one-time secret */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["McpToken"];
+                    };
+                };
+                /** @description unknown scope, missing name, or too many active tokens */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/mcp_tokens/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** Format: uuid */
+                id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke one token, without ending other sessions */
+        delete: {
+            parameters: {
+                query?: never;
+                header: {
+                    Authorization: string;
+                };
+                path: {
+                    /** Format: uuid */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description revoked */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description another account's token */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;
@@ -3222,6 +3487,105 @@ export interface components {
             is_admin: boolean;
             /** @enum {string|null} */
             provider?: "google_oauth2" | "apple" | null;
+        };
+        /** @description One Anthropic content block, as a client renders it. Thinking signatures are dropped — they are meaningless to a client and the bulkiest thing in the record. */
+        ChatBlock: {
+            /** @enum {string} */
+            type: "text" | "thinking" | "tool_use" | "tool_result";
+            text?: string | null;
+            id?: string | null;
+            name?: string | null;
+            input?: Record<string, never> | null;
+            tool_use_id?: string | null;
+            ok?: boolean | null;
+        };
+        ChatMessage: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            role: "user" | "assistant";
+            position: number;
+            blocks: components["schemas"]["ChatBlock"][];
+        };
+        /** @description The call the confirmation gate parked. `prompt` is the sentence the tool itself declared; `fingerprint` must be echoed on /confirm so an answer can only settle the call it was drawn for. */
+        PendingTool: {
+            name: string;
+            input: Record<string, never>;
+            prompt: string | null;
+            fingerprint: string | null;
+        };
+        Conversation: {
+            /** Format: uuid */
+            id: string;
+            title?: string | null;
+            /** @enum {string} */
+            state: "active" | "awaiting_confirmation" | "failed";
+            pending?: components["schemas"]["PendingTool"] | null;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            messages?: components["schemas"]["ChatMessage"][];
+            usage?: components["schemas"]["ChatUsage"];
+        };
+        /** @description Spend and cache accounting. Present only for admins — the server decides, so a non-admin never receives it. */
+        ChatUsage: {
+            cost_cents: number;
+            last_run?: {
+                outcome?: string | null;
+                state: string;
+                rounds: number;
+                input_tokens: number;
+                output_tokens: number;
+                cache_read_tokens: number;
+                duration_ms?: number | null;
+            } | null;
+        };
+        /** @description One line of a turn's narration, carrying the cursor to resume from. */
+        ChatEvent: {
+            type: string;
+            position: number;
+            text?: string | null;
+            name?: string | null;
+            ok?: boolean | null;
+            /** @description The tool's own progress sentence. */
+            doing?: string | null;
+            message?: string | null;
+            tool?: components["schemas"]["PendingTool"] | null;
+        };
+        ChatEventsPage: {
+            events: components["schemas"]["ChatEvent"][];
+            /** @description False means stop polling. */
+            running: boolean;
+        };
+        TurnQueued: {
+            queued: boolean;
+            /** @description Narration position to watch from. */
+            after: number;
+        };
+        Attachment: {
+            /** @description Signed blob id. Bytes never enter the agent's context. */
+            id: string;
+            filename: string;
+            content_type: string;
+            byte_size: number;
+        };
+        /** @description A least-privilege credential for an MCP client. The secret is returned only by create — nothing stored can reproduce it. */
+        McpToken: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** @description Empty means unrestricted. */
+            scopes: string[];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            last_used_at?: string | null;
+            /** @description Only ever present on create. */
+            secret?: string | null;
+        };
+        ErrorResponse: {
+            error: string;
         };
         AuthResponse: {
             user: components["schemas"]["UserPayload"];

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -26,6 +26,19 @@ export type UserPayload    = components['schemas']['UserPayload'];
 export type AuthResponse   = components['schemas']['AuthResponse'];
 export type ProfilePayload = components['schemas']['ProfilePayload'];
 export type IngredientRef  = components['schemas']['IngredientRef'];
+
+// Chat + MCP. Anchored here so the web and mobile clients import the
+// generated shape rather than hand-writing one that can drift from the
+// API — `codegen:check` in ci-js.yml fails if these stop matching the
+// rswag specs they came from.
+export type Conversation   = components['schemas']['Conversation'];
+export type ChatMessage    = components['schemas']['ChatMessage'];
+export type ChatBlock      = components['schemas']['ChatBlock'];
+export type PendingTool    = components['schemas']['PendingTool'];
+export type ChatUsage      = components['schemas']['ChatUsage'];
+export type ChatEventsPage = components['schemas']['ChatEventsPage'];
+export type Attachment     = components['schemas']['Attachment'];
+export type McpToken       = components['schemas']['McpToken'];
 export type TagRef         = components['schemas']['TagRef'];
 
 /**


### PR DESCRIPTION
## Summary

- `CLAUDE.md` requires an rswag spec + regenerated types **in the same PR** as a new endpoint. This session added ~12 endpoints without one — and I twice wrote "no openapi/codegen churn" as though that were convenient rather than debt. Both web and mobile hand-wrote the wire shapes, which is the drift the rule prevents.
- **Generated types nobody imports don't prevent drift**, so the web client now aliases them. That immediately paid: tsc rejected the UI because the schema marked `cache_read_tokens`/`fingerprint` optional while the code assumed they're always present. The serializer *does* always emit them — so the **schema** was wrong, and marking them required fixed the contract rather than papering over it downstream.
- Also fixes a subtle one: **OpenAPI 3.0 ignores siblings of `$ref`**, so `pending: { $ref, nullable: true }` silently produced a non-nullable reference. rswag caught it because these specs run real requests against the schema.
