### PR TITLE
fix(chat): format costs in dollars for amounts >= $1, cents otherwise

### DIFF
--- a/apps/api/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/apps/api/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -28,12 +28,18 @@ module Api
                                     .where(users: { is_admin: false })
                                     .where(created_at: today_utc)
                                     .count,
-            spend_today_cents: IngestionRun.where(created_at: today_utc).sum(:api_cost_cents),
+            spend_today_cents: total_spend_today(today_utc),
             ceiling_cents: Integer(ENV.fetch(
               "INGESTION_DAILY_COST_CEILING_CENTS",
               ::Ingestion::StartRun::DAILY_COST_CEILING_CENTS_DEFAULT
             ))
           }
+        end
+
+        def total_spend_today(today_utc)
+          ingestion_spend = IngestionRun.where(created_at: today_utc).sum(:api_cost_cents).to_i
+          chat_spend = Conversation.where(created_at: today_utc).sum(:api_cost_cents).to_i
+          ingestion_spend + chat_spend
         end
 
         # All four are cheap indexed counts (partial index on flagged

--- a/apps/web/src/app/chat/_ChatClient.tsx
+++ b/apps/web/src/app/chat/_ChatClient.tsx
@@ -325,6 +325,11 @@ function interesting(outcome: string | null | undefined): string | null {
   return outcome && !BENIGN_OUTCOMES.has(outcome) ? outcome : null;
 }
 
+function formatCost(cents: number): string {
+  if (cents < 100) return `${cents}¢`;
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
 function UsagePills({ usage }: { usage: ChatUsage }): ReactElement {
   const run = usage.last_run;
   const pills = [
@@ -332,8 +337,8 @@ function UsagePills({ usage }: { usage: ChatUsage }): ReactElement {
     // conversation lifetime and labelled it "total" beside per-run token
     // counts, which invited reading a whole conversation's spend as the
     // price of the last dozen tokens.
-    run ? `${run.cost_cents}¢ turn` : null,
-    `${usage.cost_cents}¢ conversation`,
+    run ? `${formatCost(run.cost_cents)} turn` : null,
+    `${formatCost(usage.cost_cents)} conversation`,
     run ? `${run.rounds} rounds` : null,
     run
       ? `${run.cache_read_tokens.toLocaleString()} cache r / ${run.cache_write_tokens.toLocaleString()} w`


### PR DESCRIPTION
## Why

Costs displayed in the Chat tool and admin dashboard were incomplete or hard to read. The chat interface showed all costs as raw cents (e.g., "495¢" for $4.95), and the admin dashboard only tracked ingestion costs, missing chat API spend entirely.

## What

- **Chat display**: Added `formatCost()` helper to intelligently format currency — cents (¢) for amounts under $1.00, dollars ($) for $1.00+
- **Admin dashboard**: Created `total_spend_today()` method that rolls up both ingestion run costs and conversation API costs (previously only ingestion was tracked)

## Test plan

- [x] CI green
- [x] Web tests pass (67 test files, 423 tests)
- [x] Dashboard spec validates spend_today_cents as integer (unchanged contract)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8GHgJURfZprMhHV92RxDt)_