### PR TITLE
fix(api): constrain the titler's reply instead of asking for one

### DIFF
--- a/apps/api/app/models/conversation.rb
+++ b/apps/api/app/models/conversation.rb
@@ -69,13 +69,18 @@ class Conversation < ApplicationRecord
     stored.map { |m| { role: m.role, content: m.content } } + repair_for(stored.last)
   end
 
-  # The first thing the person said, for whoever needs to name this.
+  # The rows this turn already has in hand.
   #
-  # Reads the rows `transcript` already loaded rather than asking for the
-  # one it wants. A `WHERE role = 'user' LIMIT 1` would be a cheaper
-  # query and a worse one: it is a second round trip to Postgres for a
-  # record sitting in memory, and the spec guarding this turn's message
-  # loads counts round trips, not rows.
+  # `transcript` loads them once per turn and every write path keeps them
+  # honest, so anything else that wants to look at this turn's messages
+  # should look here rather than asking Postgres again. A `WHERE role =
+  # 'user' LIMIT 1` is a cheaper query and a worse one: it is a second
+  # round trip for a record already in memory, and the spec guarding this
+  # turn's message loads counts round trips, not rows. Falls back to a
+  # real load for a caller that reaches this before any model call.
+  def loaded_messages = @stored_messages || messages.to_a
+
+  # The first thing the person said, for whoever needs to name this.
   #
   # A `tool_result` is a `user`-role message, so the earliest one is only
   # the person talking if it is not that. It never is in practice — a
@@ -83,7 +88,7 @@ class Conversation < ApplicationRecord
   # predicate and the alternative is naming a conversation after a menu
   # payload.
   def opening_question
-    opening = (@stored_messages || messages).find { |message| message.role == "user" }
+    opening = loaded_messages.find { |message| message.role == "user" }
     opening&.text unless opening&.tool_result?
   end
 

--- a/apps/api/app/services/anthropic_client.rb
+++ b/apps/api/app/services/anthropic_client.rb
@@ -109,11 +109,19 @@ class AnthropicClient
   # onto IngestionRun.api_cost_cents. Nil until a call succeeds.
   attr_reader :last_usage
 
-  def initialize(api_key: nil, model: nil, base_url: nil, conn: nil)
+  # `timeout` and `retries` exist for callers whose work is optional.
+  # The defaults are sized for the vision call that legitimately runs
+  # minutes, and a caller on a user's critical path inherits that budget
+  # whether or not its own request deserves it — a 240-second read plus
+  # three retries is the right patience for extracting a menu and the
+  # wrong patience for anything a person is waiting behind.
+  def initialize(api_key: nil, model: nil, base_url: nil, conn: nil, timeout: nil, retries: nil)
     @api_key  = api_key  || ENV["ANTHROPIC_API_KEY"] || ""
     @model    = model    || DEFAULT_MODEL
     @base_url = base_url || ENDPOINT
     @conn     = conn # tests can inject a stubbed Faraday connection
+    @timeout  = timeout
+    @retries  = retries
   end
 
   # Low-level pass-through to /v1/messages. Returns a parsed Hash on
@@ -276,8 +284,8 @@ class AnthropicClient
       # 8k max_tokens budget legitimately runs minutes. faraday-retry
       # can multiply the worst case ~3x.
       f.options.open_timeout = Integer(ENV.fetch("ANTHROPIC_OPEN_TIMEOUT", 10))
-      f.options.timeout      = Integer(ENV.fetch("ANTHROPIC_READ_TIMEOUT", 240))
-      f.request  :retry, max: 3,
+      f.options.timeout      = @timeout || Integer(ENV.fetch("ANTHROPIC_READ_TIMEOUT", 240))
+      f.request  :retry, max: @retries || 3,
                           interval: 0.5,
                           backoff_factor: 2,
                           retry_statuses: [429, 500, 502, 503, 504],

--- a/apps/api/app/services/chat/agent_loop.rb
+++ b/apps/api/app/services/chat/agent_loop.rb
@@ -651,13 +651,18 @@ module Chat
     # opened to do and not re-named as it wanders.
     def name_conversation(result)
       return if @conversation.title.present?
-      # Nothing worth naming a conversation after, and on the path that
-      # matters most it would be actively wrong: a turn refused for
-      # spending its budget would answer by spending again. A turn that
-      # fails leaves the column null and the next one that works names it.
-      return unless result&.ok?
+      # An answer, specifically — not merely "did not error". A turn that
+      # parked on a confirmation has produced a question, not a reply, and
+      # naming from it would fix a half-finished exchange as the name for
+      # good. On the path that matters most, `ok?` would be actively
+      # wrong: a turn refused for spending its budget would answer by
+      # spending again.
+      return unless result&.state == :done
+      # The retry that makes failure cheap is unbounded on its own — see
+      # `Titler::NAMING_WINDOW_MESSAGES`.
+      return if @conversation.loaded_messages.size > Titler::NAMING_WINDOW_MESSAGES
 
-      named = Titler.new.call(question: @conversation.opening_question, answer: result&.text)
+      named = Titler.new.call(question: @conversation.opening_question, answer: result.text)
       record_side_usage(named.usage, named.model)
       @conversation.update!(title: named.title) if named.title.present?
     rescue StandardError => e

--- a/apps/api/app/services/chat/titler.rb
+++ b/apps/api/app/services/chat/titler.rb
@@ -48,9 +48,32 @@ module Chat
     # for a sentence's worth of signal.
     MAX_EXCERPT = 600
 
+    # A title call has a person waiting behind it — the turn holds the
+    # conversation lock until this returns, so the `done` event and any
+    # queued next turn are both behind it. The shared defaults (240s
+    # read, three retries) are sized for the vision call that extracts a
+    # menu; inheriting them here means a 429 storm could withhold a
+    # finished answer for minutes to decorate it. A title is worth one
+    # quick attempt and nothing more.
+    TIMEOUT_SECONDS = 15
+    RETRIES         = 0
+
+    # Naming happens early or not at all.
+    #
+    # The retry that makes a failure cheap — leave `title` null and let
+    # the next turn try — is also unbounded on its own: a conversation
+    # nothing can name (a greeting the model correctly declines, an
+    # outage that outlasts the chat) would otherwise buy a haiku call on
+    # every turn forever, billed against the same per-conversation
+    # ceiling the answers come out of. After a few exchanges the opening
+    # is no longer what the conversation is about anyway, so the window
+    # closes.
+    NAMING_WINDOW_MESSAGES = 12
+
     SCHEMA = {
       "type" => "object",
       "required" => %w[title],
+      "additionalProperties" => false,
       "properties" => { "title" => { "type" => "string" } }
     }.freeze
 
@@ -107,15 +130,26 @@ module Chat
     # Lazily built: only the first turn of a conversation ever asks, so a
     # client per turn would be a connection per turn for nothing.
     def client
-      @client ||= @injected || AnthropicClient.new(model: MODEL)
+      @client ||= @injected || AnthropicClient.new(model: MODEL, timeout: TIMEOUT_SECONDS, retries: RETRIES)
     end
 
+    # **Constrained, not requested.** `response_schema` alone validates
+    # after the fact and shapes nothing: `ResponseParser` says so in as
+    # many words — "the Anthropic system prompt is responsible for
+    # telling the model 'respond with strict JSON, no prose'". This
+    # prompt asks for a title, so a schema without `output_config` would
+    # get one, in prose, and then throw it away as unparseable on every
+    # single call — a feature that fails open into doing nothing, quietly,
+    # forever. Grammar-constrained decoding is what actually makes the
+    # reply a `{"title": …}`; the post-hoc schema stays as the check.
     def ask(material)
       client.messages_create(
         model:      MODEL,
         max_tokens: 100,
         system:     client.system_blocks({ text: PROMPT, cache: true }),
         messages:   [ { role: "user", content: [ { type: "text", text: material } ] } ],
+        output_config:   { format: { type: "json_schema",
+                                     schema: ::Ingestion::SchemaForRequest.derive(SCHEMA) } },
         response_schema: SCHEMA
       )
     end
@@ -134,11 +168,26 @@ module Chat
     # guarantee. Newlines and control characters would break the row;
     # surrounding quotes are the model's most common way of ignoring the
     # instruction not to use them.
+    #
+    # The quotes come off only as a matched pair. Stripping each end
+    # independently turns `Dairy-free lunch at "Nonna"` — a title quoting
+    # a restaurant, exactly the specificity this wants — into one with an
+    # unbalanced quote left in the middle.
+    #
+    # And the clamp truncates with `omission: ""`. `String#truncate`
+    # otherwise appends an ellipsis, which is trailing punctuation, which
+    # is the thing two lines of prompt just asked the model not to do.
     def clean(title)
-      flat = title.to_s.gsub(/[[:cntrl:]]/, " ").squeeze(" ").strip.delete_prefix('"').delete_suffix('"').strip
+      flat = unquote(title.to_s.gsub(/[[:cntrl:]]/, " ").squeeze(" ").strip)
       return nil if flat.blank? || REJECTED.include?(flat.downcase.delete_suffix("."))
 
-      flat.truncate(MAX_LENGTH)
+      flat.truncate(MAX_LENGTH, omission: "")
+    end
+
+    def unquote(text)
+      return text unless text.length > 1 && text.start_with?('"') && text.end_with?('"')
+
+      text[1..-2].strip
     end
   end
 end

--- a/apps/api/spec/services/chat/agent_loop_spec.rb
+++ b/apps/api/spec/services/chat/agent_loop_spec.rb
@@ -1353,6 +1353,35 @@ RSpec.describe Chat::AgentLoop do
       expect(conversation.reload.title).to eq("First thing asked")
     end
 
+    # A parked turn has produced a question, not an answer. Naming from it
+    # would fix a half-finished exchange as the name for good, since the
+    # title is written once and never revised.
+    it "waits for an answer rather than naming a turn parked on a confirmation" do
+      item   = create(:item, :published, restaurant: restaurant)
+      review = create(:review, user: user, item: item, body: "fine")
+      expect(Chat::Titler).not_to receive(:new)
+
+      result = loop_with(call_tool("delete_review", { "review_id" => review.id })).run(text: "delete my review")
+
+      expect(result).to be_awaiting_confirmation
+      expect(conversation.reload.title).to be_nil
+    end
+
+    # Leaving the column null so the next turn retries is what makes a
+    # failure cheap, and on its own it is unbounded: a conversation
+    # nothing can name would buy a haiku call on every turn forever,
+    # against the same ceiling the answers come out of.
+    it "stops trying once the opening is no longer what the chat is about" do
+      Array.new(Chat::Titler::NAMING_WINDOW_MESSAGES + 1) do |i|
+        conversation.append!(role: "user", content: [{ type: "text", text: "message #{i}" }])
+      end
+      expect(Chat::Titler).not_to receive(:new)
+
+      loop_with(say("Sure.")).run(text: "one more")
+
+      expect(conversation.reload.title).to be_nil
+    end
+
     # A turn refused for spending its budget would otherwise answer by
     # spending again.
     it "does not spend on naming a turn that failed" do

--- a/apps/api/spec/services/chat/titler_spec.rb
+++ b/apps/api/spec/services/chat/titler_spec.rb
@@ -74,6 +74,50 @@ RSpec.describe Chat::Titler, :real_titler do
     it "declines an empty title rather than storing a blank row" do
       expect(titling(named("   ")).call(question: "hi").title).to be_nil
     end
+
+    # `String#truncate` appends "..." by default, which is trailing
+    # punctuation — the exact thing the prompt two lines up asks against.
+    it "clamps without leaving punctuation behind" do
+      title = titling(named("Dairy-free lunch spots " * 8)).call(question: "hello").title
+
+      expect(title.length).to eq(described_class::MAX_LENGTH)
+      expect(title).not_to match(/[.…]\z/)
+    end
+
+    # Stripping each end independently mangles a title that quotes a
+    # restaurant — which is the specificity this is asking the model for.
+    it "leaves an inner quotation intact" do
+      expect(titling(named('Dairy-free lunch at "Nonna"')).call(question: "lunch").title)
+        .to eq('Dairy-free lunch at "Nonna"')
+    end
+  end
+
+  # `response_schema` validates a reply; it does not shape one. Without
+  # `output_config` the model answers this prompt in prose — it is asked
+  # for a title, not for JSON — and every call dies in `JSON.parse` and
+  # fails open to no title at all, forever and silently. Probed against
+  # live haiku before the constraint was added: the reply was
+  # `Gluten-free options at Ninis`, not `{"title": …}`.
+  it "constrains the reply to JSON rather than asking for it" do
+    client = ScriptedClient.new(named("Lunch at Ninis"))
+
+    described_class.new(client: client).call(question: "lunch")
+
+    expect(client.requests.first[:output_config])
+      .to eq(format: { type: "json_schema", schema: Ingestion::SchemaForRequest.derive(described_class::SCHEMA) })
+  end
+
+  # A person is waiting behind this: the turn holds the conversation lock
+  # until it returns, so the terminal event and any queued next turn are
+  # both behind a call made only to decorate an answer already on screen.
+  it "gives itself a smaller budget than the shared default" do
+    allow(AnthropicClient).to receive(:new).and_call_original
+
+    described_class.new.send(:client)
+
+    expect(AnthropicClient).to have_received(:new).with(
+      model: described_class::MODEL, timeout: described_class::TIMEOUT_SECONDS, retries: described_class::RETRIES
+    )
   end
 
   # The exchange can carry menu text transcribed from a stranger's


### PR DESCRIPTION
## Summary

- #591 auto-merged on its first commit's green CI, ~90 seconds before the review fixes were pushed. Master has the titler that **can never produce a title**: `response_schema` validates a reply, it does not shape one, so haiku answers this prompt in prose and every call dies in `JSON.parse` and fails open. It bills a call per conversation and stores nothing.
- Fixed with `output_config` — the constrained path `Ingestion::ExtractRun` already uses. Verified live against haiku: the reply is now `{"title" => "Gluten-free options at Ninis"}`.
- Also from that review: a bounded timeout (the titler inherited the 240s/3-retry budget sized for menu vision, with a person waiting behind it), a bound on the retry-next-turn loop, gating on `:done` rather than `ok?`, and two `clean` bugs.
