### PR TITLE
fix(web): dish page 500 for signed-in users

### DIFF
--- a/apps/web/src/app/restaurants/[slug]/items/[id]/_FavoriteDishButton.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/_FavoriteDishButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import FavoriteButton from '../../_FavoriteButton';
+import { setItemFavorite } from '../../../../../lib/restaurants';
+
+/**
+ * Client boundary for the dish-page save button. The page is a server
+ * component, so it can't hand FavoriteButton an onToggle function
+ * directly — functions don't cross the RSC boundary (doing so 500'd
+ * the page for every signed-in viewer). This wrapper takes only
+ * serializable props and binds the fetch itself.
+ */
+export default function FavoriteDishButton({
+  itemId,
+  initialFavorited,
+}: {
+  itemId: string;
+  initialFavorited: boolean;
+}) {
+  return (
+    <FavoriteButton
+      initialFavorited={initialFavorited}
+      onToggle={(next) => setItemFavorite(itemId, next)}
+      savedLabel="Saved"
+      unsavedLabel="Save this dish"
+      testId="favorite-dish"
+    />
+  );
+}

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/__tests__/FavoriteDishButton.test.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/__tests__/FavoriteDishButton.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import FavoriteDishButton from '../_FavoriteDishButton';
+
+// The dish page is a server component, so the save button must live
+// behind a client boundary that takes only serializable props — passing
+// an onToggle function from the page 500'd every signed-in view. This
+// pins the wrapper's contract: itemId in, favorite fetch out.
+describe('FavoriteDishButton', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('saves the dish through the favorite proxy for its itemId', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ item_id: 'dish-1', favorited: true }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<FavoriteDishButton itemId="dish-1" initialFavorited={false} />);
+
+    const btn = screen.getByTestId('favorite-dish');
+    expect(btn).toHaveTextContent('Save this dish');
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'true'));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/items/dish-1/favorite',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(btn).toHaveTextContent('Saved');
+  });
+});

--- a/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
+++ b/apps/web/src/app/restaurants/[slug]/items/[id]/page.tsx
@@ -3,13 +3,12 @@ import Link from 'next/link';
 import {
   fetchItem,
   fetchRestaurant,
-  setItemFavorite,
   type Restaurant,
   type RestaurantItem,
 } from '../../../../../lib/restaurants';
 import { fetchReviewsServer, type ReviewsResponse } from '../../../../../lib/reviews';
 import { getServerJwt, getServerUserId } from '../../../../../lib/server-auth';
-import FavoriteButton from '../../_FavoriteButton';
+import FavoriteDishButton from './_FavoriteDishButton';
 import { ReviewsClient } from './ReviewsClient';
 import { SuggestFixClient } from './SuggestFixClient';
 
@@ -91,13 +90,7 @@ function Page({
 
       {currentUserId && (
         <div className="mt-bw-4">
-          <FavoriteButton
-            initialFavorited={item.favorited ?? false}
-            onToggle={(next) => setItemFavorite(item.id, next)}
-            savedLabel="Saved"
-            unsavedLabel="Save this dish"
-            testId="favorite-dish"
-          />
+          <FavoriteDishButton itemId={item.id} initialFavorited={item.favorited ?? false} />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Every signed-in view of every dish detail page has 500'd since #447: the server-component page passed an inline `onToggle` function into the `'use client'` FavoriteButton, an RSC boundary violation that only detonates inside the `currentUserId &&` branch — so anonymous smoke checks kept passing.
- New `_FavoriteDishButton` client wrapper takes only serializable props and binds `setItemFavorite` itself; test pins the wrapper's contract.
