### PR TITLE
fix(web): homepage preset example names a preset that exists

### DIFF
--- a/apps/mobile/store-listing/app-store.md
+++ b/apps/mobile/store-listing/app-store.md
@@ -20,7 +20,7 @@ App Store Connect → My Apps → BiteWorthy → App Store tab.
 BiteWorthy is a pocket food filter for celiac, allergies, vegan, and every other dietary need. Snap a photo of a menu — or paste a link — and BiteWorthy hides the dishes that aren't safe for you. With *why*, every time.
 
 How it works:
-1. Pick a filter — Celiac, Tree Nut, Vegan, Diabetes-friendly, or build your own avoid list.
+1. Pick a filter — Celiac, Tree Nut, Vegan, Halal, or build your own avoid list.
 2. Scan a menu — camera, photo library, or paste a link to a PDF / online menu.
 3. See only safe dishes — hidden items each say *why*. Tap "show anyway" to override one for this meal.
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -140,7 +140,7 @@ function FeatureRow(): ReactElement {
     {
       emoji: '🥗',
       title: 'Pick your filter',
-      body: 'Six taps to a working profile. Pick a preset (Celiac, Tree Nut, Vegan, Diabetes-friendly, …) or build your own avoid list.',
+      body: 'Six taps to a working profile. Pick a preset (Celiac, Tree Nut, Vegan, Halal, …) or build your own avoid list.',
     },
     {
       emoji: '✓',


### PR DESCRIPTION
## Summary
- The hero copy advertised a "Diabetes-friendly" preset that has never existed in the catalog — a user who came for it can't find it in onboarding (finding 12 in `docs/plans/ux-exploration-2026-08-15.md`). Swapped for Halal, which ships.
- The adjacent "30 restaurants" claim is deliberately untouched: seeding 30 is an open launch gate (`launch-readiness.md` §6), flagged in the doc as a judgment call.
