### PR TITLE
docs: correct three claims the code no longer supports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ See `docs/schema.md` for the 60-second tour of all ~30 tables, and `docs/ingesti
 Two workflows gate PRs:
 
 - `ci-js.yml` — runs on changes to `apps/web/`, `apps/mobile/`, `packages/`, `docs/openapi.json`, or root config. Steps: `pnpm typecheck` → `pnpm lint` → `pnpm test` → api-types codegen drift check.
-- `ci-api.yml` — runs on changes to `apps/api/`. Boots Postgres 16 + ImageMagick (dish-photo cropping shells out to it), then `bin/rails db:create db:schema:load`, then `bin/rspec`. **Brakeman runs in the same job and blocks** (no `continue-on-error`); **Rubocop** runs with `continue-on-error: true` (informational only).
+- `ci-api.yml` — runs on changes to `apps/api/`. Boots Postgres 16 + ImageMagick (dish-photo cropping shells out to it), then `bin/rails db:create db:schema:load`, then `bin/rspec`. **Brakeman and Rubocop run in the same job and both block** (neither has `continue-on-error`). Rubocop inherits Rails' omakase style plus a generated `.rubocop_todo.yml` that freezes the pre-existing offences, so new code has to be clean while the backlog stays grandfathered — run `bundle exec rubocop --parallel` before pushing rather than adding a todo entry.
 
 Both are required for auto-merge. Don't request human review on red.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -160,8 +160,19 @@ in the [roadmap history](status-archive/roadmap-phases-0-8.md).)
   whatever `?next=` holds without validating it starts with `/`, so
   `/login?next=https://evil.com` bounces a successful login off-site.
   Pre-dates the admin workstream (the suggestions queue minted these
-  links first) but W1 added another producer. Fix: `startsWith('/')`
-  guard (reject `//`) before `router.replace`.
+  links first) but W1 added another producer. **The fix prescribed here
+  — `startsWith('/')`, reject `//` — is not sufficient**, and was
+  measured to be: `/\evil.com` and `.//evil.com` both pass it and still
+  leave the origin, because the router normalizes *after* the check
+  (backslashes become slashes for special schemes; dot-segment
+  resolution can create an authority on serialization). A guard has to
+  re-resolve the value it returns, not just inspect the one it got.
+
+- **`pnpm build` fails on clean master** — `@biteworthy/mobile#build`
+  (`expo export`) exits non-zero with no local changes, and `ci-js.yml`
+  never runs `build`, so nothing catches it. Not blocking today (Vercel
+  builds web on its own and mobile ships through EAS), but it means the
+  root `pnpm build` cannot be used as a pre-push check.
 
 - **Onboarding-chip flake recurred (3rd occurrence)** — the test fixed
   in #199 ("renders a chip per preset once the fetch resolves") timed


### PR DESCRIPTION
## Summary

- `CLAUDE.md` said Rubocop runs `continue-on-error: true` and is informational. It has no `continue-on-error` and blocks — a contributor trusting the doc pushes lint failures into a required check.
- The roadmap prescribed `startsWith('/')` for the `?next=` open redirect. Measured against the real router, that is not sufficient: `/\evil.com` and `.//evil.com` pass it and still leave the origin, so leaving it invites someone to implement it and believe the hole is closed.
- Records that `pnpm build` fails on clean master (`expo export`) and `ci-js.yml` never runs it, so the root build cannot serve as a pre-push check.
