### PR TITLE
chore: release 2026.8.17.1

### DIFF
--- a/packages/version-history/src/history.json
+++ b/packages/version-history/src/history.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2026.8.17.1",
+    "date": "2026-08-17",
+    "notes": [
+      "You can now change your username — in Account settings on web and in the new Settings → Account screen on mobile. Usernames are case-insensitive: pick Alice and alice is yours too."
+    ]
+  },
+  {
     "version": "2026.8.17",
     "date": "2026-08-17",
     "notes": [


### PR DESCRIPTION
## Summary

- Release 2026.8.17.1 — username editing (web + mobile + admin) lands in the changelog so the shipped version is not stale behind #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119K5yiktHU8iuJ3uzdrLRp
